### PR TITLE
Added blacklist check for `recipient` during `redeemRequest`

### DIFF
--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -132,6 +132,10 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1 {
         onlyRedeemerOrRiver
         returns (uint32 redeemRequestId)
     {
+        IRiverV1 river = _castedRiver();
+        if (IAllowlistV1(river.getAllowlist()).isDenied(_recipient)) {
+            revert RecipientIsDenied();
+        }
         return _requestRedeem(_lsETHAmount, _recipient);
     }
 

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -101,6 +101,9 @@ interface IRedeemManagerV1 {
     /// @notice Thrown when the claim owner is denied
     error ClaimOwnerIsDenied();
 
+    /// @notice Thrown when the recipient of redeemRequest is denied
+    error RecipientIsDenied();
+
     /// @param _river The address of the River contract
     function initializeRedeemManagerV1(address _river) external;
 


### PR DESCRIPTION
## Description

Added a check to ensure that black listed address can't be added as a recipient for redemption request

## Notice

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [x] Have you assigned this PR to yourself?
- [x] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [x] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [x] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Testing

- [x] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?