### PR TITLE
feat: allow to deposit and transfer in a single contract call

### DIFF
--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -107,9 +107,14 @@ contract RiverV1 is
         address _recipient,
         uint256 _amount
     ) internal override {
-        (AllowlistAddress.get()).onlyAllowed(_depositor, DEPOSIT_MASK); // this call reverts if unauthorized or denied
-        (AllowlistAddress.get()).onlyAllowed(_recipient, TRANSFER_MASK);
-        SharesManagerV1._mintShares(_recipient, _amount);
+        SharesManagerV1._mintShares(_depositor, _amount);
+        if (_depositor == _recipient) {
+            (AllowlistAddress.get()).onlyAllowed(_depositor, DEPOSIT_MASK); // this call reverts if unauthorized or denied
+        } else {
+            (AllowlistAddress.get()).onlyAllowed(_depositor, DEPOSIT_MASK + TRANSFER_MASK); // this call reverts if unauthorized or denied
+            (AllowlistAddress.get()).onlyAllowed(_recipient, TRANSFER_MASK);
+            _transfer(_depositor, _recipient, _amount);
+        }
     }
 
     /// @notice Handler called whenever a deposit to the consensus layer is made. Should retrieve _requestedAmount or lower keys

--- a/contracts/src/components/TransferManager.1.sol
+++ b/contracts/src/components/TransferManager.1.sol
@@ -45,9 +45,14 @@ abstract contract TransferManagerV1 {
         return address(this).balance;
     }
 
-    /// @notice Explicit deposit method
+    /// @notice Explicit deposit method to mint on msg.sender
+    function deposit() external payable {
+        _deposit(msg.sender);
+    }
+
+    /// @notice Explicit deposit method to mint on msg.sender and transfer to _recipient
     /// @param _recipient Address receiving the minted lsETH
-    function deposit(address _recipient) external payable {
+    function depositAndTransfer(address _recipient) external payable {
         _deposit(_recipient);
     }
 

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -137,7 +137,7 @@ contract RiverV1SetupOneTests {
 
         vm.startPrank(joe);
         vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", joe));
-        river.deposit{value: 100 ether}(joe);
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
     }
 
@@ -150,10 +150,10 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK);
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(joe);
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(bob);
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -214,10 +214,10 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK);
 
         vm.startPrank(bob);
-        river.deposit{value: 100 ether}(joe);
+        river.depositAndTransfer{value: 100 ether}(joe);
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(bob);
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -279,21 +279,21 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK);
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(joe);
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(bob);
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
 
         _deny(joe);
         vm.startPrank(joe);
         vm.expectRevert(abi.encodeWithSignature("Denied(address)", joe));
-        river.deposit{value: 100 ether}(joe);
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
 
         vm.startPrank(bob);
         vm.expectRevert(abi.encodeWithSignature("Denied(address)", joe));
-        river.deposit{value: 100 ether}(joe);
+        river.depositAndTransfer{value: 100 ether}(joe);
         vm.stopPrank();
 
         assert(river.balanceOfUnderlying(joe) == 100 ether);
@@ -343,10 +343,10 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK);
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(joe);
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(bob);
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -412,10 +412,10 @@ contract RiverV1SetupOneTests {
         vm.stopPrank();
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(joe);
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(bob);
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -478,10 +478,10 @@ contract RiverV1SetupOneTests {
         _allow(bob, DEPOSIT_MASK);
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(joe);
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(bob);
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -550,10 +550,10 @@ contract RiverV1SetupOneTests {
         vm.stopPrank();
 
         vm.startPrank(joe);
-        river.deposit{value: 100 ether}(joe);
+        river.deposit{value: 100 ether}();
         vm.stopPrank();
         vm.startPrank(bob);
-        river.deposit{value: 1000 ether}(bob);
+        river.deposit{value: 1000 ether}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == 100 ether);
         assert(river.balanceOfUnderlying(bob) == 1000 ether);
@@ -625,13 +625,13 @@ contract RiverV1SetupOneTests {
         if (joeBalance == 0) {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        river.deposit{value: joeBalance}(joe);
+        river.deposit{value: joeBalance}();
         vm.stopPrank();
         vm.startPrank(bob);
         if (bobBalance == 0) {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        river.deposit{value: bobBalance}(bob);
+        river.deposit{value: bobBalance}();
         vm.stopPrank();
         assert(river.balanceOfUnderlying(joe) == joeBalance);
         assert(river.balanceOfUnderlying(bob) == bobBalance);

--- a/contracts/test/components/TransferManager.1.t.sol
+++ b/contracts/test/components/TransferManager.1.t.sol
@@ -48,7 +48,7 @@ contract TransferManagerV1DepositTests {
         } else {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        transferManager.deposit{value: _amount}(_user);
+        transferManager.deposit{value: _amount}();
 
         assert(_user.balance == 0);
         assert(address(transferManager).balance == _amount);
@@ -75,7 +75,7 @@ contract TransferManagerV1DepositTests {
         } else {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        transferManager.deposit{value: _amount}(_anotherUser);
+        transferManager.depositAndTransfer{value: _amount}(_anotherUser);
 
         assert(_user.balance == 0);
         assert(address(transferManager).balance == _amount);
@@ -170,7 +170,7 @@ contract TransferManagerV1CallbackTests {
         } else {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        transferManager.deposit{value: _amount}(_user);
+        transferManager.deposit{value: _amount}();
 
         assert(_user.balance == 0);
     }
@@ -193,7 +193,7 @@ contract TransferManagerV1CallbackTests {
         } else {
             vm.expectRevert(abi.encodeWithSignature("EmptyDeposit()"));
         }
-        transferManager.deposit{value: _amount}(_anotherUser);
+        transferManager.depositAndTransfer{value: _amount}(_anotherUser);
 
         assert(_user.balance == 0);
     }


### PR DESCRIPTION
Adds a new argument to the deposit method that allows to mint new shares to another recipient, so depositors doesn't have to mint then transfer the funds.