### PR TITLE
fix: oracle river interface + add oracle to river tests

### DIFF
--- a/contracts/src/Oracle.1.sol
+++ b/contracts/src/Oracle.1.sol
@@ -5,6 +5,7 @@ import "./Initializable.sol";
 import "./libraries/Errors.sol";
 import "./libraries/LibOwnable.sol";
 import "./interfaces/IRiverOracleInput.sol";
+import "./interfaces/IRiverToken.sol";
 
 import "./state/shared/AdministratorAddress.sol";
 import "./state/shared/RiverAddress.sol";
@@ -489,15 +490,15 @@ contract OracleV1 is Initializable {
         _clearReporting(_epochId + _beaconSpec.epochsPerFrame);
 
         IRiverOracleInput riverAddress = IRiverOracleInput(RiverAddress.get());
-        uint256 prevTotalEth = riverAddress.totalSupply();
+        uint256 prevTotalEth = IRiverToken(address(riverAddress)).totalUnderlyingSupply();
         riverAddress.setBeaconData(_validatorCount, _balanceSum, bytes32(_epochId));
-        uint256 postTotalEth = riverAddress.totalSupply();
+        uint256 postTotalEth = IRiverToken(address(riverAddress)).totalUnderlyingSupply();
 
         uint256 timeElapsed = (_epochId - LastEpochId.get()) * _beaconSpec.slotsPerEpoch * _beaconSpec.secondsPerSlot;
 
         _sanityChecks(postTotalEth, prevTotalEth, timeElapsed);
         LastEpochId.set(_epochId);
 
-        emit PostTotalShares(postTotalEth, prevTotalEth, timeElapsed, riverAddress.totalShares());
+        emit PostTotalShares(postTotalEth, prevTotalEth, timeElapsed, IRiverToken(address(riverAddress)).totalSupply());
     }
 }

--- a/contracts/src/interfaces/IRiverOracleInput.sol
+++ b/contracts/src/interfaces/IRiverOracleInput.sol
@@ -7,8 +7,4 @@ interface IRiverOracleInput {
         uint256 _validatorBalanceSum,
         bytes32 _roundId
     ) external;
-
-    function totalSupply() external returns (uint256);
-
-    function totalShares() external returns (uint256);
 }

--- a/contracts/src/interfaces/IRiverToken.sol
+++ b/contracts/src/interfaces/IRiverToken.sol
@@ -15,4 +15,8 @@ interface IRiverToken {
     ) external returns (bool);
 
     function transfer(address _to, uint256 _value) external returns (bool);
+
+    function totalSupply() external returns (uint256);
+
+    function totalUnderlyingSupply() external returns (uint256);
 }

--- a/contracts/test/WLSETH.1.t.sol
+++ b/contracts/test/WLSETH.1.t.sol
@@ -11,31 +11,39 @@ contract RiverTokenMock is IRiverToken {
     mapping(address => uint256) internal balances;
     mapping(address => mapping(address => uint256)) internal approvals;
     uint256 internal underlyingAssetTotal;
-    uint256 internal totalSupply;
+    uint256 internal _totalSupply;
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function totalUnderlyingSupply() external view returns (uint256) {
+        return underlyingAssetTotal;
+    }
 
     function balanceOf(address _owner) external view returns (uint256 balance) {
         return balances[_owner];
     }
 
     function balanceOfUnderlying(address _owner) external view returns (uint256 balance) {
-        if (totalSupply == 0) {
+        if (_totalSupply == 0) {
             return 0;
         }
-        return (balances[_owner] * underlyingAssetTotal) / totalSupply;
+        return (balances[_owner] * underlyingAssetTotal) / _totalSupply;
     }
 
     function underlyingBalanceFromShares(uint256 shares) external view returns (uint256) {
-        if (totalSupply == 0) {
+        if (_totalSupply == 0) {
             return 0;
         }
-        return (shares * underlyingAssetTotal) / totalSupply;
+        return (shares * underlyingAssetTotal) / _totalSupply;
     }
 
     function sharesFromUnderlyingBalance(uint256 underlyingBalance) external view returns (uint256) {
         if (underlyingAssetTotal == 0) {
             return 0;
         }
-        return (underlyingBalance * totalSupply) / underlyingAssetTotal;
+        return (underlyingBalance * _totalSupply) / underlyingAssetTotal;
     }
 
     function transferFrom(
@@ -68,9 +76,9 @@ contract RiverTokenMock is IRiverToken {
 
     function sudoSetBalance(address _who, uint256 _amount) external {
         if (balances[_who] > _amount) {
-            totalSupply -= (balances[_who] - _amount);
+            _totalSupply -= (balances[_who] - _amount);
         } else {
-            totalSupply += (_amount - balances[_who]);
+            _totalSupply += (_amount - balances[_who]);
         }
         balances[_who] = _amount;
     }

--- a/contracts/test/mocks/RiverMock.sol
+++ b/contracts/test/mocks/RiverMock.sol
@@ -31,11 +31,11 @@ contract RiverMock is IRiverOracleInput {
         _totalShares = _newTotalShares;
     }
 
-    function totalSupply() external view returns (uint256) {
+    function totalUnderlyingSupply() external view returns (uint256) {
         return _totalSupply;
     }
 
-    function totalShares() external view returns (uint256) {
+    function totalSupply() external view returns (uint256) {
         return _totalShares;
     }
 }

--- a/deploy/3_deploy_river_and_oracle.ts
+++ b/deploy/3_deploy_river_and_oracle.ts
@@ -20,6 +20,19 @@ const func: DeployFunction = async function ({
 }: HardhatRuntimeEnvironment) {
   logStep();
 
+  let genesisTimestamp = 0;
+  switch (network.name) {
+    case "goerli":
+    case "mockedGoerli": {
+      genesisTimestamp = 1616508000;
+      break;
+    }
+    case "mainnet": {
+      genesisTimestamp = 1606824023;
+      break;
+    }
+  }
+
   const { deployer, proxyAdministrator, systemAdministrator, treasury } = await getNamedAccounts();
 
   let depositContract = (await getNamedAccounts()).depositContract;
@@ -125,7 +138,7 @@ const func: DeployFunction = async function ({
       proxyContract: "TUPProxy",
       execute: {
         methodName: "initOracleV1",
-        args: [riverDeployment.address, oracleFirewallDeployment.address, 225, 32, 12, 1606824023, 1000, 500],
+        args: [riverDeployment.address, oracleFirewallDeployment.address, 225, 32, 12, genesisTimestamp, 1000, 500],
       },
     },
   });


### PR DESCRIPTION
- Fix the issue where the Oracle would call methods that were remove from the cToken transition
- Add the Oracle to the River main test suite and not only a mock