### PR TITLE
feat: add zero address fallback on tupproxy + test suite

### DIFF
--- a/contracts/src/TUPProxy.sol
+++ b/contracts/src/TUPProxy.sol
@@ -35,10 +35,14 @@ contract TUPProxy is TransparentUpgradeableProxy {
     }
 
     /// @dev Overrides the fallback method to check if system is not paused before
+    /// @dev Address Zero is allowed to perform calls even if system is paused. This allows
+    /// view functions to be called when the system is paused as rpc providers can easily
+    /// set the sender address to zero.
     function _beforeFallback() internal override {
-        if (StorageSlot.getBooleanSlot(_PAUSE_SLOT).value == true) {
+        if (StorageSlot.getBooleanSlot(_PAUSE_SLOT).value == false || msg.sender == address(0)) {
+            super._beforeFallback();
+        } else {
             revert CallWhenPaused();
         }
-        super._beforeFallback();
     }
 }

--- a/contracts/test/TUPProxy.t.sol
+++ b/contracts/test/TUPProxy.t.sol
@@ -1,0 +1,142 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.8.10;
+
+import "../src/TUPProxy.sol";
+import "./Vm.sol";
+
+contract DummyCounter {
+    error BigError(uint256);
+    error CallWentIn();
+
+    uint256 public i;
+
+    function inc() external {
+        ++i;
+    }
+
+    function fail() external view {
+        revert BigError(i);
+    }
+
+    function isPaused() external pure {
+        revert CallWentIn();
+    }
+}
+
+contract DummyCounterEvolved is DummyCounter {
+    bool internal init;
+
+    function superInc() external {
+        ++i;
+        ++i;
+    }
+
+    function superI() external view returns (uint256) {
+        return i * i;
+    }
+
+    function initEvolved(uint256 _i) external {
+        require(init == false, "already initialised");
+        i = _i;
+        init = true;
+    }
+}
+
+contract TUPProxyTest {
+    Vm internal vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    DummyCounter internal implem;
+    DummyCounterEvolved internal implemEvolved;
+    TUPProxy internal proxy;
+
+    address internal admin = address(1);
+
+    function setUp() public {
+        implem = new DummyCounter();
+        implemEvolved = new DummyCounterEvolved();
+        proxy = new TUPProxy(address(implem), admin, "");
+    }
+
+    function testViewFunc() public view {
+        assert(DummyCounter(address(proxy)).i() == 0);
+    }
+
+    function testFunc() public {
+        assert(DummyCounter(address(proxy)).i() == 0);
+        DummyCounter(address(proxy)).inc();
+        assert(DummyCounter(address(proxy)).i() == 1);
+    }
+
+    function testAdminFuncAsLambda() public {
+        vm.expectRevert(abi.encodeWithSignature("CallWentIn()"));
+        proxy.isPaused();
+    }
+
+    function testFuncAsAdmin() public {
+        assert(DummyCounter(address(proxy)).i() == 0);
+        vm.startPrank(admin);
+        vm.expectRevert("TransparentUpgradeableProxy: admin cannot fallback to proxy target");
+        DummyCounter(address(proxy)).inc();
+    }
+
+    function testRevert() public {
+        vm.expectRevert(abi.encodeWithSignature("BigError(uint256)", 0));
+        DummyCounter(address(proxy)).fail();
+        DummyCounter(address(proxy)).inc();
+        vm.expectRevert(abi.encodeWithSignature("BigError(uint256)", 1));
+        DummyCounter(address(proxy)).fail();
+    }
+
+    function testUpgradeToAndCall() public {
+        assert(DummyCounter(address(proxy)).i() == 0);
+        vm.startPrank(admin);
+        proxy.upgradeToAndCall(address(implemEvolved), abi.encodeWithSignature("initEvolved(uint256)", 5));
+        vm.stopPrank();
+        assert(DummyCounterEvolved(address(proxy)).i() == 5);
+        DummyCounterEvolved(address(proxy)).superInc();
+        assert(DummyCounterEvolved(address(proxy)).i() == 7);
+        assert(DummyCounterEvolved(address(proxy)).superI() == 49);
+    }
+
+    function testPause() public {
+        assert(DummyCounter(address(proxy)).i() == 0);
+        DummyCounter(address(proxy)).inc();
+        assert(DummyCounter(address(proxy)).i() == 1);
+        vm.startPrank(admin);
+        proxy.pause();
+        vm.stopPrank();
+        vm.expectRevert(abi.encodeWithSignature("CallWhenPaused()"));
+        DummyCounter(address(proxy)).inc();
+    }
+
+    function testUnPause() public {
+        assert(DummyCounter(address(proxy)).i() == 0);
+        DummyCounter(address(proxy)).inc();
+        assert(DummyCounter(address(proxy)).i() == 1);
+        vm.startPrank(admin);
+        proxy.pause();
+        assert(proxy.isPaused() == true);
+        vm.stopPrank();
+        vm.expectRevert(abi.encodeWithSignature("CallWhenPaused()"));
+        DummyCounter(address(proxy)).inc();
+        vm.startPrank(admin);
+        proxy.unpause();
+        assert(proxy.isPaused() == false);
+        vm.stopPrank();
+        DummyCounter(address(proxy)).inc();
+        assert(DummyCounter(address(proxy)).i() == 2);
+    }
+
+    function testPauseAddressZeroFallback() public {
+        assert(DummyCounter(address(proxy)).i() == 0);
+        DummyCounter(address(proxy)).inc();
+        assert(DummyCounter(address(proxy)).i() == 1);
+        vm.startPrank(admin);
+        proxy.pause();
+        vm.stopPrank();
+
+        vm.startPrank(address(0));
+        assert(DummyCounter(address(proxy)).i() == 1);
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
When the system is paused, no call is forwarded to the contracts. This behavior will brake frontends as they will not be able to make view calls to the system. In order to prevent that from happening, we allow the address(0) to do calls on the paused system like if the system wasn't paused. This will allow frontends/backends doing rpc calls to always use address(0) as the caller address and ensure that they can fetch the data from the contracts at all time.