### PR TITLE
feat(test) adds more Deposit BYOV Allocation tests

### DIFF
--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -4253,7 +4253,8 @@ contract OperatorsRegistryV1AllocationCorrectnessTests is OperatorAllocationTest
             address opAddr = makeAddr(string(abi.encodePacked("op", vm.toString(i))));
             operatorsRegistry.addOperator(string(abi.encodePacked("Operator ", vm.toString(i))), opAddr);
 
-            bytes memory keys = genBytes(uint256(keysPerOp) * (ValidatorKeys.PUBLIC_KEY_LENGTH + ValidatorKeys.SIGNATURE_LENGTH));
+            bytes memory keys =
+                genBytes(uint256(keysPerOp) * (ValidatorKeys.PUBLIC_KEY_LENGTH + ValidatorKeys.SIGNATURE_LENGTH));
             rawKeysByOperator.push(keys);
             operatorsRegistry.addValidators(i, keysPerOp, keys);
 
@@ -4321,7 +4322,11 @@ contract OperatorsRegistryV1AllocationCorrectnessTests is OperatorAllocationTest
 
         // Keys 1-8: op1 validators 0-7
         for (uint256 i = 0; i < 8; ++i) {
-            assertEq(publicKeys[1 + i], _extractPublicKey(1, i), string(abi.encodePacked("Key should be op1 validator ", vm.toString(i))));
+            assertEq(
+                publicKeys[1 + i],
+                _extractPublicKey(1, i),
+                string(abi.encodePacked("Key should be op1 validator ", vm.toString(i)))
+            );
         }
 
         // Key 9: op2 validator 0


### PR DESCRIPTION
What's missing

  1. No test verifies the actual keys returned match the correct operator. Every test checks publicKeys.length and operator.funded, but none asserts that the keys in positions 0-1 belong to operator 0 and keys 2-4 belong to operator 1. The tests prove the right count per operator but not the right keys per operator.

  The testRegularDepositDistribution test does use vm.expectEmit to check FundedValidatorKeys events with the actual key bytes -- that's the one exception
  that validates key content per operator.

  2. No test for uneven/asymmetric multi-operator allocation with content verification. For example: allocate 1 to op0, 8 to op1, 1 to op2, and verify each operator got the correct keys from their own key set.

  3. No test for a large number of operators (e.g., 10+). All tests use 2-5 operators. A test with, say, 15 operators where only 3 get allocations would exercise the linear search in _updateCountOfPickedValidatorsForEachOperator more thoroughly.

  4. No test for allocation to non-contiguous operator indexes. For example, operators exist at indexes 0,1,2,3,4 but allocations only target 0 and 4 (skipping middle ones). The testInactiveDepositDistribution covers this partially (operators 0,2,4) but only when the skipped ones are inactive, not when active operators are simply not allocated to.

  5. No test that passes allocations through the full depositToConsensusLayerWithDepositRoot -> River -> OperatorsRegistry path and verifies per-operator funded counts. The River and DepositManager tests mostly check reverts and total counts, not per-operator correctness through the full stack.

  Bottom line

  The count correctness ("operator X got N validators") is well tested. The content correctness ("the keys returned for operator X are actually operator
  X's keys") relies almost entirely on the FundedValidatorKeys event assertions in testRegularDepositDistribution. I'd recommend at least one more test
  that does a multi-operator asymmetric allocation and verifies the returned key bytes match each operator's registered keys.

## Description

<!-- Please provide a detailed description of your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->