### PR TITLE
Revert hardcoded consts

### DIFF
--- a/contracts/src/state/oracle/BeaconReportBounds.sol
+++ b/contracts/src/state/oracle/BeaconReportBounds.sol
@@ -10,9 +10,8 @@ library BeaconReportBounds {
 
     uint256 public constant DELTA_BASE = 10_000;
 
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.beaconReportBounds")) - 1) */
     bytes32 internal constant BEACON_REPORT_BOUNDS_SLOT =
-        hex"8a8a043b81dd88a581f2aa1faf076f45266d72ec8307cdf217c10a967969249e";
+        bytes32(uint256(keccak256("river.state.beaconReportBounds")) - 1);
 
     struct Slot {
         BeaconReportBoundsStruct value;

--- a/contracts/src/state/oracle/BeaconSpec.sol
+++ b/contracts/src/state/oracle/BeaconSpec.sol
@@ -10,8 +10,7 @@ library BeaconSpec {
         uint64 genesisTime;
     }
 
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.beaconSpec")) - 1) */
-    bytes32 internal constant BEACON_SPEC_SLOT = hex"910cad6638f0b06b72ead1455bffc33be6e9b1c24417cc3f692aaaf0bef75a15";
+    bytes32 internal constant BEACON_SPEC_SLOT = bytes32(uint256(keccak256("river.state.beaconSpec")) - 1);
 
     struct Slot {
         BeaconSpecStruct value;

--- a/contracts/src/state/oracle/ExpectedEpochId.sol
+++ b/contracts/src/state/oracle/ExpectedEpochId.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library ExpectedEpochId {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.expectedEpochId")) - 1) */
-    bytes32 internal constant EXPECTED_EPOCH_ID_SLOT =
-        hex"45d0d54fdd66220435526b0d20a3e002dad71447d5a32fb8efce72e62d4e0227";
+    bytes32 internal constant EXPECTED_EPOCH_ID_SLOT = bytes32(uint256(keccak256("river.state.expectedEpochId")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(EXPECTED_EPOCH_ID_SLOT);

--- a/contracts/src/state/oracle/LastEpochId.sol
+++ b/contracts/src/state/oracle/LastEpochId.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library LastEpochId {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.lastEpochId")) - 1) */
-    bytes32 internal constant LAST_EPOCH_ID_SLOT =
-        hex"af3d74d3b4106d19ea8994739c1a66b48922195975ea284f4cd201487a79b9ec";
+    bytes32 internal constant LAST_EPOCH_ID_SLOT = bytes32(uint256(keccak256("river.state.lastEpochId")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(LAST_EPOCH_ID_SLOT);

--- a/contracts/src/state/oracle/OracleMembers.sol
+++ b/contracts/src/state/oracle/OracleMembers.sol
@@ -2,9 +2,7 @@
 pragma solidity 0.8.10;
 
 library OracleMembers {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.oracleMembers")) - 1) */
-    bytes32 internal constant ORACLE_MEMBERS_SLOT =
-        hex"c4aba040293e5848600dd7b64a390db880c4a70937c23383e6c5b6619689863a";
+    bytes32 internal constant ORACLE_MEMBERS_SLOT = bytes32(uint256(keccak256("river.state.oracleMembers")) - 1);
 
     struct Slot {
         address[] value;

--- a/contracts/src/state/oracle/Quorum.sol
+++ b/contracts/src/state/oracle/Quorum.sol
@@ -4,8 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library Quorum {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.quorum")) - 1) */
-    bytes32 internal constant QUORUM_SLOT = hex"ffa4a5d927096d2bbb9d71111d7c9929ecbdcbe9bffc8d35f55b642e81698eba";
+    bytes32 internal constant QUORUM_SLOT = bytes32(uint256(keccak256("river.state.quorum")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(QUORUM_SLOT);

--- a/contracts/src/state/oracle/ReportsPositions.sol
+++ b/contracts/src/state/oracle/ReportsPositions.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library ReportsPositions {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.reportsPositions")) - 1) */
-    bytes32 internal constant REPORTS_POSITIONS_SLOT =
-        hex"50e65b39a6b6b7bb3298d9d19e41cecec530b7916ba516c44f4d79e3a9dcd7a6";
+    bytes32 internal constant REPORTS_POSITIONS_SLOT = bytes32(uint256(keccak256("river.state.reportsPositions")) - 1);
 
     function get(uint256 idx) internal view returns (bool) {
         uint256 mask = 1 << idx;

--- a/contracts/src/state/oracle/ReportsVariants.sol
+++ b/contracts/src/state/oracle/ReportsVariants.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.10;
 library ReportsVariants {
     uint256 internal constant COUNT_OUTMASK = 0xFFFFFFFFFFFFFFFFFFFFFFFF0000;
 
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.reportsVariants")) - 1) */
-    bytes32 internal constant REPORTS_VARIANTS_SLOT =
-        hex"f1827321f6d023724a23b4e28f3ef67f741d185cff4e224f6dcbb56935784fcc";
+    bytes32 internal constant REPORTS_VARIANTS_SLOT = bytes32(uint256(keccak256("river.state.reportsVariants")) - 1);
 
     struct Slot {
         uint256[] value;

--- a/contracts/src/state/oracle/RiverAddress.sol
+++ b/contracts/src/state/oracle/RiverAddress.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library RiverAddress {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.riverAddress")) - 1) */
-    bytes32 internal constant RIVER_ADDRESS_SLOT =
-        hex"1ec4138404500a2a0be2c2f9b103581c2a7fa783a934f91a6cc5cc924404973b";
+    bytes32 internal constant RIVER_ADDRESS_SLOT = bytes32(uint256(keccak256("river.state.riverAddress")) - 1);
 
     function get() internal view returns (address) {
         return UnstructuredStorage.getStorageAddress(RIVER_ADDRESS_SLOT);

--- a/contracts/src/state/river/AllowerAddress.sol
+++ b/contracts/src/state/river/AllowerAddress.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library AllowerAddress {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.allowerAddress")) - 1) */
-    bytes32 internal constant ALLOWER_ADDRESS_SLOT =
-        hex"3d8762f71ac4675044de4231ebed7df0f8a8819893c6b6278d0461fc4a979b7f";
+    bytes32 internal constant ALLOWER_ADDRESS_SLOT = bytes32(uint256(keccak256("river.state.allowerAddress")) - 1);
 
     function get() internal view returns (address) {
         return UnstructuredStorage.getStorageAddress(ALLOWER_ADDRESS_SLOT);

--- a/contracts/src/state/river/Allowlist.sol
+++ b/contracts/src/state/river/Allowlist.sol
@@ -2,8 +2,7 @@
 pragma solidity 0.8.10;
 
 library Allowlist {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.allowlist")) - 1) */
-    bytes32 internal constant ALLOWLIST_SLOT = hex"f13551d5cf1b23afc8669eb5ef15070e351923179334eb1a5aa569477f4a4134";
+    bytes32 internal constant ALLOWLIST_SLOT = bytes32(uint256(keccak256("river.state.allowlist")) - 1);
 
     struct Slot {
         mapping(address => bool) value;

--- a/contracts/src/state/river/ApprovalsPerOwner.sol
+++ b/contracts/src/state/river/ApprovalsPerOwner.sol
@@ -2,9 +2,8 @@
 pragma solidity 0.8.10;
 
 library ApprovalsPerOwner {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.approvalsPerOwner")) - 1) */
     bytes32 internal constant APPROVALS_PER_OWNER_SLOT =
-        hex"c852254d5b703a16bb13b3e233a335d6459c5da5db0ca732d7a684ee05407846";
+        bytes32(uint256(keccak256("river.state.approvalsPerOwner")) - 1);
 
     struct Slot {
         mapping(address => mapping(address => uint256)) value;

--- a/contracts/src/state/river/BeaconValidatorBalanceSum.sol
+++ b/contracts/src/state/river/BeaconValidatorBalanceSum.sol
@@ -4,9 +4,8 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library BeaconValidatorBalanceSum {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.beaconValidatorBalanceSum")) - 1) */
     bytes32 internal constant VALIDATOR_BALANCE_SUM_SLOT =
-        hex"42b27da24a254372d1e7ea692a34d85d9237abb39a65153affece1e2f1e608ff";
+        bytes32(uint256(keccak256("river.state.beaconValidatorBalanceSum")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(VALIDATOR_BALANCE_SUM_SLOT);

--- a/contracts/src/state/river/BeaconValidatorCount.sol
+++ b/contracts/src/state/river/BeaconValidatorCount.sol
@@ -4,9 +4,8 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library BeaconValidatorCount {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.beaconValidatorCount")) - 1) */
     bytes32 internal constant BEACON_VALIDATOR_COUNT_SLOT =
-        hex"6929b6137e885d965ed089510659a629a29a4a54f85c28286fa5e0d7dcf27a36";
+        bytes32(uint256(keccak256("river.state.beaconValidatorCount")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(BEACON_VALIDATOR_COUNT_SLOT);

--- a/contracts/src/state/river/DepositContractAddress.sol
+++ b/contracts/src/state/river/DepositContractAddress.sol
@@ -5,9 +5,8 @@ import "../../interfaces/IDepositContract.sol";
 import "../../libraries/UnstructuredStorage.sol";
 
 library DepositContractAddress {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.depositContractAddress")) - 1) */
     bytes32 internal constant DEPOSIT_CONTRACT_ADDRESS_SLOT =
-        hex"35efb61d8784060218d9d6aa40eae55904de43779c1afc79c74dfefcfdf9125f";
+        bytes32(uint256(keccak256("river.state.depositContractAddress")) - 1);
 
     function get() internal view returns (IDepositContract) {
         return IDepositContract(UnstructuredStorage.getStorageAddress(DEPOSIT_CONTRACT_ADDRESS_SLOT));

--- a/contracts/src/state/river/DepositedValidatorCount.sol
+++ b/contracts/src/state/river/DepositedValidatorCount.sol
@@ -4,9 +4,8 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library DepositedValidatorCount {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.depositedValidatorCount")) - 1) */
     bytes32 internal constant DEPOSITED_VALIDATOR_COUNT_SLOT =
-        hex"c77078e3530c08cdb2440817c81de4836500b4708ea4d15672b7fe98956423a7";
+        bytes32(uint256(keccak256("river.state.depositedValidatorCount")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(DEPOSITED_VALIDATOR_COUNT_SLOT);

--- a/contracts/src/state/river/GlobalFee.sol
+++ b/contracts/src/state/river/GlobalFee.sol
@@ -4,8 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library GlobalFee {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.globalFee")) - 1) */
-    bytes32 internal constant GLOBAL_FEE_SLOT = hex"094efef62d2ce60c14ffacd35a1b50546d3a9d503aff1df040176fffd6c92a36";
+    bytes32 internal constant GLOBAL_FEE_SLOT = bytes32(uint256(keccak256("river.state.globalFee")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(GLOBAL_FEE_SLOT);

--- a/contracts/src/state/river/LastOracleRoundId.sol
+++ b/contracts/src/state/river/LastOracleRoundId.sol
@@ -4,9 +4,8 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library LastOracleRoundId {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.lastOracleRoundId")) - 1) */
     bytes32 internal constant LAST_ORACLE_ROUND_ID_SLOT =
-        hex"d7f2d45e512a86049f7a113657b39731b6b558609584243063a52cd31a8eb528";
+        bytes32(uint256(keccak256("river.state.lastOracleRoundId")) - 1);
 
     function get() internal view returns (bytes32) {
         return UnstructuredStorage.getStorageBytes32(LAST_ORACLE_ROUND_ID_SLOT);

--- a/contracts/src/state/river/OperatorRewardsShare.sol
+++ b/contracts/src/state/river/OperatorRewardsShare.sol
@@ -4,9 +4,8 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library OperatorRewardsShare {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.operatorRewardsShare")) - 1) */
     bytes32 internal constant OPERATOR_REWARDS_SHARE_SLOT =
-        hex"8b296ea79529153bb5bae302cb8c44db7ed739099e80c9f19feb68f6a43578a7";
+        bytes32(uint256(keccak256("river.state.operatorRewardsShare")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(OPERATOR_REWARDS_SHARE_SLOT);

--- a/contracts/src/state/river/Operators.sol
+++ b/contracts/src/state/river/Operators.sol
@@ -2,12 +2,9 @@
 pragma solidity 0.8.10;
 
 library Operators {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.operators")) - 1) */
-    bytes32 internal constant OPERATORS_SLOT = hex"794c962401f2e1bb68ba8627fb26fd4eea0439023c691c35b68bb144bfe10112";
+    bytes32 internal constant OPERATORS_SLOT = bytes32(uint256(keccak256("river.state.operators")) - 1);
 
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.operatorsMapping")) - 1) */
-    bytes32 internal constant OPERATORS_MAPPING_SLOT =
-        hex"b005a38730de558570646e2e51c331893c451361d6a7ba50d9c54b48e05ddd26";
+    bytes32 internal constant OPERATORS_MAPPING_SLOT = bytes32(uint256(keccak256("river.state.operatorsMapping")) - 1);
 
     struct Operator {
         bool active;

--- a/contracts/src/state/river/OracleAddress.sol
+++ b/contracts/src/state/river/OracleAddress.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library OracleAddress {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.oracleAddress")) - 1) */
-    bytes32 internal constant ORACLE_ADDRESS_SLOT =
-        hex"c8cbea9407c380ae944f052b5a442330057683c5abdbd453493f9750806afeca";
+    bytes32 internal constant ORACLE_ADDRESS_SLOT = bytes32(uint256(keccak256("river.state.oracleAddress")) - 1);
 
     function get() internal view returns (address) {
         return UnstructuredStorage.getStorageAddress(ORACLE_ADDRESS_SLOT);

--- a/contracts/src/state/river/Shares.sol
+++ b/contracts/src/state/river/Shares.sol
@@ -4,8 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library Shares {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.shares")) - 1) */
-    bytes32 internal constant SHARES_SLOT = hex"6b842b424335d94ccad97e54548dfa02673c1268aba38d3c3c32d28c8988b70a";
+    bytes32 internal constant SHARES_SLOT = bytes32(uint256(keccak256("river.state.shares")) - 1);
 
     function get() internal view returns (uint256) {
         return UnstructuredStorage.getStorageUint256(SHARES_SLOT);

--- a/contracts/src/state/river/SharesPerOwner.sol
+++ b/contracts/src/state/river/SharesPerOwner.sol
@@ -2,8 +2,7 @@
 pragma solidity 0.8.10;
 
 library SharesPerOwner {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.sharesPerOwner")) - 1) */
-    bytes32 internal constant SHARES_SLOT = hex"0fb4a5ac9287f4f508aa7253ee2d57c6a228b1b30e210d73fffd59389d3a8837";
+    bytes32 internal constant SHARES_SLOT = bytes32(uint256(keccak256("river.state.sharesPerOwner")) - 1);
 
     struct Slot {
         mapping(address => uint256) value;

--- a/contracts/src/state/river/TreasuryAddress.sol
+++ b/contracts/src/state/river/TreasuryAddress.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library TreasuryAddress {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.treasuryAddress")) - 1) */
-    bytes32 internal constant TREASURY_ADDRESS_SLOT =
-        hex"aa490d1834c76465b09f09618af9f91fbbd04c30f1f453b24b1e8f907c9e1fa2";
+    bytes32 internal constant TREASURY_ADDRESS_SLOT = bytes32(uint256(keccak256("river.state.treasuryAddress")) - 1);
 
     function get() internal view returns (address) {
         return UnstructuredStorage.getStorageAddress(TREASURY_ADDRESS_SLOT);

--- a/contracts/src/state/river/ValidatorKeys.sol
+++ b/contracts/src/state/river/ValidatorKeys.sol
@@ -10,9 +10,7 @@ library ValidatorKeys {
     error InvalidPublicKey();
     error InvalidSignature();
 
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.validatorKeys")) - 1) */
-    bytes32 internal constant VALIDATOR_KEYS_SLOT =
-        hex"6018b2d18c7378174a403e179ce41a2df430338a150b2bcec4b7a08291285573";
+    bytes32 internal constant VALIDATOR_KEYS_SLOT = bytes32(uint256(keccak256("river.state.validatorKeys")) - 1);
 
     struct Slot {
         mapping(uint256 => mapping(uint256 => bytes)) value;

--- a/contracts/src/state/river/WithdrawalCredentials.sol
+++ b/contracts/src/state/river/WithdrawalCredentials.sol
@@ -3,9 +3,8 @@ pragma solidity 0.8.10;
 import "../../libraries/UnstructuredStorage.sol";
 
 library WithdrawalCredentials {
-    /* Hardcoded hex is: bytes32(uint256(keccak256("river.state.withdrawalCredentials")) - 1); */
     bytes32 internal constant WITHDRAWAL_CREDENTIALS_SLOT =
-        hex"b649e50315f962b32d487e696a81b4828631b11f8424daaaa37e9e97766a2c41";
+        bytes32(uint256(keccak256("river.state.withdrawalCredentials")) - 1);
 
     function get() internal view returns (bytes32) {
         return UnstructuredStorage.getStorageBytes32(WITHDRAWAL_CREDENTIALS_SLOT);


### PR DESCRIPTION
We concluded [here](https://github.com/River-Protocol/river-contracts/issues/19) that hardcoding the consts in our state contracts did not save gas, so we should revert the change for code readability