### PR TITLE
fix: add maxRedeemableEth value to emitted event

### DIFF
--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -308,7 +308,7 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1 {
 
         _setRedeemDemand(RedeemDemand.get() + _lsETHAmount);
 
-        emit RequestedRedeem(_recipient, height, _lsETHAmount, redeemRequestId);
+        emit RequestedRedeem(_recipient, height, _lsETHAmount, maxRedeemableEth, redeemRequestId);
     }
 
     /// @notice Internal structure used to optimize stack usage in _claimRedeemRequest

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -12,8 +12,9 @@ interface IRedeemManagerV1 {
     /// @param owner The owner of the redeem request
     /// @param height The height of the redeem request in LsETH
     /// @param amount The amount of the redeem request in LsETH
+    /// @param maxRedeemableEth The maximum amount of eth that can be redeemed from this request
     /// @param id The id of the new redeem request
-    event RequestedRedeem(address indexed owner, uint256 height, uint256 amount, uint32 id);
+    event RequestedRedeem(address indexed owner, uint256 height, uint256 amount, uint256 maxRedeemableEth, uint32 id);
 
     /// @notice Emitted when a withdrawal event is created
     /// @param height The height of the withdrawal event in LsETH

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -90,7 +90,7 @@ contract RedeemManagerV1Tests is Test {
     address internal allowlistAdmin;
     address internal allowlistAllower;
 
-    event RequestedRedeem(address indexed owner, uint256 height, uint256 size, uint32 id);
+    event RequestedRedeem(address indexed owner, uint256 height, uint256 size, uint256 maxRedeemableEth, uint32 id);
     event ReportedWithdrawal(uint256 height, uint256 size, uint256 ethAmount, uint32 id);
     event SatisfiedRedeemRequest(
         uint32 indexed redeemRequestId,
@@ -151,7 +151,7 @@ contract RedeemManagerV1Tests is Test {
 
         vm.prank(user);
         vm.expectEmit(true, true, true, true);
-        emit RequestedRedeem(user, 0, amount, 0);
+        emit RequestedRedeem(user, 0, amount, amount, 0);
         redeemManager.requestRedeem(amount, user);
 
         uint32[] memory requests = new uint32[](1);
@@ -186,7 +186,7 @@ contract RedeemManagerV1Tests is Test {
 
         vm.prank(user);
         vm.expectEmit(true, true, true, true);
-        emit RequestedRedeem(user, 0, amount, 0);
+        emit RequestedRedeem(user, 0, amount, amount, 0);
         redeemManager.requestRedeem(amount);
 
         uint32[] memory requests = new uint32[](1);


### PR DESCRIPTION
## Description

The `RequestedRedeem` event did not emit the maximum eth that the request can redeem. This PR adds this value to the event/

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [x] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

Indexing should be adapted

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?
