### PR TITLE
Add pull action to retrieve funds from withdrawal credential upon migration

### DIFF
--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -473,6 +473,9 @@ contract RiverV1 is
         if (exitedEthAmount > 0) {
             _setBalanceToRedeem(BalanceToRedeem.get() + exitedEthAmount);
         }
+        if (collectedCLFunds > 0) {
+            emit PulledCLFunds(collectedCLFunds);
+        }
     }
 
     /// @notice Pulls funds from the redeem manager exceeding eth buffer

--- a/contracts/src/interfaces/IRiver.1.sol
+++ b/contracts/src/interfaces/IRiver.1.sol
@@ -16,6 +16,10 @@ interface IRiverV1 is IConsensusLayerDepositManagerV1, IUserDepositManagerV1, IS
     /// @param amount The amount pulled
     event PulledELFees(uint256 amount);
 
+    /// @notice Funds have been pulled from the Withdrawal Contract
+    /// @param amount The amount pulled
+    event PulledCLFunds(uint256 amount);
+
     /// @notice Funds have been pulled from the Coverage Fund
     /// @param amount The amount pulled
     event PulledCoverageFunds(uint256 amount);

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -694,6 +694,7 @@ contract RiverV1TestsMigrations is Test, BytesGenerator {
 
     event SetRedeemManager(address redeemManager);
     event SetOperatorsRegistry(address indexed operatorsRegistry);
+    event PulledCLFunds(uint256 amount);
 
     uint64 constant epochsPerFrame = 225;
     uint64 constant slotsPerEpoch = 32;
@@ -787,6 +788,10 @@ contract RiverV1TestsMigrations is Test, BytesGenerator {
         assertEq(address(withdraw).balance, amount);
 
         withdraw.initializeWithdrawV1(address(river));
+        if (amount > 0) {
+            vm.expectEmit(true, true, true, true);
+            emit PulledCLFunds(amount);
+        }
         river.initRiverV1_1(
             address(redeemManager),
             epochsPerFrame,


### PR DESCRIPTION
#### Description

Some validators had their `feeRecipient` miss-configured to the Withdrawal contract instead of the ELFeeRecipient contract. This resulted in some EL fees (around 0.25 ETH) being transferred to the withdrawal contract instead of the ELFeeRecipient. Currently, the protocol does not allow to recover those funds which are locked on the Withdraw contract.

This change pulling those funds back into the system at Withdrawal migration time.

#### Note about protocol fee accounting 

In anticipation of Shapella, as an interim solution Oracle now includes funds on the withdraw contract as part of the CL balance. This is to ensure the total underlying supply of ETH does not drop due to the partial withdrawal (we need to keep accounting for skimmed funds).

So the 0.25 ETH that were on the withdraw contract by mistake have been accounted in the total underlying supply and we generated protocol service fee for it.

At Liquid Collective protocol upgrade time (planned for May), we will upgrade Oracle to its "final" version compatible with the new post-withdrawal report format and stop accounting for the balance on the withdraw contract (given we will be able to accurately compute skimmed balance in a more advanced way). If not recovering the 0.25 ETH we will have a drop of rewards.

#### Extra Information

This will require to upgrade the withdraw contract before upgrading River