### PR TITLE
Update function name on `ConsensusLayerDepositManager`

### DIFF
--- a/contracts/src/components/ConsensusLayerDepositManager.1.sol
+++ b/contracts/src/components/ConsensusLayerDepositManager.1.sol
@@ -88,7 +88,7 @@ abstract contract ConsensusLayerDepositManagerV1 is IConsensusLayerDepositManage
     }
 
     /// @inheritdoc IConsensusLayerDepositManagerV1
-    function depositToConsensusLayer(uint256 _maxCount, bytes32 _depositRoot) external {
+    function depositToConsensusLayerWithDepositRoot(uint256 _maxCount, bytes32 _depositRoot) external {
         if (msg.sender != KeeperAddress.get()) {
             revert OnlyKeeper();
         }

--- a/contracts/src/interfaces/components/IConsensusLayerDepositManager.1.sol
+++ b/contracts/src/interfaces/components/IConsensusLayerDepositManager.1.sol
@@ -71,5 +71,5 @@ interface IConsensusLayerDepositManagerV1 {
     /// @notice Deposits current balance to the Consensus Layer by batches of 32 ETH
     /// @param _maxCount The maximum amount of validator keys to fund
     /// @param _depositRoot The root of the deposit tree
-    function depositToConsensusLayer(uint256 _maxCount, bytes32 _depositRoot) external;
+    function depositToConsensusLayerWithDepositRoot(uint256 _maxCount, bytes32 _depositRoot) external;
 }

--- a/contracts/test/Firewall.t.sol
+++ b/contracts/test/Firewall.t.sol
@@ -101,7 +101,7 @@ contract FirewallTests is BytesGenerator, Test {
 
         bytes32 withdrawalCredentials = withdraw.getCredentials();
         bytes4[] memory executorCallableRiverSelectors = new bytes4[](2);
-        executorCallableRiverSelectors[0] = river.depositToConsensusLayer.selector;
+        executorCallableRiverSelectors[0] = river.depositToConsensusLayerWithDepositRoot.selector;
         executorCallableRiverSelectors[1] = river.setOracle.selector;
         riverFirewall = new Firewall(riverGovernorDAO, executor, address(river), executorCallableRiverSelectors);
         firewalledRiver = RiverV1(payable(address(riverFirewall)));
@@ -282,26 +282,26 @@ contract FirewallTests is BytesGenerator, Test {
         vm.stopPrank();
     }
 
-    function testGovernorCannotDepositToConsensusLayer() public {
+    function testGovernorCannotdepositToConsensusLayerWithDepositRoot() public {
         // Assert this by expecting NotEnoughFunds, NOT Unauthorized
         vm.startPrank(riverGovernorDAO);
         vm.expectRevert(abi.encodeWithSignature("NotEnoughFunds()"));
-        firewalledRiver.depositToConsensusLayer(10, bytes32(0));
+        firewalledRiver.depositToConsensusLayerWithDepositRoot(10, bytes32(0));
         vm.stopPrank();
     }
 
-    function testExecutorCannotDepositToConsensusLayer() public {
+    function testExecutorCannotdepositToConsensusLayerWithDepositRoot() public {
         // Assert this by expecting NotEnoughFunds, NOT Unauthorized
         vm.startPrank(executor);
         vm.expectRevert(abi.encodeWithSignature("NotEnoughFunds()"));
-        firewalledRiver.depositToConsensusLayer(10, bytes32(0));
+        firewalledRiver.depositToConsensusLayerWithDepositRoot(10, bytes32(0));
         vm.stopPrank();
     }
 
-    function testRandomCallerCannotDepositToConsensusLayer() public {
+    function testRandomCallerCannotdepositToConsensusLayerWithDepositRoot() public {
         vm.startPrank(joe);
         vm.expectRevert(unauthJoe);
-        firewalledRiver.depositToConsensusLayer(10, bytes32(0));
+        firewalledRiver.depositToConsensusLayerWithDepositRoot(10, bytes32(0));
         vm.stopPrank();
     }
 

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -556,9 +556,9 @@ contract RiverV1Tests is RiverV1TestBase {
         river.debug_moveDepositToCommitted();
 
         vm.prank(admin);
-        river.depositToConsensusLayer(17, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(17, bytes32(0));
         vm.prank(admin);
-        river.depositToConsensusLayer(17, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(17, bytes32(0));
 
         OperatorsV2.Operator memory op1 = operatorsRegistry.getOperator(operatorOneIndex);
         OperatorsV2.Operator memory op2 = operatorsRegistry.getOperator(operatorTwoIndex);
@@ -595,9 +595,9 @@ contract RiverV1Tests is RiverV1TestBase {
         river.debug_moveDepositToCommitted();
 
         vm.prank(admin);
-        river.depositToConsensusLayer(17, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(17, bytes32(0));
         vm.prank(admin);
-        river.depositToConsensusLayer(17, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(17, bytes32(0));
 
         OperatorsV2.Operator memory op1 = operatorsRegistry.getOperator(operatorOneIndex);
         OperatorsV2.Operator memory op2 = operatorsRegistry.getOperator(operatorTwoIndex);
@@ -691,9 +691,9 @@ contract RiverV1Tests is RiverV1TestBase {
         river.debug_moveDepositToCommitted();
 
         vm.prank(admin);
-        river.depositToConsensusLayer(17, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(17, bytes32(0));
         vm.prank(admin);
-        river.depositToConsensusLayer(17, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(17, bytes32(0));
 
         OperatorsV2.Operator memory op1 = operatorsRegistry.getOperator(operatorOneIndex);
         OperatorsV2.Operator memory op2 = operatorsRegistry.getOperator(operatorTwoIndex);
@@ -738,11 +738,11 @@ contract RiverV1Tests is RiverV1TestBase {
         river.debug_moveDepositToCommitted();
 
         vm.prank(admin);
-        river.depositToConsensusLayer(1, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(1, bytes32(0));
         vm.prank(admin);
-        river.depositToConsensusLayer(2, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(2, bytes32(0));
         vm.prank(admin);
-        river.depositToConsensusLayer(31, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(31, bytes32(0));
 
         OperatorsV2.Operator memory op1 = operatorsRegistry.getOperator(operatorOneIndex);
         OperatorsV2.Operator memory op2 = operatorsRegistry.getOperator(operatorTwoIndex);
@@ -779,14 +779,14 @@ contract RiverV1Tests is RiverV1TestBase {
         river.debug_moveDepositToCommitted();
 
         vm.prank(admin);
-        river.depositToConsensusLayer(20, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(20, bytes32(0));
         uint32[] memory stoppedCounts = new uint32[](3);
         stoppedCounts[0] = 10;
         stoppedCounts[1] = 10;
         stoppedCounts[2] = 0;
         operatorsRegistry.sudoStoppedValidatorCounts(stoppedCounts, 20);
         vm.prank(admin);
-        river.depositToConsensusLayer(10, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(10, bytes32(0));
 
         OperatorsV2.Operator memory op1 = operatorsRegistry.getOperator(operatorOneIndex);
         OperatorsV2.Operator memory op2 = operatorsRegistry.getOperator(operatorTwoIndex);
@@ -965,7 +965,7 @@ contract RiverV1TestsReport_HEAVY_FUZZING is RiverV1TestBase {
         }
 
         vm.prank(admin);
-        river.depositToConsensusLayer(depositCount, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(depositCount, bytes32(0));
 
         _newSalt = _salt;
     }
@@ -1760,7 +1760,7 @@ contract RiverV1TestsReport_HEAVY_FUZZING is RiverV1TestBase {
         river.debug_moveDepositToCommitted();
 
         vm.prank(admin);
-        river.depositToConsensusLayer(count, bytes32(0));
+        river.depositToConsensusLayerWithDepositRoot(count, bytes32(0));
 
         return _salt;
     }

--- a/contracts/test/components/ConsensusLayerDepositManager.1.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManager.1.t.sol
@@ -118,7 +118,7 @@ contract ConsensusLayerDepositManagerV1Tests is Test {
         ConsensusLayerDepositManagerV1ExposeInitializer(address(depositManager)).sudoSyncBalance();
         vm.expectRevert(abi.encodeWithSignature("NotEnoughFunds()"));
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(5, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(5, bytes32(0));
     }
 
     function testDepositTenValidators() public {
@@ -126,7 +126,7 @@ contract ConsensusLayerDepositManagerV1Tests is Test {
         ConsensusLayerDepositManagerV1ExposeInitializer(address(depositManager)).sudoSyncBalance();
         assert(address(depositManager).balance == 320 ether);
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(10, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(10, bytes32(0));
         assert(address(depositManager).balance == 0);
     }
 
@@ -135,7 +135,7 @@ contract ConsensusLayerDepositManagerV1Tests is Test {
         ConsensusLayerDepositManagerV1ExposeInitializer(address(depositManager)).sudoSyncBalance();
         assert(address(depositManager).balance == 640 ether);
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(20, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(20, bytes32(0));
         assert(address(depositManager).balance == 320 ether);
     }
 }
@@ -261,7 +261,7 @@ contract ConsensusLayerDepositManagerV1ErrorTests is Test {
         ConsensusLayerDepositManagerV1ControllableValidatorKeyRequest(address(depositManager)).setScenario(1);
         vm.expectRevert(abi.encodeWithSignature("InconsistentPublicKeys()"));
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(5, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(5, bytes32(0));
     }
 
     function testInconsistentSignature() public {
@@ -270,7 +270,7 @@ contract ConsensusLayerDepositManagerV1ErrorTests is Test {
         ConsensusLayerDepositManagerV1ControllableValidatorKeyRequest(address(depositManager)).setScenario(2);
         vm.expectRevert(abi.encodeWithSignature("InconsistentSignatures()"));
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(5, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(5, bytes32(0));
     }
 
     function testUnavailableKeys() public {
@@ -279,7 +279,7 @@ contract ConsensusLayerDepositManagerV1ErrorTests is Test {
         ConsensusLayerDepositManagerV1ControllableValidatorKeyRequest(address(depositManager)).setScenario(3);
         vm.expectRevert(abi.encodeWithSignature("NoAvailableValidatorKeys()"));
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(5, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(5, bytes32(0));
     }
 
     function testInvalidPublicKeyCount() public {
@@ -288,7 +288,7 @@ contract ConsensusLayerDepositManagerV1ErrorTests is Test {
         ConsensusLayerDepositManagerV1ControllableValidatorKeyRequest(address(depositManager)).setScenario(4);
         vm.expectRevert(abi.encodeWithSignature("InvalidPublicKeyCount()"));
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(5, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(5, bytes32(0));
     }
 }
 
@@ -317,7 +317,7 @@ contract ConsensusLayerDepositManagerV1WithdrawalCredentialError is Test {
         ConsensusLayerDepositManagerV1ControllableValidatorKeyRequest(address(depositManager)).setKeeper(address(0x1));
         vm.expectRevert(abi.encodeWithSignature("InvalidWithdrawalCredentials()"));
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(5, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(5, bytes32(0));
         ConsensusLayerDepositManagerV1ExposeInitializer(address(depositManager)).sudoSetWithdrawalCredentials(
             withdrawalCredentials
         );
@@ -407,7 +407,7 @@ contract ConsensusLayerDepositManagerV1ValidKeysTest is Test {
             bytes32(uint256(uint160(address(0x1))))
         );
         vm.startPrank(address(0x1));
-        depositManager.depositToConsensusLayer(1, depositContract.get_deposit_root());
+        depositManager.depositToConsensusLayerWithDepositRoot(1, depositContract.get_deposit_root());
         assert(DepositContractEnhancedMock(address(depositContract)).debug_getLastDepositDataRoot() == depositDataRoot);
     }
 
@@ -419,7 +419,7 @@ contract ConsensusLayerDepositManagerV1ValidKeysTest is Test {
         );
         vm.startPrank(address(0x1));
         vm.expectRevert(abi.encodeWithSignature("InvalidDepositRoot()"));
-        depositManager.depositToConsensusLayer(1, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(1, bytes32(0));
     }
 }
 
@@ -444,7 +444,7 @@ contract ConsensusLayerDepositManagerV1InvalidDepositContract is Test {
         ConsensusLayerDepositManagerV1ValidKeys(address(depositManager)).sudoSyncBalance();
         vm.expectRevert(abi.encodeWithSignature("ErrorOnDeposit()"));
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(1, bytes32(0));
+        depositManager.depositToConsensusLayerWithDepositRoot(1, bytes32(0));
     }
 }
 
@@ -479,7 +479,7 @@ contract ConsensusLayerDepositManagerV1KeeperTest is Test {
             bytes32(uint256(uint160(address(0x1))))
         );
         vm.startPrank(address(0x1));
-        depositManager.depositToConsensusLayer(1, depositContract.get_deposit_root());
+        depositManager.depositToConsensusLayerWithDepositRoot(1, depositContract.get_deposit_root());
         assert(DepositContractEnhancedMock(address(depositContract)).debug_getLastDepositDataRoot() == depositDataRoot);
     }
 
@@ -494,6 +494,6 @@ contract ConsensusLayerDepositManagerV1KeeperTest is Test {
         bytes32 depositRoot = depositContract.get_deposit_root();
         vm.expectRevert(abi.encodeWithSignature("OnlyKeeper()"));
         vm.prank(address(0x1));
-        depositManager.depositToConsensusLayer(1, depositRoot);
+        depositManager.depositToConsensusLayerWithDepositRoot(1, depositRoot);
     }
 }

--- a/deploy/devHolesky/07_deployment_check.ts
+++ b/deploy/devHolesky/07_deployment_check.ts
@@ -694,11 +694,11 @@ const func: DeployFunction = async function ({
   } else {
     console.log("Executor should not have permission to call setConsensusLayerData");
   }
-  // River Executor should not have permission to call legacy depositToConsensusLayer = $(cast call ${RIVER_FIREWALL} "executorCanCall(bytes4)(bool)" $(cast sig "depositToConsensusLayer(uint256)"))"
-  if (await RiverFirewallContract.callStatic.executorCanCall(RiverContract.interface.getSighash("depositToConsensusLayer(uint256)"))) {
-    throw new Error("Executor have permission to call depositToConsensusLayer");
+  // River Executor should not have permission to call legacy depositToConsensusLayerWithDepositRoot = $(cast call ${RIVER_FIREWALL} "executorCanCall(bytes4)(bool)" $(cast sig "depositToConsensusLayerWithDepositRoot(uint256)"))"
+  if (await RiverFirewallContract.callStatic.executorCanCall(RiverContract.interface.getSighash("depositToConsensusLayerWithDepositRoot(uint256)"))) {
+    throw new Error("Executor have permission to call depositToConsensusLayerWithDepositRoot");
   } else {
-    console.log("Executor should not have permission to call depositToConsensusLayer");
+    console.log("Executor should not have permission to call depositToConsensusLayerWithDepositRoot");
   }
 
   //TODO: Also add tests for checking correct initialization of the contracts

--- a/deploy/mainnet/03_deploy_river_oracle_and_operators_registry.ts
+++ b/deploy/mainnet/03_deploy_river_oracle_and_operators_registry.ts
@@ -85,7 +85,7 @@ const func: DeployFunction = async function ({
     contract: "Firewall",
     from: deployer,
     log: true,
-    args: [governor, executor, futureRiverAddress, [riverInterface.getSighash("depositToConsensusLayer")]],
+    args: [governor, executor, futureRiverAddress, [riverInterface.getSighash("depositToConsensusLayerWithDepositRoot")]],
   });
 
   const allowlistDeployment = await deployments.get("Allowlist");


### PR DESCRIPTION
## Description

The function `depositToConsensusLayer` on `ConsensusLayerDepositManager`'s  was modified to include the deposit root to mitigate the frontrun bug. This lead to change in the function signature. This change prevents backward compatibility in our backend.
To provide backward compatibility we decided to rename the function to `depositToConsensusLayerWithDepositRoot` 

## Notice

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [x] Have you assigned this PR to yourself?
- [x] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [x] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Testing

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?
