### PR TITLE
fix: initialize reentrancy guard PE-52

### DIFF
--- a/contracts/src/WLSETH.1.sol
+++ b/contracts/src/WLSETH.1.sol
@@ -36,6 +36,7 @@ contract WLSETHV1 is IWLSETHV1, Initializable, ReentrancyGuardUpgradeable {
 
     /// @inheritdoc IWLSETHV1
     function initWLSETHV1(address _river) external initializer {
+        __ReentrancyGuard_init();
         RiverAddress.set(_river);
         emit SetRiver(_river);
     }


### PR DESCRIPTION
## Fix: missing initialization of reentrancy guard PE-52

<!-- Please provide a detailed description of your changes -->

Closes PE-52

Fixes: Informational:  ReentrancyGuardUpgradeable isn't initialized in the initialize function

1. Added  __ReentrancyGuard_init();

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [x] Have you assigned this PR to yourself?
- [x] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [x] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [x] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->