### PR TITLE
Added version view function

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-de33b6af53005037b463318d2628b5cfcaf39916
 
       - name: Run coverage
         run: forge coverage --report lcov && mv lcov.info lcov.txt

--- a/.github/workflows/HeavyTests.yaml
+++ b/.github/workflows/HeavyTests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: install foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-de33b6af53005037b463318d2628b5cfcaf39916
 
       - name: run tests
         run: forge test --force -vvv --gas-report --match-contract HEAVY_FUZZING

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-de33b6af53005037b463318d2628b5cfcaf39916
 
       - name: Run tests
         run: make test

--- a/.github/workflows/foundry-gas-diff.yml
+++ b/.github/workflows/foundry-gas-diff.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-de33b6af53005037b463318d2628b5cfcaf39916
 
       # Add any step generating a gas report to a temporary file named gasreport.ansi. For example:
       - name: Run tests

--- a/contracts/src/Allowlist.1.sol
+++ b/contracts/src/Allowlist.1.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.20;
 
 import "./interfaces/IAllowlist.1.sol";
+import "./interfaces/IVersion.sol";
 
 import "./libraries/LibAllowlistMasks.sol";
 import "./Initializable.sol";
@@ -18,7 +19,7 @@ import "./state/allowlist/Allowlist.sol";
 /// @notice each bit represents a right in the system. The DENY_MASK defined the mask
 /// @notice used to identify if the denied bit is on, preventing users from interacting
 /// @notice with the system
-contract AllowlistV1 is IAllowlistV1, Initializable, Administrable {
+contract AllowlistV1 is IAllowlistV1, IVersionV1, Initializable, Administrable {
     /// @inheritdoc IAllowlistV1
     function initAllowlistV1(address _admin, address _allower) external init(0) {
         _setAdmin(_admin);
@@ -157,5 +158,10 @@ contract AllowlistV1 is IAllowlistV1, Initializable, Administrable {
         }
 
         emit SetAllowlistPermissions(_accounts, _permissions);
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/Allowlist.1.sol
+++ b/contracts/src/Allowlist.1.sol
@@ -162,6 +162,6 @@ contract AllowlistV1 is IAllowlistV1, IVersionV1, Initializable, Administrable {
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/CoverageFund.1.sol
+++ b/contracts/src/CoverageFund.1.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.20;
 import "./interfaces/IRiver.1.sol";
 import "./interfaces/IAllowlist.1.sol";
 import "./interfaces/ICoverageFund.1.sol";
+import "./interfaces/IVersion.sol";
 
 import "./libraries/LibUint256.sol";
 import "./libraries/LibAllowlistMasks.sol";
@@ -28,7 +29,7 @@ import "./state/slashingCoverage/BalanceForCoverage.sol";
 /// @notice the coverage fund will be pulled after the revenue stream, and there won't be any commission on the eth pulled.
 /// @notice Once a Slashing event occurs, the team will do its best to inject the recovery funds in at maximum 365 days
 /// @notice The entities allowed to donate are selected by the team. It will mainly be treasury entities or insurance protocols able to fill this coverage fund properly.
-contract CoverageFundV1 is Initializable, ICoverageFundV1 {
+contract CoverageFundV1 is Initializable, ICoverageFundV1, IVersionV1 {
     /// @inheritdoc ICoverageFundV1
     function initCoverageFundV1(address _riverAddress) external init(0) {
         RiverAddress.set(_riverAddress);
@@ -70,5 +71,10 @@ contract CoverageFundV1 is Initializable, ICoverageFundV1 {
     /// @inheritdoc ICoverageFundV1
     fallback() external payable {
         revert InvalidCall();
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/CoverageFund.1.sol
+++ b/contracts/src/CoverageFund.1.sol
@@ -75,6 +75,6 @@ contract CoverageFundV1 is Initializable, ICoverageFundV1, IVersionV1 {
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/ELFeeRecipient.1.sol
+++ b/contracts/src/ELFeeRecipient.1.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import "./interfaces/IRiver.1.sol";
 import "./interfaces/IELFeeRecipient.1.sol";
+import "./interfaces/IVersion.sol";
 
 import "./libraries/LibUint256.sol";
 
@@ -13,7 +14,7 @@ import "./state/shared/RiverAddress.sol";
 /// @title Execution Layer Fee Recipient (v1)
 /// @author Kiln
 /// @notice This contract receives all the execution layer fees from the proposed blocks + bribes
-contract ELFeeRecipientV1 is Initializable, IELFeeRecipientV1 {
+contract ELFeeRecipientV1 is Initializable, IELFeeRecipientV1, IVersionV1 {
     /// @inheritdoc IELFeeRecipientV1
     function initELFeeRecipientV1(address _riverAddress) external init(0) {
         RiverAddress.set(_riverAddress);
@@ -41,5 +42,10 @@ contract ELFeeRecipientV1 is Initializable, IELFeeRecipientV1 {
     /// @inheritdoc IELFeeRecipientV1
     fallback() external payable {
         revert InvalidCall();
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/ELFeeRecipient.1.sol
+++ b/contracts/src/ELFeeRecipient.1.sol
@@ -46,6 +46,6 @@ contract ELFeeRecipientV1 is Initializable, IELFeeRecipientV1, IVersionV1 {
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/Firewall.sol
+++ b/contracts/src/Firewall.sol
@@ -119,6 +119,6 @@ contract Firewall is IFirewall, IVersionV1, Administrable {
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/Firewall.sol
+++ b/contracts/src/Firewall.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.20;
 
 import "./interfaces/IFirewall.sol";
+import "./interfaces/IVersion.sol";
 
 import "./Administrable.sol";
 
@@ -14,7 +15,7 @@ import "./Administrable.sol";
 ///         Random callers cannot call anything through this contract, even if the underlying function
 ///         is unpermissioned in the underlying contract.
 ///         Calls to non-admin functions should be called at the underlying contract directly.
-contract Firewall is IFirewall, Administrable {
+contract Firewall is IFirewall, IVersionV1, Administrable {
     /// @inheritdoc IFirewall
     address public executor;
 
@@ -114,5 +115,10 @@ contract Firewall is IFirewall, Administrable {
     function _fallback() internal virtual {
         _checkCallerRole();
         _forward(destination, msg.value);
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import "./interfaces/IOperatorRegistry.1.sol";
 import "./interfaces/IRiver.1.sol";
+import "./interfaces/IVersion.sol";
 
 import "./libraries/LibUint256.sol";
 
@@ -22,7 +23,7 @@ import "./state/migration/OperatorsRegistry_FundedKeyEventRebroadcasting_Operato
 /// @title Operators Registry (v1)
 /// @author Kiln
 /// @notice This contract handles the list of operators and their keys
-contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrable {
+contract OperatorsRegistryV1 is IOperatorsRegistryV1, IVersionV1, Initializable, Administrable {
     /// @notice Maximum validators given to an operator per selection loop round
     uint256 internal constant MAX_VALIDATOR_ATTRIBUTION_PER_ROUND = 5;
 
@@ -896,5 +897,10 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
     function _setTotalValidatorExitsRequested(uint256 _currentValue, uint256 _newValue) internal {
         TotalValidatorExitsRequested.set(_newValue);
         emit SetTotalValidatorExitsRequested(_currentValue, _newValue);
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -901,6 +901,6 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, IVersionV1, Initializable,
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/Oracle.1.sol
+++ b/contracts/src/Oracle.1.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import "./interfaces/IRiver.1.sol";
 import "./interfaces/IOracle.1.sol";
+import "./interfaces/IVersion.sol";
 
 import "./Administrable.sol";
 import "./Initializable.sol";
@@ -17,7 +18,7 @@ import "./state/oracle/ReportsPositions.sol";
 /// @title Oracle (v1)
 /// @author Kiln
 /// @notice This contract handles the input from the allowed oracle members. Highly inspired by Lido's implementation.
-contract OracleV1 is IOracleV1, Initializable, Administrable {
+contract OracleV1 is IOracleV1, IVersionV1, Initializable, Administrable {
     modifier onlyAdminOrMember(address _oracleMember) {
         if (msg.sender != _getAdmin() && msg.sender != _oracleMember) {
             revert LibErrors.Unauthorized(msg.sender);
@@ -279,5 +280,10 @@ contract OracleV1 is IOracleV1, Initializable, Administrable {
     /// @return The casted River interface
     function _river() internal view returns (IRiverV1) {
         return IRiverV1(payable(RiverAddress.get()));
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/Oracle.1.sol
+++ b/contracts/src/Oracle.1.sol
@@ -284,6 +284,6 @@ contract OracleV1 is IOracleV1, IVersionV1, Initializable, Administrable {
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -552,6 +552,6 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1, IVersionV1 {
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.20;
 import "./interfaces/IAllowlist.1.sol";
 import "./interfaces/IRiver.1.sol";
 import "./interfaces/IRedeemManager.1.sol";
+import "./interfaces/IVersion.sol";
 import "./libraries/LibAllowlistMasks.sol";
 import "./libraries/LibUint256.sol";
 import "./Initializable.sol";
@@ -17,7 +18,7 @@ import "./state/redeemManager/RedeemDemand.sol";
 /// @title Redeem Manager (v1)
 /// @author Kiln
 /// @notice This contract handles the redeem requests of all users
-contract RedeemManagerV1 is Initializable, IRedeemManagerV1 {
+contract RedeemManagerV1 is Initializable, IRedeemManagerV1, IVersionV1 {
     /// @notice Value returned when resolving a redeem request that is unsatisfied
     int64 internal constant RESOLVE_UNSATISFIED = -1;
     /// @notice Value returned when resolving a redeem request that is out of bounds
@@ -547,5 +548,10 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1 {
     function _setRedeemDemand(uint256 _newValue) internal {
         emit SetRedeemDemand(RedeemDemand.get(), _newValue);
         RedeemDemand.set(_newValue);
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -614,6 +614,6 @@ contract RiverV1 is
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -7,6 +7,7 @@ import "./interfaces/IRiver.1.sol";
 import "./interfaces/IWithdraw.1.sol";
 import "./interfaces/IELFeeRecipient.1.sol";
 import "./interfaces/ICoverageFund.1.sol";
+import "./interfaces/IVersion.sol";
 
 import "./components/ConsensusLayerDepositManager.1.sol";
 import "./components/UserDepositManager.1.sol";
@@ -38,7 +39,8 @@ contract RiverV1 is
     OracleManagerV1,
     Initializable,
     Administrable,
-    IRiverV1
+    IRiverV1,
+    IVersionV1
 {
     /// @inheritdoc IRiverV1
     function initRiverV1(
@@ -608,5 +610,10 @@ contract RiverV1 is
             _setCommittedBalance(CommittedBalance.get() + currentMaxCommittableAmount);
             _setBalanceToDeposit(currentBalanceToDeposit - currentMaxCommittableAmount);
         }
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/Withdraw.1.sol
+++ b/contracts/src/Withdraw.1.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.20;
 import "./Initializable.sol";
 import "./interfaces/IRiver.1.sol";
 import "./interfaces/IWithdraw.1.sol";
+import "./interfaces/IVersion.sol";
 import "./libraries/LibErrors.sol";
 import "./libraries/LibUint256.sol";
 
@@ -12,7 +13,7 @@ import "./state/shared/RiverAddress.sol";
 /// @title Withdraw (v1)
 /// @author Kiln
 /// @notice This contract is in charge of holding the exit and skimming funds and allow river to pull these funds
-contract WithdrawV1 is IWithdrawV1, Initializable {
+contract WithdrawV1 is IWithdrawV1, Initializable, IVersionV1 {
     modifier onlyRiver() {
         if (msg.sender != RiverAddress.get()) {
             revert LibErrors.Unauthorized(msg.sender);
@@ -50,5 +51,10 @@ contract WithdrawV1 is IWithdrawV1, Initializable {
     function _setRiver(address _river) internal {
         RiverAddress.set(_river);
         emit SetRiver(_river);
+    }
+
+    /// @inheritdoc IVersionV1
+    function version() external pure returns (string memory) {
+        return "1.0.0";
     }
 }

--- a/contracts/src/Withdraw.1.sol
+++ b/contracts/src/Withdraw.1.sol
@@ -55,6 +55,6 @@ contract WithdrawV1 is IWithdrawV1, Initializable, IVersionV1 {
 
     /// @inheritdoc IVersionV1
     function version() external pure returns (string memory) {
-        return "1.0.0";
+        return "1.1.0";
     }
 }

--- a/contracts/src/interfaces/IVersion.sol
+++ b/contracts/src/interfaces/IVersion.sol
@@ -1,0 +1,8 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.20;
+
+interface IVersionV1 {
+    /// @notice Retrieves the version of the contract
+    /// @return Version of the contract
+    function version() external pure returns (string memory);
+}

--- a/contracts/test/Allowlist.1.t.sol
+++ b/contracts/test/Allowlist.1.t.sol
@@ -397,6 +397,6 @@ contract AllowlistV1Tests is AllowlistV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(allowlist.version(), "1.0.0");
+        assertEq(allowlist.version(), "1.1.0");
     }
 }

--- a/contracts/test/Allowlist.1.t.sol
+++ b/contracts/test/Allowlist.1.t.sol
@@ -395,4 +395,8 @@ contract AllowlistV1Tests is AllowlistV1TestBase {
         vm.expectRevert(abi.encodeWithSignature("InvalidCount()"));
         allowlist.setAllowPermissions(allowees, permissions);
     }
+
+    function testVersion() external {
+        assertEq(allowlist.version(), "1.0.0");
+    }
 }

--- a/contracts/test/CoverageFund.1.t.sol
+++ b/contracts/test/CoverageFund.1.t.sol
@@ -223,4 +223,8 @@ contract CoverageFundTestV1 is CoverageFundV1TestBase {
         river.pullCoverageFunds(address(coverageFund), 0);
         assertEq(0, address(river).balance);
     }
+
+    function testVersion() external {
+        assertEq(coverageFund.version(), "1.0.0");
+    }
 }

--- a/contracts/test/CoverageFund.1.t.sol
+++ b/contracts/test/CoverageFund.1.t.sol
@@ -225,6 +225,6 @@ contract CoverageFundTestV1 is CoverageFundV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(coverageFund.version(), "1.0.0");
+        assertEq(coverageFund.version(), "1.1.0");
     }
 }

--- a/contracts/test/ELFeeRecipient.1.t.sol
+++ b/contracts/test/ELFeeRecipient.1.t.sol
@@ -146,6 +146,6 @@ contract ELFeeRecipientV1Test is ELFeeRecipientV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(feeRecipient.version(), "1.0.0");
+        assertEq(feeRecipient.version(), "1.1.0");
     }
 }

--- a/contracts/test/ELFeeRecipient.1.t.sol
+++ b/contracts/test/ELFeeRecipient.1.t.sol
@@ -144,4 +144,8 @@ contract ELFeeRecipientV1Test is ELFeeRecipientV1TestBase {
         address(feeRecipient).call{value: 1e18}(abi.encodeWithSignature("Hello()"));
         vm.stopPrank();
     }
+
+    function testVersion() external {
+        assertEq(feeRecipient.version(), "1.0.0");
+    }
 }

--- a/contracts/test/Firewall.t.sol
+++ b/contracts/test/Firewall.t.sol
@@ -503,4 +503,8 @@ contract FirewallTests is BytesGenerator, Test {
         riverFirewall.setExecutor(don);
         vm.stopPrank();
     }
+
+    function testVersion() external {
+        assertEq(riverFirewall.version(), "1.0.0");
+    }
 }

--- a/contracts/test/Firewall.t.sol
+++ b/contracts/test/Firewall.t.sol
@@ -505,6 +505,6 @@ contract FirewallTests is BytesGenerator, Test {
     }
 
     function testVersion() external {
-        assertEq(riverFirewall.version(), "1.0.0");
+        assertEq(riverFirewall.version(), "1.1.0");
     }
 }

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -3078,6 +3078,6 @@ contract OperatorsRegistryV1TestDistribution is Test {
     }
 
     function testVersion() external {
-        assertEq(operatorsRegistry.version(), "1.0.0");
+        assertEq(operatorsRegistry.version(), "1.1.0");
     }
 }

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -3076,4 +3076,8 @@ contract OperatorsRegistryV1TestDistribution is Test {
         assert(publicKeys.length == 0);
         assert(signatures.length == 0);
     }
+
+    function testVersion() external {
+        assertEq(operatorsRegistry.version(), "1.0.0");
+    }
 }

--- a/contracts/test/Oracle.1.t.sol
+++ b/contracts/test/Oracle.1.t.sol
@@ -742,4 +742,8 @@ contract OracleV1Tests is OracleV1TestBase {
     function testGetReportVariantCount() external {
         assertEq(0, oracle.getReportVariantsCount());
     }
+
+    function testVersion() external {
+        assertEq(oracle.version(), "1.0.0");
+    }
 }

--- a/contracts/test/Oracle.1.t.sol
+++ b/contracts/test/Oracle.1.t.sol
@@ -744,6 +744,6 @@ contract OracleV1Tests is OracleV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(oracle.version(), "1.0.0");
+        assertEq(oracle.version(), "1.1.0");
     }
 }

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -1724,6 +1724,6 @@ contract RedeemManagerV1Tests is Test {
     }
 
     function testVersion() external {
-        assertEq(redeemManager.version(), "1.0.0");
+        assertEq(redeemManager.version(), "1.1.0");
     }
 }

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -1722,4 +1722,8 @@ contract RedeemManagerV1Tests is Test {
         vm.prank(user2);
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
     }
+
+    function testVersion() external {
+        assertEq(redeemManager.version(), "1.0.0");
+    }
 }

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -199,6 +199,10 @@ contract RiverV1Tests is RiverV1TestBase {
         vm.stopPrank();
     }
 
+    function testVersion() external {
+        assertEq(river.version(), "1.0.0");
+    }
+
     function testOnlyAdminCanSetKeeper() public {
         address keeper = makeAddr("keeper");
         assert(river.getKeeper() == admin);

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -200,7 +200,7 @@ contract RiverV1Tests is RiverV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(river.version(), "1.0.0");
+        assertEq(river.version(), "1.1.0");
     }
 
     function testOnlyAdminCanSetKeeper() public {

--- a/contracts/test/Withdraw.1.t.sol
+++ b/contracts/test/Withdraw.1.t.sol
@@ -164,4 +164,8 @@ contract WithdrawV1Tests is WithdrawV1TestBase {
         river.debug_pullFunds(address(withdraw), 0);
         assertEq(0, address(river).balance);
     }
+
+    function testVersion() external {
+        assertEq(withdraw.version(), "1.0.0");
+    }
 }

--- a/contracts/test/Withdraw.1.t.sol
+++ b/contracts/test/Withdraw.1.t.sol
@@ -166,6 +166,6 @@ contract WithdrawV1Tests is WithdrawV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(withdraw.version(), "1.0.0");
+        assertEq(withdraw.version(), "1.1.0");
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,3 +4,6 @@ optimizer_runs = 100
 
 [rpc_endpoints]
 mainnet = "${MAINNET_FORK_RPC_URL}"
+
+[fuzz]
+runs = 1500


### PR DESCRIPTION
## Description

Currently there is no way to understand which version of the contract is deployed. We introduce a new interface `IVersionV1` which is implemented by all the major contracts. The interface exposes a method which returns the hard coded version of the contract.

## Notice

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [x] Have you assigned this PR to yourself?
- [x] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [x] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [x] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Testing

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?