### PR TITLE
chore(docs): fix codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/liquid-collective/liquid-collective-protocol/actions/workflows/Tests.yaml/badge.svg)](https://github.com/liquid-collective/liquid-collective-protocol/actions/workflows/Tests.yaml)
 [![mythril](https://github.com/liquid-collective/liquid-collective-protocol/actions/workflows/Mythril.yaml/badge.svg)](https://github.com/liquid-collective/liquid-collective-protocol/actions/workflows/Mythril.yaml)
 [![lint](https://github.com/liquid-collective/liquid-collective-protocol/actions/workflows/Lint.yaml/badge.svg)](https://github.com/liquid-collective/liquid-collective-protocol/actions/workflows/Lint.yaml)
-[![codecov](https://codecov.io/gh/liquid-collective/liquid-collective-protocol/branch/master/graph/badge.svg?token=RJYWIW2ADS)](https://codecov.io/gh/liquid-collective/liquid-collective-protocol)
+[![codecov](https://codecov.io/gh/liquid-collective/liquid-collective-protocol/branch/main/graph/badge.svg?token=RJYWIW2ADS)](https://codecov.io/gh/liquid-collective/liquid-collective-protocol)
 [![license](https://img.shields.io/badge/license-busl--1.1-blue.svg)](./LICENSE)
 
 This repository contains the Liquid Collective Protocol's smart contracts.


### PR DESCRIPTION
## Description

CodeCov badge is pointing to the `master` stats, but `master` doesn't exist (we use `main`).

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [x] Have you assigned this PR to yourself?
- [x] Have you added at least 1 reviewer?
- [x] Have you updated the official documentation?
- [x] Have you added sufficient documentation in your code?
- [x] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [x] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [x] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->