### PR TITLE
feat(ETH-38): remove allowlist controls on transfer

### DIFF
--- a/contracts/src/interfaces/IAllowlist.sol
+++ b/contracts/src/interfaces/IAllowlist.sol
@@ -2,5 +2,11 @@
 pragma solidity 0.8.10;
 
 interface IAllowlist {
-    function isAllowed(address _user, uint256 _mask) external view returns (bool);
+    function onlyAllowed(address _account, uint256 _mask) external view;
+
+    function isAllowed(address _account, uint256 _mask) external view returns (bool);
+
+    function isDenied(address _account) external view returns (bool);
+
+    function hasPermission(address _account, uint256 _mask) external view returns (bool);
 }

--- a/contracts/test/Allowlist.1.t.sol
+++ b/contracts/test/Allowlist.1.t.sol
@@ -33,6 +33,7 @@ contract AllowlistV1Tests {
 
     uint256 internal constant TEST_ONE_MASK = 0x1;
     uint256 internal constant TEST_TWO_MASK = 0x1 << 1;
+    uint256 internal constant DENIED_MASK = 0x1 << 255;
 
     function testSetAllowlistStatus(uint256 userSalt) public {
         address user = uf._new(userSalt);
@@ -163,5 +164,60 @@ contract AllowlistV1Tests {
         assert(nonAdmin != testAdmin);
         vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", nonAdmin));
         allowlist.setAllower(newAllower);
+    }
+
+    function testSetUserDenied(uint256 userSalt) public {
+        address user = uf._new(userSalt);
+        vm.startPrank(allower);
+        {
+            assert(allowlist.isDenied(user) == false);
+            address[] memory allowees = new address[](1);
+            allowees[0] = user;
+            uint256[] memory statuses = AllowlistHelper.batchAllowees(allowees.length, TEST_ONE_MASK);
+            allowlist.allow(allowees, statuses);
+            assert(allowlist.isDenied(user) == false);
+            assert(allowlist.isAllowed(user, TEST_ONE_MASK) == true);
+        }
+        {
+            address[] memory allowees = new address[](1);
+            allowees[0] = user;
+            uint256[] memory statuses = AllowlistHelper.batchAllowees(allowees.length, TEST_ONE_MASK + DENIED_MASK);
+            allowlist.allow(allowees, statuses);
+            assert(allowlist.isDenied(user) == true);
+            assert(allowlist.isAllowed(user, TEST_ONE_MASK) == false);
+            vm.expectRevert(abi.encodeWithSignature("Denied(address)", user));
+            allowlist.onlyAllowed(user, TEST_ONE_MASK);
+        }
+    }
+
+    function testGetRawPermissions(uint256 userSalt) public {
+        address user = uf._new(userSalt);
+        vm.startPrank(allower);
+        {
+            assert(allowlist.isDenied(user) == false);
+            address[] memory allowees = new address[](1);
+            allowees[0] = user;
+            uint256[] memory statuses = AllowlistHelper.batchAllowees(allowees.length, TEST_ONE_MASK + TEST_TWO_MASK);
+            allowlist.allow(allowees, statuses);
+            assert(allowlist.isAllowed(user, TEST_ONE_MASK) == true);
+            assert(allowlist.hasPermission(user, TEST_ONE_MASK) == true);
+            assert(allowlist.isAllowed(user, TEST_TWO_MASK) == true);
+            assert(allowlist.hasPermission(user, TEST_TWO_MASK) == true);
+            assert(allowlist.getPermissions(user) == TEST_ONE_MASK + TEST_TWO_MASK);
+        }
+        {
+            address[] memory allowees = new address[](1);
+            allowees[0] = user;
+            uint256[] memory statuses = AllowlistHelper.batchAllowees(
+                allowees.length,
+                TEST_ONE_MASK + TEST_TWO_MASK + DENIED_MASK
+            );
+            allowlist.allow(allowees, statuses);
+            assert(allowlist.isAllowed(user, TEST_ONE_MASK) == false);
+            assert(allowlist.hasPermission(user, TEST_ONE_MASK) == true);
+            assert(allowlist.isAllowed(user, TEST_TWO_MASK) == false);
+            assert(allowlist.hasPermission(user, TEST_TWO_MASK) == true);
+            assert(allowlist.getPermissions(user) == TEST_ONE_MASK + TEST_TWO_MASK + DENIED_MASK);
+        }
     }
 }

--- a/contracts/test/components/SharesManager.1.t.sol
+++ b/contracts/test/components/SharesManager.1.t.sol
@@ -9,6 +9,22 @@ import "../utils/UserFactory.sol";
 
 contract SharesManagerPublicDeal is SharesManagerV1 {
     uint256 public balanceSum;
+    error Denied(address _account);
+
+    mapping(address => bool) internal denied;
+
+    function setDenied(address _account) external {
+        denied[_account] = true;
+    }
+
+    function _onTransfer(address _from, address _to) internal view override {
+        if (denied[_from]) {
+            revert Denied(_from);
+        }
+        if (denied[_to]) {
+            revert Denied(_to);
+        }
+    }
 
     function setValidatorBalance(uint256 _amount) external {
         balanceSum = _amount;
@@ -41,6 +57,8 @@ contract SharesManagerV1Tests {
     UserFactory internal uf = new UserFactory();
 
     SharesManagerV1 internal sharesManager;
+
+    error Denied(address _account);
 
     function setUp() public {
         sharesManager = new SharesManagerPublicDeal();
@@ -347,6 +365,104 @@ contract SharesManagerV1Tests {
             assert(newBalanceUserOne == sharesManager.balanceOf(_userOne));
             assert(newBalanceUserTwo == sharesManager.balanceOf(_userTwo));
             assert(newBalanceUserOne + newBalanceUserTwo == totalAllowance);
+        }
+        vm.stopPrank();
+    }
+
+    function testApproveAndTransferUnauthorizedSender(
+        uint256 _userOneSalt,
+        uint256 _userTwoSalt,
+        uint128 _allowance
+    ) public {
+        address _userOne = uf._new(_userOneSalt);
+        address _userTwo = uf._new(_userTwoSalt);
+        SharesManagerPublicDeal(payable(address(sharesManager))).deal(_userOne, _allowance);
+        SharesManagerPublicDeal(payable(address(sharesManager))).setValidatorBalance(uint256(_allowance));
+        SharesManagerPublicDeal(payable(address(sharesManager))).setDenied(_userOne);
+        vm.startPrank(_userOne);
+        uint256 totalAllowance = sharesManager.balanceOf(_userOne);
+        assert(0 == sharesManager.allowance(_userOne, _userTwo));
+        sharesManager.approve(_userTwo, totalAllowance);
+        vm.stopPrank();
+        assert(totalAllowance == sharesManager.allowance(_userOne, _userTwo));
+        assert(totalAllowance == sharesManager.balanceOf(_userOne));
+        assert(0 == sharesManager.balanceOf(_userTwo));
+        uint256 transferValue = totalAllowance;
+        if (transferValue > 0) {
+            vm.startPrank(_userTwo);
+            vm.expectRevert(abi.encodeWithSignature("Denied(address)", _userOne));
+            sharesManager.transferFrom(_userOne, _userTwo, transferValue);
+            vm.stopPrank();
+        }
+    }
+
+    function testApproveAndTransferUnauthorizedReceiver(
+        uint256 _userOneSalt,
+        uint256 _userTwoSalt,
+        uint128 _allowance
+    ) public {
+        address _userOne = uf._new(_userOneSalt);
+        address _userTwo = uf._new(_userTwoSalt);
+        SharesManagerPublicDeal(payable(address(sharesManager))).deal(_userOne, _allowance);
+        SharesManagerPublicDeal(payable(address(sharesManager))).setValidatorBalance(uint256(_allowance));
+        SharesManagerPublicDeal(payable(address(sharesManager))).setDenied(_userTwo);
+        vm.startPrank(_userOne);
+        uint256 totalAllowance = sharesManager.balanceOf(_userOne);
+        assert(0 == sharesManager.allowance(_userOne, _userTwo));
+        sharesManager.approve(_userTwo, totalAllowance);
+        vm.stopPrank();
+        assert(totalAllowance == sharesManager.allowance(_userOne, _userTwo));
+        assert(totalAllowance == sharesManager.balanceOf(_userOne));
+        assert(0 == sharesManager.balanceOf(_userTwo));
+        uint256 transferValue = totalAllowance;
+        if (transferValue > 0) {
+            vm.startPrank(_userTwo);
+            vm.expectRevert(abi.encodeWithSignature("Denied(address)", _userTwo));
+            sharesManager.transferFrom(_userOne, _userTwo, transferValue);
+            vm.stopPrank();
+        }
+    }
+
+    function testTransferUnauthorizedSender(
+        uint256 _userOneSalt,
+        uint256 _userTwoSalt,
+        uint128 _allowance
+    ) public {
+        address _userOne = uf._new(_userOneSalt);
+        address _userTwo = uf._new(_userTwoSalt);
+        SharesManagerPublicDeal(payable(address(sharesManager))).deal(_userOne, _allowance);
+        SharesManagerPublicDeal(payable(address(sharesManager))).setValidatorBalance(uint256(_allowance));
+        SharesManagerPublicDeal(payable(address(sharesManager))).setDenied(_userOne);
+
+        vm.startPrank(_userOne);
+        uint256 totalAllowance = sharesManager.balanceOf(_userOne);
+        assert(0 == sharesManager.balanceOf(_userTwo));
+        uint256 transferValue = totalAllowance;
+        if (transferValue > 0) {
+            vm.expectRevert(abi.encodeWithSignature("Denied(address)", _userOne));
+            sharesManager.transfer(_userTwo, transferValue);
+        }
+        vm.stopPrank();
+    }
+
+    function testTransferUnauthorizedReceiver(
+        uint256 _userOneSalt,
+        uint256 _userTwoSalt,
+        uint128 _allowance
+    ) public {
+        address _userOne = uf._new(_userOneSalt);
+        address _userTwo = uf._new(_userTwoSalt);
+        SharesManagerPublicDeal(payable(address(sharesManager))).deal(_userOne, _allowance);
+        SharesManagerPublicDeal(payable(address(sharesManager))).setValidatorBalance(uint256(_allowance));
+        SharesManagerPublicDeal(payable(address(sharesManager))).setDenied(_userTwo);
+
+        vm.startPrank(_userOne);
+        uint256 totalAllowance = sharesManager.balanceOf(_userOne);
+        assert(0 == sharesManager.balanceOf(_userTwo));
+        uint256 transferValue = totalAllowance;
+        if (transferValue > 0) {
+            vm.expectRevert(abi.encodeWithSignature("Denied(address)", _userTwo));
+            sharesManager.transfer(_userTwo, transferValue);
         }
         vm.stopPrank();
     }


### PR DESCRIPTION
Resolves #54

Removes the need to give the transfer right on the Allowlist to all users. Only Deposits are currently protected. This PR also add the deny list to the Allowlist contract.