### PR TITLE
Update redeemManager to revert claim if initiator is denied [ETH-2118]

### DIFF
--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -316,6 +316,7 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1, ProtocolVersion {
                 height: height,
                 amount: _lsETHAmount,
                 owner: _recipient,
+                initiator: msg.sender,
                 maxRedeemableEth: maxRedeemableEth
             })
         );
@@ -493,6 +494,9 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1, ProtocolVersion {
 
             if (allowList.isDenied(params.redeemRequest.owner)) {
                 revert ClaimOwnerIsDenied();
+            }
+            if (allowList.isDenied(params.redeemRequest.initiator)) {
+                revert ClaimInitiatorIsDenied();
             }
 
             // we check that the redeem request is not already claimed

--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -315,7 +315,7 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1, ProtocolVersion {
             RedeemQueue.RedeemRequest({
                 height: height,
                 amount: _lsETHAmount,
-                owner: _recipient,
+                recipient: _recipient,
                 initiator: msg.sender,
                 maxRedeemableEth: maxRedeemableEth
             })
@@ -492,8 +492,8 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1, ProtocolVersion {
             // we load the redeem request in memory
             params.redeemRequest = redeemRequests[_redeemRequestIds[idx]];
 
-            if (allowList.isDenied(params.redeemRequest.owner)) {
-                revert ClaimOwnerIsDenied();
+            if (allowList.isDenied(params.redeemRequest.recipient)) {
+                revert ClaimRecipientIsDenied();
             }
             if (allowList.isDenied(params.redeemRequest.initiator)) {
                 revert ClaimInitiatorIsDenied();
@@ -528,14 +528,14 @@ contract RedeemManagerV1 is Initializable, IRedeemManagerV1, ProtocolVersion {
             claimStatuses[idx] = params.redeemRequest.amount == 0 ? CLAIM_FULLY_CLAIMED : CLAIM_PARTIALLY_CLAIMED;
 
             {
-                (bool success, bytes memory rdata) = params.redeemRequest.owner.call{value: params.ethAmount}("");
+                (bool success, bytes memory rdata) = params.redeemRequest.recipient.call{value: params.ethAmount}("");
                 if (!success) {
-                    revert ClaimRedeemFailed(params.redeemRequest.owner, rdata);
+                    revert ClaimRedeemFailed(params.redeemRequest.recipient, rdata);
                 }
             }
             emit ClaimedRedeemRequest(
                 _redeemRequestIds[idx],
-                params.redeemRequest.owner,
+                params.redeemRequest.recipient,
                 params.ethAmount,
                 params.lsETHAmount,
                 params.redeemRequest.amount

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -9,12 +9,12 @@ import "../state/redeemManager/WithdrawalStack.sol";
 /// @notice This contract handles the redeem requests of all users
 interface IRedeemManagerV1 {
     /// @notice Emitted when a redeem request is created
-    /// @param owner The owner of the redeem request
+    /// @param recipient The recipient of the redeem request
     /// @param height The height of the redeem request in LsETH
     /// @param amount The amount of the redeem request in LsETH
     /// @param maxRedeemableEth The maximum amount of eth that can be redeemed from this request
     /// @param id The id of the new redeem request
-    event RequestedRedeem(address indexed owner, uint256 height, uint256 amount, uint256 maxRedeemableEth, uint32 id);
+    event RequestedRedeem(address indexed recipient, uint256 height, uint256 amount, uint256 maxRedeemableEth, uint32 id);
 
     /// @notice Emitted when a withdrawal event is created
     /// @param height The height of the withdrawal event in LsETH
@@ -98,8 +98,8 @@ interface IRedeemManagerV1 {
     /// @param rdata The revert data
     error ClaimRedeemFailed(address recipient, bytes rdata);
 
-    /// @notice Thrown when the claim owner is denied
-    error ClaimOwnerIsDenied();
+    /// @notice Thrown when the claim recipient is denied
+    error ClaimRecipientIsDenied();
 
     /// @notice Thrown when the claim initiator is denied
     error ClaimInitiatorIsDenied();

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -101,7 +101,7 @@ interface IRedeemManagerV1 {
     /// @notice Thrown when the claim owner is denied
     error ClaimOwnerIsDenied();
 
-    /// @notice Thrown when the claim initiator is denied   
+    /// @notice Thrown when the claim initiator is denied
     error ClaimInitiatorIsDenied();
 
     /// @notice Thrown when the recipient of redeemRequest is denied

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -14,7 +14,9 @@ interface IRedeemManagerV1 {
     /// @param amount The amount of the redeem request in LsETH
     /// @param maxRedeemableEth The maximum amount of eth that can be redeemed from this request
     /// @param id The id of the new redeem request
-    event RequestedRedeem(address indexed recipient, uint256 height, uint256 amount, uint256 maxRedeemableEth, uint32 id);
+    event RequestedRedeem(
+        address indexed recipient, uint256 height, uint256 amount, uint256 maxRedeemableEth, uint32 id
+    );
 
     /// @notice Emitted when a withdrawal event is created
     /// @param height The height of the withdrawal event in LsETH

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -101,6 +101,9 @@ interface IRedeemManagerV1 {
     /// @notice Thrown when the claim owner is denied
     error ClaimOwnerIsDenied();
 
+    /// @notice Thrown when the claim initiator is denied   
+    error ClaimInitiatorIsDenied();
+
     /// @notice Thrown when the recipient of redeemRequest is denied
     error RecipientIsDenied();
 

--- a/contracts/src/state/redeemManager/RedeemQueue.sol
+++ b/contracts/src/state/redeemManager/RedeemQueue.sol
@@ -15,6 +15,8 @@ library RedeemQueue {
         uint256 maxRedeemableEth;
         /// @custom:attribute The owner of the redeem request
         address owner;
+        /// @custom:attribute The initiator of the redeem request
+        address initiator;
         /// @custom:attribute The height is the cumulative sum of all the sizes of preceding redeem requests
         uint256 height;
     }

--- a/contracts/src/state/redeemManager/RedeemQueue.sol
+++ b/contracts/src/state/redeemManager/RedeemQueue.sol
@@ -13,8 +13,8 @@ library RedeemQueue {
         uint256 amount;
         /// @custom:attribute The maximum amount of ETH redeemable by this request
         uint256 maxRedeemableEth;
-        /// @custom:attribute The owner of the redeem request
-        address owner;
+        /// @custom:attribute The recipient of the redeem request
+        address recipient;
         /// @custom:attribute The initiator of the redeem request
         address initiator;
         /// @custom:attribute The height is the cumulative sum of all the sizes of preceding redeem requests

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -1622,7 +1622,6 @@ contract RedeemManagerV1Tests is Test {
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
     }
 
-
     // A denied user when undenied would be able to claim the ETH
     function testClaimRedeemRequestClaimsWithDeniedUserUndenied(uint256 _salt) external {
         uint128 amount = uint128(bound(_salt, 1, type(uint128).max));

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -97,7 +97,7 @@ contract RedeemManagerV1Tests is Test {
     address internal allowlistAllower;
     address internal allowlistDenier;
 
-    event RequestedRedeem(address indexed owner, uint256 height, uint256 size, uint256 maxRedeemableEth, uint32 id);
+    event RequestedRedeem(address indexed recipient, uint256 height, uint256 size, uint256 maxRedeemableEth, uint32 id);
     event ReportedWithdrawal(uint256 height, uint256 size, uint256 ethAmount, uint32 id);
     event SatisfiedRedeemRequest(
         uint32 indexed redeemRequestId,
@@ -196,7 +196,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
             assertEq(rr.maxRedeemableEth, amount);
         }
 
@@ -231,7 +231,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
             assertEq(rr.maxRedeemableEth, amount);
         }
 
@@ -283,7 +283,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, recipient);
+            assertEq(rr.recipient, recipient);
             assertEq(rr.maxRedeemableEth, amount);
         }
 
@@ -344,7 +344,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount0);
-            assertEq(rr.owner, user0);
+            assertEq(rr.recipient, user0);
         }
 
         {
@@ -352,7 +352,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount0);
             assertEq(rr.amount, amount1);
-            assertEq(rr.owner, user1);
+            assertEq(rr.recipient, user1);
         }
 
         assertEq(redeemManager.getRedeemRequestCount(), 2);
@@ -522,7 +522,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -567,7 +567,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount);
             assertEq(rr.amount, 0);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -603,7 +603,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -647,7 +647,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount);
             assertEq(rr.amount, 0);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -683,7 +683,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -741,7 +741,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount);
             assertEq(rr.amount, 0);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -811,7 +811,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -858,7 +858,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount / 2);
             assertEq(rr.amount, amount - (amount / 2));
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -1008,7 +1008,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -1062,7 +1062,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount);
             assertEq(rr.amount, 0);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -1113,7 +1113,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -1121,7 +1121,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, userB);
+            assertEq(rr.recipient, userB);
         }
 
         {
@@ -1164,7 +1164,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount);
             assertEq(rr.amount, 0);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -1172,7 +1172,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount * 2);
             assertEq(rr.amount, 0);
-            assertEq(rr.owner, userB);
+            assertEq(rr.recipient, userB);
         }
 
         {
@@ -1397,7 +1397,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(redeemRequest.height, idx * 30e18);
             assertEq(redeemRequest.amount, 30e18);
-            assertEq(redeemRequest.owner, user);
+            assertEq(redeemRequest.recipient, user);
             assertEq(redeemRequest.maxRedeemableEth, applyRate(30e18, rates[idx]));
         }
 
@@ -1521,7 +1521,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -1548,12 +1548,12 @@ contract RedeemManagerV1Tests is Test {
 
         _denyUser(user);
 
-        // A user can't claim if the owner is denied
-        vm.expectRevert(abi.encodeWithSignature("ClaimOwnerIsDenied()"));
+        // A user can't claim if the recipient is denied
+        vm.expectRevert(abi.encodeWithSignature("ClaimRecipientIsDenied()"));
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
 
         // The denied user can't claim
-        vm.expectRevert(abi.encodeWithSignature("ClaimOwnerIsDenied()"));
+        vm.expectRevert(abi.encodeWithSignature("ClaimRecipientIsDenied()"));
         vm.prank(user);
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
     }
@@ -1584,7 +1584,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
             assertEq(rr.initiator, initiator); // Check the initiator
         }
 
@@ -1616,7 +1616,7 @@ contract RedeemManagerV1Tests is Test {
         vm.expectRevert(abi.encodeWithSignature("ClaimInitiatorIsDenied()"));
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
 
-        // The allowed owner can't claim, if the initiator is denied
+        // The allowed recipient can't claim, if the initiator is denied
         vm.expectRevert(abi.encodeWithSignature("ClaimInitiatorIsDenied()"));
         vm.prank(user);
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
@@ -1647,7 +1647,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, 0);
             assertEq(rr.amount, amount);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -1674,12 +1674,12 @@ contract RedeemManagerV1Tests is Test {
 
         _denyUser(user);
 
-        // A user can't claim if the owner is denied
-        vm.expectRevert(abi.encodeWithSignature("ClaimOwnerIsDenied()"));
+        // A user can't claim if the recipient is denied
+        vm.expectRevert(abi.encodeWithSignature("ClaimRecipientIsDenied()"));
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
 
         // The denied user can't claim
-        vm.expectRevert(abi.encodeWithSignature("ClaimOwnerIsDenied()"));
+        vm.expectRevert(abi.encodeWithSignature("ClaimRecipientIsDenied()"));
         vm.prank(user);
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
 
@@ -1705,7 +1705,7 @@ contract RedeemManagerV1Tests is Test {
 
             assertEq(rr.height, amount);
             assertEq(rr.amount, 0);
-            assertEq(rr.owner, user);
+            assertEq(rr.recipient, user);
         }
 
         {
@@ -1782,7 +1782,7 @@ contract RedeemManagerV1Tests is Test {
         redeemRequestIds[0] = 1;
         withdrawEventIds[0] = 1;
 
-        vm.expectRevert(abi.encodeWithSignature("ClaimOwnerIsDenied()"));
+        vm.expectRevert(abi.encodeWithSignature("ClaimRecipientIsDenied()"));
         vm.prank(user2);
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
     }

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -13,7 +13,6 @@ import "../src/RedeemManager.1.sol";
 import "../src/Allowlist.1.sol";
 import "./mocks/RejectEtherMock.sol";
 
-
 contract RiverMock {
     mapping(address => uint256) internal balances;
     mapping(address => mapping(address => uint256)) internal approvals;
@@ -143,7 +142,6 @@ contract RedeemManagerV1Tests is Test {
         vm.prank(allowlistAllower);
         allowlist.setAllowPermissions(accounts, permissions);
     }
-    
 
     function _generateAllowlistedUser(uint256 _salt) internal returns (address) {
         address user = uf._new(_salt);
@@ -1907,7 +1905,6 @@ contract RedeemManagerV1Tests is Test {
         vm.expectRevert(abi.encodeWithSignature("ClaimRedeemFailed(address,bytes)", recipient, new bytes(0)));
         redeemManager.claimRedeemRequests(redeemRequestIds, withdrawEventIds, true, type(uint16).max);
     }
-
 
     function testVersion() external {
         assertEq(redeemManager.version(), "1.2.0");

--- a/contracts/test/mocks/RejectEtherMock.sol
+++ b/contracts/test/mocks/RejectEtherMock.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract RejectEtherMock {
+    receive() external payable {
+        revert();
+    }
+}


### PR DESCRIPTION
## Description

This checks that the original request’s funds owner wasn’t blacklisted, o/w they can create temporary addresses for the recipient address tat have not be blacklisted for the recipient address, and still be able to claim their funds with those addresses.

Changes included:
- Updated the redeemRequests struct to include the initiator of the redeem request
- Updated requestRedeem function to store the msg.sender as the initiator of the redeemRequest
- Updated claimRedeemRequest to revert if the initiator of a redeemRequest is denied

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [x] Have you assigned this PR to yourself?
- [x] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [x] Have you added sufficient documentation in your code?
- [x] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [x] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
