### PR TITLE
feat(ETH-32): remove referral address from deposit

### DIFF
--- a/contracts/src/components/TransferManager.1.sol
+++ b/contracts/src/components/TransferManager.1.sol
@@ -7,7 +7,7 @@ import "../libraries/Errors.sol";
 /// @author Kiln
 /// @notice This contract handles the inbound transfers cases or the explicit submissions
 abstract contract TransferManagerV1 {
-    event UserDeposit(address indexed user, address indexed referral, uint256 amount);
+    event UserDeposit(address indexed user, uint256 amount);
     event Donation(address donator, uint256 amount);
 
     error EmptyDeposit();
@@ -24,16 +24,15 @@ abstract contract TransferManagerV1 {
     /// @param _amount Amount donated
     function _onDonation(uint256 _amount) internal virtual;
 
-    /// @notice Internal utility calling the deposit handler and emitting the deposit details and the referral address
-    /// @param _referral Referral address, address(0) if none
-    function _deposit(address _referral) internal {
+    /// @notice Internal utility calling the deposit handler and emitting the deposit details
+    function _deposit() internal {
         if (msg.value == 0) {
             revert EmptyDeposit();
         }
 
         _onDeposit(msg.sender, msg.value);
 
-        emit UserDeposit(msg.sender, _referral, msg.value);
+        emit UserDeposit(msg.sender, msg.value);
     }
 
     /// @notice Returns the amount of pending ETH
@@ -42,9 +41,8 @@ abstract contract TransferManagerV1 {
     }
 
     /// @notice Explicit deposit method
-    /// @param _referral Referral address, address(0) if none
-    function deposit(address _referral) external payable {
-        _deposit(_referral);
+    function deposit() external payable {
+        _deposit();
     }
 
     /// @notice Allows anyone to add ethers to river without minting new shares
@@ -61,7 +59,7 @@ abstract contract TransferManagerV1 {
 
     /// @notice Implicit deposit method, when the user performs a regular transfer to the contract
     receive() external payable {
-        _deposit(address(0));
+        _deposit();
     }
 
     /// @notice Invalid call, when the user sends a transaction with a data payload but no method matched

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -128,7 +128,7 @@ contract RiverV1SetupOneTests {
 
         vm.startPrank(joe);
         vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", joe));
-        river.deposit{value: 100 ether}(address(0));
+        river.deposit{value: 100 ether}();
     }
 
     // Testing regular parameters
@@ -140,10 +140,10 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK);
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(address(0));
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(address(0));
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -205,10 +205,10 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK + TRANSFER_MASK);
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(address(0));
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(address(0));
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -256,10 +256,10 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK + TRANSFER_MASK);
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(address(0));
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(address(0));
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -325,10 +325,10 @@ contract RiverV1SetupOneTests {
         vm.stopPrank();
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(address(0));
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(address(0));
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -391,10 +391,10 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK + TRANSFER_MASK);
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(address(0));
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(address(0));
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -463,10 +463,10 @@ contract RiverV1SetupOneTests {
         vm.stopPrank();
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(address(0));
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(address(0));
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -538,13 +538,13 @@ contract RiverV1SetupOneTests {
         if (joeBalance == 0) {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        river.deposit{value: joeBalance}(address(0));
+        river.deposit{value: joeBalance}();
         vm.stopPrank();
         vm.startPrank(bob);
         if (bobBalance == 0) {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        river.deposit{value: bobBalance}(address(0));
+        river.deposit{value: bobBalance}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == joeBalance);
         assert(river.balanceOfUnderlying(bob) == bobBalance);

--- a/contracts/test/components/TransferManager.1.t.sol
+++ b/contracts/test/components/TransferManager.1.t.sol
@@ -23,7 +23,7 @@ contract TransferManagerV1DepositTests {
 
     error InvalidCall();
 
-    event UserDeposit(address indexed user, address indexed referral, uint256 amount);
+    event UserDeposit(address indexed user, uint256 amount);
 
     function setUp() public {
         transferManager = new TransferManagerV1EmptyDeposit();
@@ -40,38 +40,11 @@ contract TransferManagerV1DepositTests {
 
         if (_amount > 0) {
             vm.expectEmit(true, true, true, true);
-            emit UserDeposit(_user, address(0), _amount);
+            emit UserDeposit(_user, _amount);
         } else {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        transferManager.deposit{value: _amount}(address(0));
-
-        assert(_user.balance == 0);
-        assert(address(transferManager).balance == _amount);
-        assert(transferManager.getPendingEth() == _amount);
-    }
-
-    function testDepositWithDedicatedMethodAndReferral(
-        uint256 _userSalt,
-        uint256 _referralSalt,
-        uint256 _amount
-    ) public {
-        address _user = uf._new(_userSalt);
-        address _referral = uf._new(_referralSalt);
-        vm.deal(_user, _amount);
-        vm.deal(address(transferManager), 0);
-        vm.startPrank(_user);
-
-        assert(_user.balance == _amount);
-        assert(address(transferManager).balance == 0);
-
-        if (_amount > 0) {
-            vm.expectEmit(true, true, true, true);
-            emit UserDeposit(_user, _referral, _amount);
-        } else {
-            vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
-        }
-        transferManager.deposit{value: _amount}(_referral);
+        transferManager.deposit{value: _amount}();
 
         assert(_user.balance == 0);
         assert(address(transferManager).balance == _amount);
@@ -89,7 +62,7 @@ contract TransferManagerV1DepositTests {
 
         if (_amount > 0) {
             vm.expectEmit(true, true, true, true);
-            emit UserDeposit(_user, address(0), _amount);
+            emit UserDeposit(_user, _amount);
         } else {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
@@ -162,7 +135,7 @@ contract TransferManagerV1CallbackTests {
         } else {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        transferManager.deposit{value: _amount}(address(0));
+        transferManager.deposit{value: _amount}();
 
         assert(_user.balance == 0);
     }


### PR DESCRIPTION
This PR removes the referral address argument from the deposit external method.