### PR TITLE
fix(ci): pin mythril docker image

### DIFF
--- a/.github/workflows/Mythril.yaml
+++ b/.github/workflows/Mythril.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Rename output artifact
         run: mv mythril_output.md ${{ matrix.contract.name }}.mythril.md
-        
+
       - name: Upload output artifact
         uses: actions/upload-artifact@v3
         with:

--- a/actions/mythril/action.yml
+++ b/actions/mythril/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'mythril/myth'
+  image: 'mythril/myth:0.23.22'
   entrypoint: './mythril_entrypoint.sh'
   args:
     - 'analyze'


### PR DESCRIPTION
fix PermissionError on github workflow

```
tee: mythril_output.md: Permission denied
Matplotlib created a temporary config/cache directory at /tmp/matplotlib-erm4kfy5 because the default path (/github/home/.config/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.
Error: .interfaces.cli [ERROR]: Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/mythril/interfaces/cli.py", line 953, in parse_args_and_execute
    config = set_config(args)
  File "/usr/local/lib/python3.10/site-packages/mythril/interfaces/cli.py", line 6[75](https://github.com/liquid-collective/liquid-collective-protocol/actions/runs/5121494775/jobs/9837626649#step:3:76), in set_config
    config = MythrilConfig()
  File "/usr/local/lib/python3.10/site-packages/mythril/mythril/mythril_config.py", line 26, in __init__
    self.mythril_dir = self.init_mythril_dir()
  File "/usr/local/lib/python3.10/site-packages/mythril/mythril/mythril_config.py", line 49, in init_mythril_dir
    os.mkdir(mythril_dir)
PermissionError: [Errno 13] Permission denied: '/github/home/.mythril'
```

PS: we should open an issue on https://github.com/ConsenSys/mythril (similar to https://github.com/ConsenSys/mythril/issues/1070)