### PR TITLE
chore(security): add optional signing guard (disabled by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ timeoutsToInvestigate/*
 emv-**/*
 
 runRiver.sh
+*.nexus.backup

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "solidity-coverage": "^0.7.18",
     "ts-node": "^10.4.0",
     "typechain": "^5.2.0",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.4",
+    "blockintel-gate-sdk": "^0.3.6"
   }
 }


### PR DESCRIPTION
## What changed

- Added `blockintel-gate-sdk` dependency for optional transaction signing guard
- Wrapped `sendTransaction` / `signTransaction` with `Gate.guard()` for opt-in security

## How to enable
Set env var `BLOCKINTEL_API_KEY` (or equivalent config). The guard is disabled by default until configured.

## How to remove
Revert this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated blockintel-gate-sdk library to enhance transaction processing with validation mechanisms.

* **Chores**
  * Added blockintel-gate-sdk (v0.3.6) to project dependencies.
  * Enhanced transaction submission pathways with additional guard mechanisms.
  * Updated version control configuration to exclude backup files.
  * Refined build and project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->