### PR TITLE
feat(river): add metadata setter and getter

### DIFF
--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -17,7 +17,7 @@ import "./state/river/AllowlistAddress.sol";
 import "./state/river/OperatorsRegistryAddress.sol";
 import "./state/river/CollectorAddress.sol";
 import "./state/river/GlobalFee.sol";
-import "./state/river/Metadata.sol";
+import "./state/river/MetadataURI.sol";
 import "./state/river/ELFeeRecipientAddress.sol";
 
 /// @title River (v1)
@@ -137,8 +137,8 @@ contract RiverV1 is
     }
 
     /// @inheritdoc IRiverV1
-    function getMetadata() external view returns (string memory) {
-        return Metadata.get();
+    function getMetadataURI() external view returns (string memory) {
+        return MetadataURI.get();
     }
 
     /// @inheritdoc IRiverV1
@@ -166,9 +166,9 @@ contract RiverV1 is
     }
 
     /// @inheritdoc IRiverV1
-    function setMetadata(string memory _metadata) external onlyAdmin {
-        Metadata.set(_metadata);
-        emit SetMetadata(_metadata);
+    function setMetadataURI(string memory _metadataURI) external onlyAdmin {
+        MetadataURI.set(_metadataURI);
+        emit SetMetadataURI(_metadataURI);
     }
 
     /// @inheritdoc IRiverV1

--- a/contracts/src/interfaces/IRiver.1.sol
+++ b/contracts/src/interfaces/IRiver.1.sol
@@ -34,9 +34,9 @@ interface IRiverV1 is IConsensusLayerDepositManagerV1, IUserDepositManagerV1, IS
     /// @param operatorRegistry The new Operators Registry
     event SetOperatorsRegistry(address indexed operatorRegistry);
 
-    /// @notice The stored Metadata string has been changed
-    /// @param metadata The new Metadata string
-    event SetMetadata(string metadata);
+    /// @notice The stored Metadata URI string has been changed
+    /// @param metadataURI The new Metadata URI string
+    event SetMetadataURI(string metadataURI);
 
     /// @notice The system underlying supply increased. This is a snapshot of the balances for accounting purposes
     /// @param _collector The address of the collector during this event
@@ -101,9 +101,9 @@ interface IRiverV1 is IConsensusLayerDepositManagerV1, IUserDepositManagerV1, IS
     /// @return The operators registry address
     function getOperatorsRegistry() external view returns (address);
 
-    /// @notice Retrieve the metadata string value
-    /// @return The metadata string value
-    function getMetadata() external view returns (string memory);
+    /// @notice Retrieve the metadata uri string value
+    /// @return The metadata uri string value
+    function getMetadataURI() external view returns (string memory);
 
     /// @notice Changes the global fee parameter
     /// @param newFee New fee value
@@ -121,9 +121,9 @@ interface IRiverV1 is IConsensusLayerDepositManagerV1, IUserDepositManagerV1, IS
     /// @param _newELFeeRecipient New address for the recipient
     function setELFeeRecipient(address _newELFeeRecipient) external;
 
-    /// @notice Sets the metadata string value
-    /// @param _metadata The new metadata string value
-    function setMetadata(string memory _metadata) external;
+    /// @notice Sets the metadata uri string value
+    /// @param _metadataURI The new metadata uri string value
+    function setMetadataURI(string memory _metadataURI) external;
 
     /// @notice Input for execution layer fee earnings
     function sendELFees() external payable;

--- a/contracts/src/state/river/MetadataURI.sol
+++ b/contracts/src/state/river/MetadataURI.sol
@@ -1,11 +1,11 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.10;
 
-/// @title Metadata Storage
+/// @title Metadata URI Storage
 /// @notice Utility to manage the Metadata in storage
-library Metadata {
-    /// @notice Storage slot of the Metadata
-    bytes32 internal constant METADATA_SLOT = bytes32(uint256(keccak256("river.state.metadata")) - 1);
+library MetadataURI {
+    /// @notice Storage slot of the Metadata URI
+    bytes32 internal constant METADATA_URI_SLOT = bytes32(uint256(keccak256("river.state.metadataUri")) - 1);
 
     /// @notice Structure in storage
     struct Slot {
@@ -13,10 +13,10 @@ library Metadata {
         string value;
     }
 
-    /// @notice Retrieve the metadata
-    /// @return The metadata string
+    /// @notice Retrieve the metadata URI
+    /// @return The metadata URI string
     function get() internal view returns (string memory) {
-        bytes32 slot = METADATA_SLOT;
+        bytes32 slot = METADATA_URI_SLOT;
 
         Slot storage r;
 
@@ -28,10 +28,10 @@ library Metadata {
         return r.value;
     }
 
-    /// @notice Set the metadata value
-    /// @param _newValue The new metadata value
+    /// @notice Set the metadata URI value
+    /// @param _newValue The new metadata URI value
     function set(string memory _newValue) internal {
-        bytes32 slot = METADATA_SLOT;
+        bytes32 slot = METADATA_URI_SLOT;
 
         Slot storage r;
 

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -250,23 +250,23 @@ contract RiverV1SetupOneTests is Test, BytesGenerator {
         vm.stopPrank();
     }
 
-    event SetMetadata(string metadata);
+    event SetMetadataURI(string metadataURI);
 
-    function testSetMetadata(string memory _metadata) public {
+    function testSetMetadataURI(string memory _metadataURI) public {
         vm.startPrank(admin);
-        assertEq(river.getMetadata(), "");
+        assertEq(river.getMetadataURI(), "");
         vm.expectEmit(true, true, true, true);
-        emit SetMetadata(_metadata);
-        river.setMetadata(_metadata);
-        assertEq(river.getMetadata(), _metadata);
+        emit SetMetadataURI(_metadataURI);
+        river.setMetadataURI(_metadataURI);
+        assertEq(river.getMetadataURI(), _metadataURI);
         vm.stopPrank();
     }
 
-    function testSetMetadataUnauthorized(string memory _metadata, uint256 _salt) public {
+    function testSetMetadataURIUnauthorized(string memory _metadataURI, uint256 _salt) public {
         address unauthorized = uf._new(_salt);
         vm.prank(unauthorized);
         vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", unauthorized));
-        river.setMetadata(_metadata);
+        river.setMetadataURI(_metadataURI);
     }
 
     function _allow(address _who, uint256 _mask) internal {


### PR DESCRIPTION
Add a metadata setter and getter that can store any string value to be interpreted off-chain.