### PR TITLE
Add a POST-DEPLOYMENT.md

### DIFF
--- a/POST-DEPLOYMENT.md
+++ b/POST-DEPLOYMENT.md
@@ -1,17 +1,6 @@
 # Post Deployment Process
 
-When we do a full deployment of our contracts (not just an upgrade), we need to populate some initial data. This can include data for the sake of demonstration if we're doing a testnet deployment, and otherwise includes some necessary initial data for a mainnet deployment.
-
-## All Deployments
-
-For all deployments, we must:
-
-1. Update the deployment scripts for our contracts, in the contracts repository under the `deploy` folder
-    1. [Example pr](https://github.com/River-Protocol/river-contracts/pull/47)
-2. Deploy via `yarn hh --network goerli`, from the multisig account
-3. Update the config values we use in the contract repository under `deployments` with the output of your deployment
-    1. In particular, the ABIs (`RiverV1.json`, etc) that will be reused in by the [River CLI](https://github.com/River-Protocol/river) and [Allowlist Service](https://github.com/River-Protocol/Allowlist-Service)
-    2. [Example pr](https://github.com/River-Protocol/river-contracts/pull/53/files)
+When we do a full deployment of our contracts (not just an upgrade), we need to populate some initial data. This can include necessary seed data & initial account roles to bootstrap the ecosystem, as well as demonstration data for testnet deployments.
 
 ## Testnet Deployments
 
@@ -23,10 +12,10 @@ For testnet deployments, we must:
         2. Node operators
         3. Oracle members
     2. Deposit some ETH using the UI via the first account
-    3. Add some node operators, then validator keys, from the CLI via the second account
-    4. Deposit that staked ETH to those new validators via `depositToConsensusLayer()` from the admin account in OZ defender
+    3. Add some validator keys from the CLI via the second account
+    4. Flush that staked ETH to those new validators via `depositToConsensusLayer()` from the admin account in OZ defender
     5. Run an oracle report from the CLI via the third account
-2. Add customers to testnet allowlist so they can make example deposits or node operations
+2. Add customers to those three roles as well, so that they can make example deposits or node operations
 3. Note any bugs in steps 1 and 2, and make fast follow contributions to contracts or the reference dapp
 
 ## Mainnet Deployments


### PR DESCRIPTION
This explains what data we need to seed for testnet and mainnet releases, as well as how & where to get example data for testnet.

There are three outstanding items that we will finalise at a future date:

- The account that the AllowlistService makes its `allow()` calls from
- An up-to-date resource of ChannelPartner (aka Integrator) accounts for node operation
- An up-to-date resource for accounts we rely on as Oracle Members