### PR TITLE
chore: pectra

### DIFF
--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -15,6 +15,7 @@ import "./state/operatorsRegistry/Operators.2.sol";
 import "./state/operatorsRegistry/ValidatorKeys.sol";
 import "./state/operatorsRegistry/TotalValidatorExitsRequested.sol";
 import "./state/operatorsRegistry/CurrentValidatorExitsDemand.sol";
+import "./state/operatorsRegistry/CurrentExitDemandBalance.sol";
 import "./state/shared/RiverAddress.sol";
 
 import "./state/migration/OperatorsRegistry_FundedKeyEventRebroadcasting_KeyIndex.sol";
@@ -689,6 +690,16 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
             _setCurrentValidatorExitsDemand(vars.cachedCurrentValidatorExitsDemand, vars.currentValidatorExitsDemand);
         }
 
+        // Decrement ETH-based exit demand balance for unsolicited exits (conservative: 32 ETH per validator)
+        if (unsolicitedExitsSum > 0) {
+            uint256 currentExitDemandBalance = CurrentExitDemandBalance.get();
+            if (currentExitDemandBalance > 0) {
+                uint256 decrease = LibUint256.min(unsolicitedExitsSum * 32 ether, currentExitDemandBalance);
+                CurrentExitDemandBalance.set(currentExitDemandBalance - decrease);
+                emit SetCurrentExitDemandBalance(currentExitDemandBalance, currentExitDemandBalance - decrease);
+            }
+        }
+
         // we check that the total is matching the sum of the individual values
         if (vars.totalStoppedValidatorCount != vars.count) {
             revert InvalidStoppedValidatorCountsSum();
@@ -735,8 +746,39 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
         emit SetTotalValidatorExitsRequested(_currentValue, _newValue);
     }
 
+    /// @inheritdoc IOperatorsRegistryV1
+    function demandExitBalance(uint256 _ethAmount) external onlyRiver {
+        uint256 currentBalance = CurrentExitDemandBalance.get();
+        uint256 newBalance = currentBalance + _ethAmount;
+        CurrentExitDemandBalance.set(newBalance);
+        emit SetCurrentExitDemandBalance(currentBalance, newBalance);
+    }
+
+    /// @inheritdoc IOperatorsRegistryV1
+    function fillExitDemandBalance(uint256 _ethAmount) external onlyRiver {
+        uint256 currentBalance = CurrentExitDemandBalance.get();
+        uint256 newBalance = currentBalance > _ethAmount ? currentBalance - _ethAmount : 0;
+        CurrentExitDemandBalance.set(newBalance);
+        emit SetCurrentExitDemandBalance(currentBalance, newBalance);
+    }
+
+    /// @inheritdoc IOperatorsRegistryV1
+    function getCurrentExitDemandBalance() external view returns (uint256) {
+        return CurrentExitDemandBalance.get();
+    }
+
+    /// @notice Initializes version 1.3 of the Operators Registry (ETH-based accounting)
+    function initOperatorsRegistryV1_3() external init(2) {
+        uint256 currentDemand = CurrentValidatorExitsDemand.get();
+        if (currentDemand > 0) {
+            uint256 ethDemand = currentDemand * 32 ether;
+            CurrentExitDemandBalance.set(ethDemand);
+            emit SetCurrentExitDemandBalance(0, ethDemand);
+        }
+    }
+
     /// @inheritdoc IProtocolVersion
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -28,6 +28,9 @@ import "./state/river/BalanceToRedeem.sol";
 import "./state/river/GlobalFee.sol";
 import "./state/river/MetadataURI.sol";
 import "./state/river/LastConsensusLayerReport.sol";
+import "./state/river/InFlightDepositBalance.sol";
+import "./state/river/PendingFullExitBalance.sol";
+import "./state/river/KeeperAddress.sol";
 
 /// @title River (v1)
 /// @author Alluvial Finance Inc.
@@ -122,6 +125,18 @@ contract RiverV1 is
         unchecked {
             _setCommittedBalance(CommittedBalance.get() - dustToUncommit);
             _setBalanceToDeposit(BalanceToDeposit.get() + dustToUncommit);
+        }
+    }
+
+    /// @inheritdoc IRiverV1
+    function initRiverV1_3() external init(3) {
+        IOracleManagerV1.StoredConsensusLayerReport storage storedReport = LastConsensusLayerReport.get();
+        uint256 clValidatorCount = storedReport.validatorsCount;
+        uint256 depositedValidatorCount = DepositedValidatorCount.get();
+        if (depositedValidatorCount > clValidatorCount) {
+            uint256 inFlightBalance = (depositedValidatorCount - clValidatorCount) * DEPOSIT_SIZE;
+            InFlightDepositBalance.set(inFlightBalance);
+            emit SetInFlightDepositBalance(0, inFlightBalance);
         }
     }
 
@@ -281,6 +296,40 @@ contract RiverV1 is
         }
     }
 
+    /// @inheritdoc IRiverV1
+    function requestFullExits(IRiverV1.FullExitRequest[] calldata _exitRequests) external {
+        if (msg.sender != KeeperAddress.get()) {
+            revert OnlyKeeper();
+        }
+
+        IOperatorsRegistryV1 or_ = IOperatorsRegistryV1(OperatorsRegistryAddress.get());
+
+        uint256 totalEthAmount;
+        uint256 totalValidatorCount;
+        IOperatorsRegistryV1.OperatorAllocation[] memory allocations =
+            new IOperatorsRegistryV1.OperatorAllocation[](_exitRequests.length);
+
+        for (uint256 i = 0; i < _exitRequests.length; ++i) {
+            totalEthAmount += _exitRequests[i].ethAmount;
+            totalValidatorCount += _exitRequests[i].validatorCount;
+            allocations[i] = IOperatorsRegistryV1.OperatorAllocation({
+                operatorIndex: _exitRequests[i].operatorIndex,
+                validatorCount: _exitRequests[i].validatorCount
+            });
+        }
+
+        PendingFullExitBalance.set(PendingFullExitBalance.get() + totalEthAmount);
+        or_.fillExitDemandBalance(totalEthAmount);
+        or_.requestValidatorExits(allocations);
+
+        emit FullExitsRequested(totalEthAmount, totalValidatorCount);
+    }
+
+    /// @inheritdoc IRiverV1
+    function getPendingFullExitBalance() external view returns (uint256) {
+        return PendingFullExitBalance.get();
+    }
+
     /// @notice Overridden handler to pass the system admin inside components
     /// @return The address of the admin
     function _getRiverAdmin()
@@ -391,15 +440,37 @@ contract RiverV1 is
     /// @return The current total asset balance managed by River
     function _assetBalance() internal view override(SharesManagerV1, OracleManagerV1) returns (uint256) {
         IOracleManagerV1.StoredConsensusLayerReport storage storedReport = LastConsensusLayerReport.get();
-        uint256 clValidatorCount = storedReport.validatorsCount;
-        uint256 depositedValidatorCount = DepositedValidatorCount.get();
-        if (clValidatorCount < depositedValidatorCount) {
-            return storedReport.validatorsBalance + BalanceToDeposit.get() + CommittedBalance.get()
-                + BalanceToRedeem.get() + (depositedValidatorCount - clValidatorCount)
-                * ConsensusLayerDepositManagerV1.DEPOSIT_SIZE;
-        } else {
-            return
-                storedReport.validatorsBalance + BalanceToDeposit.get() + CommittedBalance.get() + BalanceToRedeem.get();
+        return storedReport.validatorsBalance + BalanceToDeposit.get() + CommittedBalance.get()
+            + BalanceToRedeem.get() + InFlightDepositBalance.get();
+    }
+
+    /// @notice Overridden handler to increase the in-flight deposit balance after deposits
+    /// @param _amount The ETH amount to add to the in-flight deposit balance
+    function _increaseInFlightDepositBalance(uint256 _amount) internal override {
+        uint256 oldBalance = InFlightDepositBalance.get();
+        uint256 newBalance = oldBalance + _amount;
+        InFlightDepositBalance.set(newBalance);
+        emit SetInFlightDepositBalance(oldBalance, newBalance);
+    }
+
+    /// @notice Overridden handler to decrease the in-flight deposit balance when validators activate
+    /// @param _newValidatorCount The number of newly activated validators
+    function _decreaseInFlightDepositBalance(uint32 _newValidatorCount) internal override {
+        uint256 oldBalance = InFlightDepositBalance.get();
+        uint256 decrease = uint256(_newValidatorCount) * DEPOSIT_SIZE;
+        uint256 newBalance = oldBalance > decrease ? oldBalance - decrease : 0;
+        InFlightDepositBalance.set(newBalance);
+        emit SetInFlightDepositBalance(oldBalance, newBalance);
+    }
+
+    /// @notice Overridden handler to reconcile pending full exits when exited balance increases
+    /// @param _exitedIncrease The increase in total exited ETH balance
+    function _reconcileFullExits(uint256 _exitedIncrease) internal override {
+        uint256 pendingBalance = PendingFullExitBalance.get();
+        if (pendingBalance > 0) {
+            uint256 reconciled = LibUint256.min(_exitedIncrease, pendingBalance);
+            PendingFullExitBalance.set(pendingBalance - reconciled);
+            emit FullExitsReconciled(reconciled);
         }
     }
 
@@ -526,9 +597,9 @@ contract RiverV1 is
                 _balanceFromShares(IRedeemManagerV1(RedeemManagerAddress.get()).getRedeemDemand());
 
             // if after all rebalancings, the redeem manager demand is still higher than the balance to redeem and exiting eth, we compute
-            // the amount of validators to exit in order to cover the remaining demand
+            // the amount of ETH to demand for exits in order to cover the remaining demand
             if (availableBalanceToRedeem + _exitingBalance < redeemManagerDemandInEth) {
-                // if reblancing is enabled and the redeem manager demand is higher than exiting eth, we add eth for deposit buffer to redeem buffer
+                // if rebalancing is enabled and the redeem manager demand is higher than exiting eth, we add eth for deposit buffer to redeem buffer
                 if (_depositToRedeemRebalancingAllowed && availableBalanceToDeposit > 0) {
                     uint256 rebalancingAmount = LibUint256.min(
                         availableBalanceToDeposit, redeemManagerDemandInEth - _exitingBalance - availableBalanceToRedeem
@@ -540,26 +611,16 @@ contract RiverV1 is
                     }
                 }
 
-                IOperatorsRegistryV1 or = IOperatorsRegistryV1(OperatorsRegistryAddress.get());
+                IOperatorsRegistryV1 or_ = IOperatorsRegistryV1(OperatorsRegistryAddress.get());
 
-                (uint256 totalStoppedValidatorCount, uint256 totalRequestedExitsCount) =
-                    or.getStoppedAndRequestedExitCounts();
+                // Use ETH-based pending full exit balance instead of count-based preExitingBalance
+                uint256 pendingFullExitBalance = PendingFullExitBalance.get();
 
-                // what we are calling pre-exiting balance is the amount of eth that should soon enter the exiting balance
-                // because exit requests have been made and operators might have a lag to process them
-                // we take them into account to not exit too many validators
-                uint256 preExitingBalance =
-                    (totalRequestedExitsCount > totalStoppedValidatorCount
-                                ? (totalRequestedExitsCount - totalStoppedValidatorCount)
-                                : 0) * DEPOSIT_SIZE;
+                if (availableBalanceToRedeem + _exitingBalance + pendingFullExitBalance < redeemManagerDemandInEth) {
+                    uint256 shortfall =
+                        redeemManagerDemandInEth - (availableBalanceToRedeem + _exitingBalance + pendingFullExitBalance);
 
-                if (availableBalanceToRedeem + _exitingBalance + preExitingBalance < redeemManagerDemandInEth) {
-                    uint256 validatorCountToExit = LibUint256.ceil(
-                        redeemManagerDemandInEth - (availableBalanceToRedeem + _exitingBalance + preExitingBalance),
-                        DEPOSIT_SIZE
-                    );
-
-                    or.demandValidatorExits(validatorCountToExit, DepositedValidatorCount.get());
+                    or_.demandExitBalance(shortfall);
                 }
             }
         }
@@ -610,6 +671,6 @@ contract RiverV1 is
     }
 
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/components/ConsensusLayerDepositManager.1.sol
+++ b/contracts/src/components/ConsensusLayerDepositManager.1.sol
@@ -14,6 +14,7 @@ import "../state/river/DepositedValidatorCount.sol";
 import "../state/river/BalanceToDeposit.sol";
 import "../state/river/CommittedBalance.sol";
 import "../state/river/KeeperAddress.sol";
+import "../state/river/InFlightDepositBalance.sol";
 
 /// @title Consensus Layer Deposit Manager (v1)
 /// @author Alluvial Finance Inc.
@@ -37,6 +38,11 @@ abstract contract ConsensusLayerDepositManagerV1 is IConsensusLayerDepositManage
     /// @notice Handler called to change the committed balance to deposit
     /// @param newCommittedBalance The new committed balance value
     function _setCommittedBalance(uint256 newCommittedBalance) internal virtual;
+
+    /// @notice Handler called to increase the in-flight deposit balance after deposits
+    /// @dev Must be Overridden
+    /// @param _amount The ETH amount to add to the in-flight deposit balance
+    function _increaseInFlightDepositBalance(uint256 _amount) internal virtual;
 
     /// @notice Internal helper to retrieve validator keys ready to be funded
     /// @dev Must be overridden
@@ -88,6 +94,11 @@ abstract contract ConsensusLayerDepositManagerV1 is IConsensusLayerDepositManage
     /// @inheritdoc IConsensusLayerDepositManagerV1
     function getKeeper() external view returns (address) {
         return KeeperAddress.get();
+    }
+
+    /// @inheritdoc IConsensusLayerDepositManagerV1
+    function getInFlightDepositBalance() external view returns (uint256) {
+        return InFlightDepositBalance.get();
     }
 
     /// @inheritdoc IConsensusLayerDepositManagerV1
@@ -150,6 +161,7 @@ abstract contract ConsensusLayerDepositManagerV1 is IConsensusLayerDepositManage
         emit SetDepositedValidatorCount(
             currentDepositedValidatorCount, currentDepositedValidatorCount + receivedPublicKeyCount
         );
+        _increaseInFlightDepositBalance(DEPOSIT_SIZE * receivedPublicKeyCount);
     }
 
     /// @notice Deposits 32 ETH to the official Deposit contract

--- a/contracts/src/components/OracleManager.1.sol
+++ b/contracts/src/components/OracleManager.1.sol
@@ -74,6 +74,16 @@ abstract contract OracleManagerV1 is IOracleManagerV1 {
         bool _slashingContainmentModeEnabled
     ) internal virtual;
 
+    /// @notice Handler called when new validators activate to decrease in-flight deposit balance
+    /// @dev Must be overridden
+    /// @param _newValidatorCount The number of newly activated validators
+    function _decreaseInFlightDepositBalance(uint32 _newValidatorCount) internal virtual;
+
+    /// @notice Handler called to reconcile pending full exits when exited balance increases
+    /// @dev Must be overridden
+    /// @param _exitedIncrease The increase in total exited ETH balance
+    function _reconcileFullExits(uint256 _exitedIncrease) internal virtual;
+
     /// @notice Skims the redeem balance and sends remaining funds to the deposit balance
     function _skimExcessBalanceToRedeem() internal virtual;
 
@@ -251,6 +261,7 @@ abstract contract OracleManagerV1 is IOracleManagerV1 {
         uint256 timeElapsedSinceLastReport;
         uint256 availableAmountToUpperBound;
         uint256 redeemManagerDemand;
+        uint32 lastReportValidatorsCount;
         ConsensusLayerDataReportingTrace trace;
     }
 
@@ -307,6 +318,7 @@ abstract contract OracleManagerV1 is IOracleManagerV1 {
             // we compute the new skimmed amount by taking the delta between reports
             vars.skimmedAmountIncrease = _report.validatorsSkimmedBalance - vars.lastReportSkimmedBalance;
 
+            vars.lastReportValidatorsCount = lastStoredReport.validatorsCount;
             vars.timeElapsedSinceLastReport = _timeBetweenEpochs(cls, lastStoredReport.epoch, _report.epoch);
         }
 
@@ -331,7 +343,18 @@ abstract contract OracleManagerV1 is IOracleManagerV1 {
             storedReport.validatorsCount = _report.validatorsCount;
             storedReport.rebalanceDepositToRedeemMode = _report.rebalanceDepositToRedeemMode;
             storedReport.slashingContainmentMode = _report.slashingContainmentMode;
+
+            // Decrease in-flight deposit balance when new validators activate on the consensus layer
+            if (_report.validatorsCount > vars.lastReportValidatorsCount) {
+                _decreaseInFlightDepositBalance(_report.validatorsCount - vars.lastReportValidatorsCount);
+            }
+
             LastConsensusLayerReport.set(storedReport);
+        }
+
+        // Reconcile pending full exits when exited balance increases
+        if (vars.exitedAmountIncrease > 0) {
+            _reconcileFullExits(vars.exitedAmountIncrease);
         }
 
         ReportBounds.ReportBoundsStruct memory rb = ReportBounds.get();

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -388,4 +388,23 @@ interface IOperatorsRegistryV1 {
     /// @param _count The amount of exit requests to add to the demand
     /// @param _depositedValidatorCount The total deposited validator count
     function demandValidatorExits(uint256 _count, uint256 _depositedValidatorCount) external;
+
+    /// @notice The current exit demand balance has been updated
+    /// @param previousExitDemandBalance The previous exit demand balance in ETH
+    /// @param nextExitDemandBalance The new exit demand balance in ETH
+    event SetCurrentExitDemandBalance(uint256 previousExitDemandBalance, uint256 nextExitDemandBalance);
+
+    /// @notice Increases the ETH-based exit demand balance
+    /// @dev Only callable by the river contract
+    /// @param _ethAmount The amount of ETH to add to the exit demand
+    function demandExitBalance(uint256 _ethAmount) external;
+
+    /// @notice Decreases the ETH-based exit demand balance when exit requests are filled
+    /// @dev Only callable by the river contract
+    /// @param _ethAmount The amount of ETH to subtract from the exit demand
+    function fillExitDemandBalance(uint256 _ethAmount) external;
+
+    /// @notice Retrieve the current ETH-based exit demand balance
+    /// @return The current exit demand balance in ETH
+    function getCurrentExitDemandBalance() external view returns (uint256);
 }

--- a/contracts/src/interfaces/IRiver.1.sol
+++ b/contracts/src/interfaces/IRiver.1.sol
@@ -103,6 +103,20 @@ interface IRiverV1 is IConsensusLayerDepositManagerV1, IUserDepositManagerV1, IS
         uint256 redeemManagerDemand, uint256 suppliedRedeemManagerDemand, uint256 suppliedRedeemManagerDemandInEth
     );
 
+    /// @notice The in-flight deposit balance has been updated
+    /// @param oldAmount The old in-flight deposit balance
+    /// @param newAmount The new in-flight deposit balance
+    event SetInFlightDepositBalance(uint256 oldAmount, uint256 newAmount);
+
+    /// @notice Full exits have been requested for validators
+    /// @param ethAmount The total ETH amount of the exit requests
+    /// @param validatorCount The number of validators requested to exit
+    event FullExitsRequested(uint256 ethAmount, uint256 validatorCount);
+
+    /// @notice Full exits have been reconciled based on oracle data
+    /// @param ethAmount The ETH amount reconciled from the pending full exit balance
+    event FullExitsReconciled(uint256 ethAmount);
+
     /// @notice Thrown when the amount received from the Withdraw contract doe not match the requested amount
     /// @param requested The amount that was requested
     /// @param received The amount that was received
@@ -163,6 +177,9 @@ interface IRiverV1 is IConsensusLayerDepositManagerV1, IUserDepositManagerV1, IS
 
     /// @notice Initializes version 1.2 of the River System
     function initRiverV1_2() external;
+
+    /// @notice Initializes version 1.3 of the River System (ETH-based accounting)
+    function initRiverV1_3() external;
 
     /// @notice Get the current global fee
     /// @return The global fee
@@ -268,4 +285,22 @@ interface IRiverV1 is IConsensusLayerDepositManagerV1, IUserDepositManagerV1, IS
 
     /// @notice Input for the redeem manager funds
     function sendRedeemManagerExceedingFunds() external payable;
+
+    /// @notice Structure representing a full exit request for a set of validators
+    /// @param operatorIndex The index of the operator
+    /// @param validatorCount The number of validators to exit for this operator
+    /// @param ethAmount The total ETH amount associated with this exit request
+    struct FullExitRequest {
+        uint256 operatorIndex;
+        uint256 validatorCount;
+        uint256 ethAmount;
+    }
+
+    /// @notice Requests full exits for validators with ETH-based accounting
+    /// @param _exitRequests The array of full exit requests
+    function requestFullExits(FullExitRequest[] calldata _exitRequests) external;
+
+    /// @notice Retrieve the current pending full exit balance
+    /// @return The current pending full exit balance in ETH
+    function getPendingFullExitBalance() external view returns (uint256);
 }

--- a/contracts/src/interfaces/components/IConsensusLayerDepositManager.1.sol
+++ b/contracts/src/interfaces/components/IConsensusLayerDepositManager.1.sol
@@ -77,4 +77,8 @@ interface IConsensusLayerDepositManagerV1 {
         IOperatorsRegistryV1.OperatorAllocation[] calldata _allocations,
         bytes32 _depositRoot
     ) external;
+
+    /// @notice Retrieve the current in-flight deposit balance
+    /// @return The current in-flight deposit balance in ETH
+    function getInFlightDepositBalance() external view returns (uint256);
 }

--- a/contracts/src/state/operatorsRegistry/CurrentExitDemandBalance.sol
+++ b/contracts/src/state/operatorsRegistry/CurrentExitDemandBalance.sol
@@ -1,0 +1,19 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../libraries/LibUnstructuredStorage.sol";
+
+/// @title CurrentExitDemandBalance Storage
+/// @notice Tracks the total ETH amount of exit demand that has not yet been fulfilled by exit requests
+library CurrentExitDemandBalance {
+    bytes32 internal constant CURRENT_EXIT_DEMAND_BALANCE_SLOT =
+        bytes32(uint256(keccak256("operatorsRegistry.state.currentExitDemandBalance")) - 1);
+
+    function get() internal view returns (uint256) {
+        return LibUnstructuredStorage.getStorageUint256(CURRENT_EXIT_DEMAND_BALANCE_SLOT);
+    }
+
+    function set(uint256 newValue) internal {
+        LibUnstructuredStorage.setStorageUint256(CURRENT_EXIT_DEMAND_BALANCE_SLOT, newValue);
+    }
+}

--- a/contracts/src/state/river/InFlightDepositBalance.sol
+++ b/contracts/src/state/river/InFlightDepositBalance.sol
@@ -1,0 +1,19 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../libraries/LibUnstructuredStorage.sol";
+
+/// @title InFlightDepositBalance Storage
+/// @notice Tracks the total ETH amount deposited to the consensus layer but not yet reported as active by the oracle
+library InFlightDepositBalance {
+    bytes32 internal constant IN_FLIGHT_DEPOSIT_BALANCE_SLOT =
+        bytes32(uint256(keccak256("river.state.inFlightDepositBalance")) - 1);
+
+    function get() internal view returns (uint256) {
+        return LibUnstructuredStorage.getStorageUint256(IN_FLIGHT_DEPOSIT_BALANCE_SLOT);
+    }
+
+    function set(uint256 newValue) internal {
+        LibUnstructuredStorage.setStorageUint256(IN_FLIGHT_DEPOSIT_BALANCE_SLOT, newValue);
+    }
+}

--- a/contracts/src/state/river/PendingFullExitBalance.sol
+++ b/contracts/src/state/river/PendingFullExitBalance.sol
@@ -1,0 +1,19 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../libraries/LibUnstructuredStorage.sol";
+
+/// @title PendingFullExitBalance Storage
+/// @notice Tracks the total ETH amount of validators that have been requested to exit but have not yet exited
+library PendingFullExitBalance {
+    bytes32 internal constant PENDING_FULL_EXIT_BALANCE_SLOT =
+        bytes32(uint256(keccak256("river.state.pendingFullExitBalance")) - 1);
+
+    function get() internal view returns (uint256) {
+        return LibUnstructuredStorage.getStorageUint256(PENDING_FULL_EXIT_BALANCE_SLOT);
+    }
+
+    function set(uint256 newValue) internal {
+        LibUnstructuredStorage.setStorageUint256(PENDING_FULL_EXIT_BALANCE_SLOT, newValue);
+    }
+}

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -4427,7 +4427,7 @@ contract OperatorsRegistryV1TestDistribution is OperatorAllocationTestBase {
     }
 
     function testVersion() external {
-        assertEq(operatorsRegistry.version(), "1.2.1");
+        assertEq(operatorsRegistry.version(), "1.3.0");
     }
 
     function testGetNextValidatorsToDepositFromActiveOperatorsRevertsWithEmptyAllocation() public {

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -233,7 +233,7 @@ contract RiverV1Tests is RiverV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(river.version(), "1.2.1");
+        assertEq(river.version(), "1.3.0");
     }
 
     function testOnlyAdminCanSetKeeper() public {

--- a/contracts/test/components/ConsensusLayerDepositManager.1.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManager.1.t.sol
@@ -20,6 +20,9 @@ contract ConsensusLayerDepositManagerV1ExposeInitializer is ConsensusLayerDeposi
         return address(0);
     }
 
+    function _increaseInFlightDepositBalance(uint256) internal override {}
+
+
     function publicConsensusLayerDepositManagerInitializeV1(
         address _depositContractAddress,
         bytes32 _withdrawalCredentials
@@ -81,6 +84,9 @@ contract ConsensusLayerDepositManagerV1UsesRegistry is ConsensusLayerDepositMana
     function _getRiverAdmin() internal pure override returns (address) {
         return address(0);
     }
+
+    function _increaseInFlightDepositBalance(uint256) internal override {}
+
 
     function setRegistry(IOperatorsRegistryV1 _registry) external {
         registry = _registry;
@@ -200,6 +206,9 @@ contract ConsensusLayerDepositManagerV1ControllableValidatorKeyRequest is Consen
     function _getRiverAdmin() internal pure override returns (address) {
         return address(0);
     }
+
+    function _increaseInFlightDepositBalance(uint256) internal override {}
+
 
     function publicConsensusLayerDepositManagerInitializeV1(
         address _depositContractAddress,
@@ -927,6 +936,9 @@ contract ConsensusLayerDepositManagerV1ValidKeys is ConsensusLayerDepositManager
     function _getRiverAdmin() internal pure override returns (address) {
         return address(0);
     }
+
+    function _increaseInFlightDepositBalance(uint256) internal override {}
+
 
     function publicConsensusLayerDepositManagerInitializeV1(
         address _depositContractAddress,

--- a/contracts/test/components/OracleManager.1.t.sol
+++ b/contracts/test/components/OracleManager.1.t.sol
@@ -28,6 +28,10 @@ contract OracleManagerV1ExposeInitializer is OracleManagerV1 {
         return AdministratorAddress.get();
     }
 
+    function _decreaseInFlightDepositBalance(uint32) internal override {}
+    function _reconcileFullExits(uint256) internal override {}
+
+
     constructor(
         address oracle,
         address admin,

--- a/docs/V0-plan.md
+++ b/docs/V0-plan.md
@@ -1,0 +1,482 @@
+---
+shaping: true
+---
+
+# V0 Plan: ETH-Based Accounting Foundation
+
+**Parts:** A9
+**Demo:** `_assetBalance()` uses `InFlightDepositBalance` instead of `(depositedCount - clCount) * 32`. Exit demand and pre-exiting balance track ETH amounts. No balance accounting depends on `DEPOSIT_SIZE` or validator counts.
+**Prerequisite for:** V1, V2
+
+---
+
+## Design Principle
+
+**System-level balance accounting → ETH-based.** River tracks ETH amounts for `_assetBalance()`, exit demand, and pre-exiting balance.
+
+**Operator-level management → count-based (unchanged).** OperatorsRegistry keeps `operator.funded`, `operator.requestedExits`, `stoppedValidatorCounts` as counts. These are operational (which operator has how many validators) not balance accounting.
+
+**Bridge:** The keeper provides both operator allocations (counts, for operator tracking) and ETH amounts (for system accounting) when requesting exits.
+
+---
+
+## Step-by-step Implementation
+
+### Step 1: New state storage files
+
+**File: `contracts/src/state/river/InFlightDepositBalance.sol`**
+```solidity
+library InFlightDepositBalance {
+    bytes32 internal constant IN_FLIGHT_DEPOSIT_BALANCE_SLOT =
+        bytes32(uint256(keccak256("river.state.inFlightDepositBalance")) - 1);
+
+    function get() internal view returns (uint256) {
+        return LibUnstructuredStorage.getStorageUint256(IN_FLIGHT_DEPOSIT_BALANCE_SLOT);
+    }
+
+    function set(uint256 _newValue) internal {
+        LibUnstructuredStorage.setStorageUint256(IN_FLIGHT_DEPOSIT_BALANCE_SLOT, _newValue);
+    }
+}
+```
+
+**File: `contracts/src/state/river/PendingFullExitBalance.sol`**
+```solidity
+library PendingFullExitBalance {
+    bytes32 internal constant PENDING_FULL_EXIT_BALANCE_SLOT =
+        bytes32(uint256(keccak256("river.state.pendingFullExitBalance")) - 1);
+
+    function get() internal view returns (uint256) { ... }
+    function set(uint256 _newValue) internal { ... }
+}
+```
+
+**File: `contracts/src/state/operatorsRegistry/CurrentExitDemandBalance.sol`**
+```solidity
+library CurrentExitDemandBalance {
+    bytes32 internal constant CURRENT_EXIT_DEMAND_BALANCE_SLOT =
+        bytes32(uint256(keccak256("operatorsRegistry.state.currentExitDemandBalance")) - 1);
+
+    function get() internal view returns (uint256) { ... }
+    function set(uint256 _newValue) internal { ... }
+}
+```
+
+### Step 2: ConsensusLayerDepositManager — track deposits as ETH
+
+**File: `contracts/src/components/ConsensusLayerDepositManager.1.sol`**
+
+Add new virtual function for tracking in-flight balance:
+
+```solidity
+/// @notice Handler called to increase the in-flight deposit balance
+/// @param _amount The amount deposited
+function _increaseInFlightDepositBalance(uint256 _amount) internal virtual;
+```
+
+In `depositToConsensusLayerWithDepositRoot()`, after the deposit loop (line ~147):
+
+```solidity
+// EXISTING:
+_setCommittedBalance(committedBalance - DEPOSIT_SIZE * receivedPublicKeyCount);
+uint256 currentDepositedValidatorCount = DepositedValidatorCount.get();
+DepositedValidatorCount.set(currentDepositedValidatorCount + receivedPublicKeyCount);
+
+// NEW: Track ETH in flight
+_increaseInFlightDepositBalance(DEPOSIT_SIZE * receivedPublicKeyCount);
+```
+
+Implemented in River.1.sol:
+```solidity
+function _increaseInFlightDepositBalance(uint256 _amount) internal override {
+    uint256 current = InFlightDepositBalance.get();
+    InFlightDepositBalance.set(current + _amount);
+    emit SetInFlightDepositBalance(current, current + _amount);
+}
+```
+
+**Note:** `DepositedValidatorCount` is still maintained (for CL validation in oracle reports, operator accounting) but no longer used in `_assetBalance()`.
+
+### Step 3: OracleManager — decrement InFlightDepositBalance on validator activation
+
+**File: `contracts/src/components/OracleManager.1.sol`**
+
+New virtual function:
+```solidity
+/// @notice Handler called to decrease the in-flight deposit balance when validators activate
+/// @param _newValidatorCount The number of newly activated validators
+function _decreaseInFlightDepositBalance(uint32 _newValidatorCount) internal virtual;
+```
+
+In `setConsensusLayerData()`, after storing the new report (where `validatorsCount` is updated):
+
+```solidity
+{
+    uint32 lastCount = lastStoredReport.validatorsCount;
+    uint32 newCount = _report.validatorsCount;
+    if (newCount > lastCount) {
+        _decreaseInFlightDepositBalance(newCount - lastCount);
+    }
+}
+```
+
+Implemented in River.1.sol:
+```solidity
+function _decreaseInFlightDepositBalance(uint32 _newValidatorCount) internal override {
+    uint256 activatedBalance = uint256(_newValidatorCount) * DEPOSIT_SIZE;
+    uint256 current = InFlightDepositBalance.get();
+    uint256 newValue = current > activatedBalance ? current - activatedBalance : 0;
+    InFlightDepositBalance.set(newValue);
+    emit SetInFlightDepositBalance(current, newValue);
+}
+```
+
+**Why `* DEPOSIT_SIZE` is still correct here:** Each new validator was deposited at exactly 32 ETH. This is a deposit mechanical fact (beacon deposit contract requires 32 ETH), not a balance accounting assumption. We're converting a count delta into the ETH delta it represents.
+
+### Step 4: River — modified _assetBalance()
+
+**File: `contracts/src/River.1.sol`** (line ~392)
+
+```solidity
+// OLD:
+function _assetBalance() internal view override returns (uint256) {
+    IOracleManagerV1.StoredConsensusLayerReport storage storedReport = LastConsensusLayerReport.get();
+    uint256 clValidatorCount = storedReport.validatorsCount;
+    uint256 depositedValidatorCount = DepositedValidatorCount.get();
+    if (clValidatorCount < depositedValidatorCount) {
+        return storedReport.validatorsBalance + BalanceToDeposit.get() + CommittedBalance.get()
+            + BalanceToRedeem.get() + (depositedValidatorCount - clValidatorCount)
+            * ConsensusLayerDepositManagerV1.DEPOSIT_SIZE;
+    } else {
+        return
+            storedReport.validatorsBalance + BalanceToDeposit.get() + CommittedBalance.get() + BalanceToRedeem.get();
+    }
+}
+
+// NEW:
+function _assetBalance() internal view override returns (uint256) {
+    IOracleManagerV1.StoredConsensusLayerReport storage storedReport = LastConsensusLayerReport.get();
+    return storedReport.validatorsBalance
+        + BalanceToDeposit.get()
+        + CommittedBalance.get()
+        + BalanceToRedeem.get()
+        + InFlightDepositBalance.get();
+}
+```
+
+No branching. No count arithmetic. Direct ETH amount.
+
+### Step 5: OperatorsRegistry — ETH-based exit demand
+
+**File: `contracts/src/OperatorsRegistry.1.sol`**
+
+New function alongside existing `demandValidatorExits`:
+
+```solidity
+/// @notice Demands exit balance from the system (ETH-based)
+/// @param _ethAmount The amount of ETH needed from exits
+function demandExitBalance(uint256 _ethAmount) external onlyRiver {
+    uint256 currentDemand = CurrentExitDemandBalance.get();
+    CurrentExitDemandBalance.set(currentDemand + _ethAmount);
+    emit SetCurrentExitDemandBalance(currentDemand, currentDemand + _ethAmount);
+}
+
+/// @notice Get the current exit demand in ETH
+function getCurrentExitDemandBalance() external view returns (uint256) {
+    return CurrentExitDemandBalance.get();
+}
+```
+
+### Step 6: River — ETH-based exit demand calculation
+
+**File: `contracts/src/River.1.sol`** — `_requestExitsBasedOnRedeemDemandAfterRebalancings()`
+
+```solidity
+// OLD (lines 545-562):
+// (uint256 totalStoppedValidatorCount, uint256 totalRequestedExitsCount) =
+//     or.getStoppedAndRequestedExitCounts();
+// uint256 preExitingBalance =
+//     (totalRequestedExitsCount > totalStoppedValidatorCount
+//         ? (totalRequestedExitsCount - totalStoppedValidatorCount) : 0) * DEPOSIT_SIZE;
+// if (availableBalanceToRedeem + _exitingBalance + preExitingBalance < redeemManagerDemandInEth) {
+//     uint256 validatorCountToExit = LibUint256.ceil(
+//         redeemManagerDemandInEth - (availableBalanceToRedeem + _exitingBalance + preExitingBalance),
+//         DEPOSIT_SIZE
+//     );
+//     or.demandValidatorExits(validatorCountToExit, DepositedValidatorCount.get());
+// }
+
+// NEW:
+uint256 preExitingBalance = PendingFullExitBalance.get(); // + PendingPartialExitBalance (added in V2)
+
+if (availableBalanceToRedeem + _exitingBalance + preExitingBalance < redeemManagerDemandInEth) {
+    uint256 exitDemand = redeemManagerDemandInEth
+        - (availableBalanceToRedeem + _exitingBalance + preExitingBalance);
+
+    IOperatorsRegistryV1(OperatorsRegistryAddress.get()).demandExitBalance(exitDemand);
+}
+```
+
+### Step 7: Keeper exit request — bridge ETH amounts to operator counts
+
+**File: `contracts/src/River.1.sol`**
+
+The keeper must provide both ETH amounts (for system accounting) and operator allocations (for operator tracking). New struct and function:
+
+```solidity
+struct FullExitRequest {
+    uint256 operatorIndex;
+    bytes pubkey;              // 48 bytes
+    uint256 expectedBalance;   // actual CL balance from keeper
+}
+
+/// @notice Keeper requests full validator exits with ETH amounts
+/// @param _exits The full exit requests with actual validator balances
+function requestFullExits(FullExitRequest[] calldata _exits) external {
+    if (msg.sender != KeeperAddress.get()) {
+        revert OnlyKeeper();
+    }
+
+    uint256 totalExitBalance = 0;
+
+    // Build operator allocations for OperatorsRegistry (count-based, for operator tracking)
+    // And accumulate ETH amounts for system accounting
+    for (uint256 i = 0; i < _exits.length; ++i) {
+        totalExitBalance += _exits[i].expectedBalance;
+    }
+
+    // Update system-level ETH tracking
+    PendingFullExitBalance.set(PendingFullExitBalance.get() + totalExitBalance);
+
+    // Decrement ETH demand
+    uint256 currentDemand = IOperatorsRegistryV1(OperatorsRegistryAddress.get())
+        .getCurrentExitDemandBalance();
+    uint256 filledDemand = LibUint256.min(totalExitBalance, currentDemand);
+    if (filledDemand > 0) {
+        IOperatorsRegistryV1(OperatorsRegistryAddress.get())
+            .fillExitDemandBalance(filledDemand);
+    }
+
+    // Route to OperatorsRegistry for operator-level count tracking
+    // (aggregate by operator, build OperatorAllocation[])
+    _routeFullExitsToOperatorRegistry(_exits);
+
+    emit FullExitsRequested(totalExitBalance, _exits.length);
+}
+```
+
+New function on OperatorsRegistry:
+```solidity
+/// @notice Fills exit demand balance (ETH-based), called by River
+/// @param _ethAmount The amount of ETH being filled
+function fillExitDemandBalance(uint256 _ethAmount) external onlyRiver {
+    uint256 currentDemand = CurrentExitDemandBalance.get();
+    uint256 filled = LibUint256.min(_ethAmount, currentDemand);
+    CurrentExitDemandBalance.set(currentDemand - filled);
+    emit SetCurrentExitDemandBalance(currentDemand, currentDemand - filled);
+}
+```
+
+### Step 8: Oracle — reconcile PendingFullExitBalance
+
+**File: `contracts/src/components/OracleManager.1.sol`**
+
+When the oracle reports `validatorsExitedBalance` increase, some of that is from full exits. In `setConsensusLayerData()`:
+
+```solidity
+// exitedAmountIncrease already computed (existing code)
+// In V2, partialExitIncrease will be subtracted. For V0, all exited = full exits.
+if (exitedAmountIncrease > 0) {
+    _reconcileFullExits(exitedAmountIncrease);
+}
+```
+
+New virtual function:
+```solidity
+function _reconcileFullExits(uint256 _exitedIncrease) internal virtual;
+```
+
+Implemented in River.1.sol:
+```solidity
+function _reconcileFullExits(uint256 _exitedIncrease) internal override {
+    uint256 currentPending = PendingFullExitBalance.get();
+    uint256 reconcileAmount = LibUint256.min(_exitedIncrease, currentPending);
+    if (reconcileAmount > 0) {
+        PendingFullExitBalance.set(currentPending - reconcileAmount);
+        emit FullExitsReconciled(_exitedIncrease, reconcileAmount);
+    }
+}
+```
+
+**Note:** In V2, partial exit reconciliation happens first (`_exitedIncrease -= partialExitDelta`), then the remainder reconciles `PendingFullExitBalance`.
+
+### Step 9: Unsolicited exits — handle in ETH terms
+
+**File: `contracts/src/OperatorsRegistry.1.sol`** — `_setStoppedValidatorCounts()`
+
+Currently, unsolicited exits (operators exiting without being asked) decrement `CurrentValidatorExitsDemand` (count-based). We need to also decrement `CurrentExitDemandBalance`.
+
+In the unsolicited exit handling (lines 644-650, 667-673):
+
+```solidity
+// EXISTING (keep for operator tracking):
+if (_stoppedValidatorCounts[idx] > operators[idx - 1].requestedExits) {
+    unsolicitedExitsSum += _stoppedValidatorCounts[idx] - operators[idx - 1].requestedExits;
+    operators[idx - 1].requestedExits = _stoppedValidatorCounts[idx];
+}
+
+// EXISTING (keep):
+vars.currentValidatorExitsDemand -= LibUint256.min(unsolicitedExitsSum, vars.currentValidatorExitsDemand);
+
+// NEW: Also decrement ETH-based demand (conservative estimate: count * 32 ETH)
+// This is a rough estimate since we don't know actual validator balances here.
+// The real reconciliation happens when exited funds arrive via oracle report.
+uint256 unsolicitedExitBalanceEstimate = unsolicitedExitsSum * 32 ether;
+uint256 currentEthDemand = CurrentExitDemandBalance.get();
+CurrentExitDemandBalance.set(
+    currentEthDemand > unsolicitedExitBalanceEstimate
+        ? currentEthDemand - unsolicitedExitBalanceEstimate
+        : 0
+);
+```
+
+**Note:** Using `32 ether` as estimate for unsolicited exits is acceptable here because:
+1. It's a demand reduction (conservative is fine — might under-reduce, but keeper will fill the rest)
+2. The actual ETH reconciliation happens via `PendingFullExitBalance` when oracle reports exited funds
+3. Post-V2, unsolicited exits of >32 ETH validators will be more accurately handled as the keeper provides actual balances
+
+### Step 10: Interface updates
+
+**File: `contracts/src/interfaces/IRiver.1.sol`**
+
+Add:
+- `FullExitRequest` struct
+- `requestFullExits(FullExitRequest[])` signature
+- `getInFlightDepositBalance()` view
+- `getPendingFullExitBalance()` view
+- Events: `SetInFlightDepositBalance`, `FullExitsRequested`, `FullExitsReconciled`
+
+**File: `contracts/src/interfaces/IOperatorRegistry.1.sol`**
+
+Add:
+- `demandExitBalance(uint256)` signature
+- `fillExitDemandBalance(uint256)` signature
+- `getCurrentExitDemandBalance()` view
+- Event: `SetCurrentExitDemandBalance`
+
+### Step 11: Migration (initRiverV1_3)
+
+**File: `contracts/src/River.1.sol`**
+
+```solidity
+function initRiverV1_3() external init(3) {
+    // Initialize InFlightDepositBalance from current state
+    uint256 depositedCount = DepositedValidatorCount.get();
+    uint256 clCount = LastConsensusLayerReport.get().validatorsCount;
+    if (depositedCount > clCount) {
+        uint256 inFlight = (depositedCount - clCount) * DEPOSIT_SIZE;
+        InFlightDepositBalance.set(inFlight);
+        emit SetInFlightDepositBalance(0, inFlight);
+    }
+
+    // PendingFullExitBalance starts at 0 (no pending exits tracked in ETH yet)
+    // Any existing pre-exiting validators will be reconciled as their exits complete
+}
+```
+
+**File: `contracts/src/OperatorsRegistry.1.sol`**
+
+```solidity
+function initOperatorsRegistryV1_3() external init(X) {
+    // Initialize CurrentExitDemandBalance from count-based demand
+    uint256 countDemand = CurrentValidatorExitsDemand.get();
+    uint256 ethDemand = countDemand * 32 ether; // conservative estimate
+    CurrentExitDemandBalance.set(ethDemand);
+    emit SetCurrentExitDemandBalance(0, ethDemand);
+}
+```
+
+### Step 12: Tests
+
+1. **Unit: InFlightDepositBalance tracking**
+   - Incremented by 32 ETH per deposit in `depositToConsensusLayerWithDepositRoot`
+   - Decremented when oracle reports new validators
+   - Multiple deposits in single call tracked correctly
+   - Underflow protection (floors at 0)
+
+2. **Unit: _assetBalance() without count arithmetic**
+   - Returns correct value with InFlightDepositBalance > 0
+   - No branching on depositedCount vs clCount
+   - Consistent with old calculation for same state
+
+3. **Unit: ETH-based exit demand**
+   - `demandExitBalance(ethAmount)` increments `CurrentExitDemandBalance`
+   - `fillExitDemandBalance(ethAmount)` decrements correctly
+   - Underflow protection
+
+4. **Unit: requestFullExits**
+   - Only keeper
+   - `PendingFullExitBalance` incremented by sum of `expectedBalance`
+   - `CurrentExitDemandBalance` decremented
+   - Operator-level counts still updated
+
+5. **Unit: Oracle reconciliation of full exits**
+   - `PendingFullExitBalance` decremented by exited amount increase
+   - Underflow protection
+
+6. **Unit: preExitingBalance is ETH-based**
+   - Uses `PendingFullExitBalance` not count * 32
+   - Exit demand calculation in ETH
+
+7. **Unit: Unsolicited exits**
+   - `CurrentExitDemandBalance` decremented alongside count-based demand
+   - Conservative estimate doesn't under-count
+
+8. **Integration: Full lifecycle**
+   - Deposit → InFlightDepositBalance goes up → oracle activates → goes down
+   - Redeem demand → exit demand in ETH → keeper requests exits with actual balances → oracle reports → PendingFullExitBalance reconciled
+
+9. **Migration: initRiverV1_3**
+   - InFlightDepositBalance correctly initialized from current state
+   - CurrentExitDemandBalance correctly initialized from count-based demand
+   - _assetBalance() returns same value before and after migration
+
+---
+
+## Files Created/Modified Summary
+
+| Action | File |
+|--------|------|
+| **Create** | `contracts/src/state/river/InFlightDepositBalance.sol` |
+| **Create** | `contracts/src/state/river/PendingFullExitBalance.sol` |
+| **Create** | `contracts/src/state/operatorsRegistry/CurrentExitDemandBalance.sol` |
+| **Modify** | `contracts/src/components/ConsensusLayerDepositManager.1.sol` — call `_increaseInFlightDepositBalance()` after deposits |
+| **Modify** | `contracts/src/components/OracleManager.1.sol` — call `_decreaseInFlightDepositBalance()` on new validators, `_reconcileFullExits()` on exited balance increase |
+| **Modify** | `contracts/src/River.1.sol` — `_assetBalance()` uses `InFlightDepositBalance`, new `_increaseInFlightDepositBalance()`, `_decreaseInFlightDepositBalance()`, `_reconcileFullExits()`, `requestFullExits()`, modified exit demand calc, `initRiverV1_3()` |
+| **Modify** | `contracts/src/OperatorsRegistry.1.sol` — new `demandExitBalance()`, `fillExitDemandBalance()`, `getCurrentExitDemandBalance()`, unsolicited exit ETH handling, `initOperatorsRegistryV1_3()` |
+| **Modify** | `contracts/src/interfaces/IRiver.1.sol` — new structs, functions, events |
+| **Modify** | `contracts/src/interfaces/IOperatorRegistry.1.sol` — new functions, events |
+| **Create** | Test files |
+
+---
+
+## What DEPOSIT_SIZE is still used for (deposit mechanics only)
+
+| Location | Use | Why it stays |
+|----------|-----|-------------|
+| `ConsensusLayerDepositManager._depositValidator()` | Deposit exactly 32 ETH to beacon contract | Beacon chain requires 32 ETH deposits |
+| `ConsensusLayerDepositManager.depositToConsensusLayer()` | `committedBalance / DEPOSIT_SIZE` = max deposits | Need to know how many 32 ETH deposits fit |
+| `River._commitBalanceToDeposit()` | Round to multiples of 32 ETH | Committed balance must be exact multiples |
+| `River._increaseInFlightDepositBalance()` | `+= DEPOSIT_SIZE * count` | Each deposit adds exactly 32 ETH |
+| `River._decreaseInFlightDepositBalance()` | `newValidators * DEPOSIT_SIZE` | Each activated validator was deposited at 32 ETH |
+
+All of these are **deposit mechanical facts** — the beacon deposit contract requires exactly 32 ETH per validator. This is not a balance accounting assumption.
+
+## What is NO LONGER used for accounting
+
+| Old | New |
+|-----|-----|
+| `(depositedCount - clCount) * 32` in `_assetBalance()` | `InFlightDepositBalance.get()` |
+| `(requestedExits - stopped) * 32` for pre-exiting | `PendingFullExitBalance.get()` |
+| `ceil(shortfall / 32)` for exit demand count | `shortfall` ETH directly via `demandExitBalance()` |
+| `demandValidatorExits(count)` | `demandExitBalance(ethAmount)` |

--- a/docs/V1-plan.md
+++ b/docs/V1-plan.md
@@ -1,0 +1,295 @@
+---
+shaping: true
+---
+
+# V1 Plan: Validator Consolidation (Happy Path)
+
+**Parts:** A1, A2, A3, A4, A5
+**Demo:** User requests consolidation → keeper executes → LsETH minted → oracle reconciles → conversion rate unchanged.
+
+---
+
+## Step-by-step Implementation
+
+### Step 1: New state storage files
+
+Create unstructured storage libraries following existing pattern (e.g., `BalanceToDeposit.sol`).
+
+**File: `contracts/src/state/river/PendingConsolidationBalance.sol`**
+```solidity
+library PendingConsolidationBalance {
+    bytes32 internal constant PENDING_CONSOLIDATION_BALANCE_SLOT =
+        bytes32(uint256(keccak256("river.state.pendingConsolidationBalance")) - 1);
+
+    function get() internal view returns (uint256) { ... }
+    function set(uint256 _newValue) internal { ... }
+}
+```
+
+**File: `contracts/src/state/river/ConsolidationRequests.sol`**
+
+Storage for the consolidation request array and source→requestId mapping. This is more complex than a simple uint256 — needs a struct array and a mapping.
+
+```solidity
+struct ConsolidationRequest {
+    bytes32 sourcePubkeyHash;
+    bytes32 targetPubkeyHash;
+    address recipient;
+    uint256 expectedBalance;
+    uint256 reconciledBalance;
+    uint64 requestTimestamp;
+    uint8 status; // 0=REQUESTED, 1=PENDING, 2=COMPLETED, 3=FAILED
+}
+```
+
+Options for storage:
+- **A)** Use a dedicated storage contract/library with unstructured storage for the array length and a mapping for elements (similar to `RedeemQueue.2.sol` pattern).
+- **B)** Use a simpler mapping-based approach: `mapping(uint256 => ConsolidationRequest)` + counter.
+
+Recommend **B** — simpler, no need for queue semantics. Consolidations are indexed by ID, not ordered.
+
+**File: `contracts/src/state/river/ConsolidationRequestCount.sol`**
+```solidity
+library ConsolidationRequestCount {
+    bytes32 internal constant CONSOLIDATION_REQUEST_COUNT_SLOT =
+        bytes32(uint256(keccak256("river.state.consolidationRequestCount")) - 1);
+    function get() internal view returns (uint256) { ... }
+    function set(uint256 _newValue) internal { ... }
+}
+```
+
+### Step 2: Allowlist — add CONSOLIDATION_MASK
+
+**File: `contracts/src/libraries/LibAllowlistMasks.sol`**
+
+Add:
+```solidity
+uint256 internal constant CONSOLIDATION_MASK = 0x8; // bit 4
+```
+
+No changes to Allowlist.1.sol itself — the bitmask system is generic.
+
+### Step 3: Oracle report structs — add validatorsConsolidatedBalance
+
+**File: `contracts/src/interfaces/components/IOracleManager.1.sol`**
+
+Extend `ConsensusLayerReport`:
+```solidity
+struct ConsensusLayerReport {
+    // ... existing fields ...
+    uint256 validatorsConsolidatedBalance; // NEW: cumulative, non-decreasing
+}
+```
+
+Extend `StoredConsensusLayerReport`:
+```solidity
+struct StoredConsensusLayerReport {
+    // ... existing fields ...
+    uint256 validatorsConsolidatedBalance; // NEW
+}
+```
+
+### Step 4: River — requestConsolidation()
+
+**File: `contracts/src/River.1.sol`**
+
+New imports: `PendingConsolidationBalance`, `ConsolidationRequests` state, new interface methods.
+
+```solidity
+function requestConsolidation(
+    bytes calldata _sourcePubkey,
+    bytes calldata _targetPubkey
+) external returns (uint256 requestId) {
+    // 1. Allowlist check
+    IAllowlistV1(AllowlistAddress.get()).onlyAllowed(msg.sender, LibAllowlistMasks.CONSOLIDATION_MASK);
+
+    // 2. Validate pubkey lengths
+    if (_sourcePubkey.length != PUBLIC_KEY_LENGTH) revert InvalidPublicKeyLength();
+    if (_targetPubkey.length != PUBLIC_KEY_LENGTH) revert InvalidPublicKeyLength();
+
+    // 3. Validate target belongs to LC (check OperatorsRegistry)
+    // IOperatorsRegistryV1(OperatorsRegistryAddress.get()).isValidatorKey(_targetPubkey);
+
+    // 4. Store request
+    requestId = ConsolidationRequestCount.get();
+    // Store ConsolidationRequest at requestId
+    // { sourcePubkeyHash, targetPubkeyHash, msg.sender, 0, 0, 0, REQUESTED }
+    ConsolidationRequestCount.set(requestId + 1);
+
+    // 5. Index by source for oracle lookup
+    // consolidationRequestBySource[keccak256(_sourcePubkey)] = requestId
+
+    emit ConsolidationRequested(requestId, msg.sender, _sourcePubkey, _targetPubkey);
+}
+```
+
+### Step 5: River — executeConsolidation()
+
+```solidity
+function executeConsolidation(
+    uint256 _requestId,
+    uint256 _expectedBalance
+) external {
+    // 1. Only keeper
+    if (msg.sender != KeeperAddress.get()) revert OnlyKeeper();
+
+    // 2. Load and validate request
+    // request = consolidationRequests[_requestId]
+    // require(request.status == REQUESTED)
+
+    // 3. Record expected balance and update status
+    // request.expectedBalance = _expectedBalance
+    // request.requestTimestamp = uint64(block.timestamp)
+    // request.status = PENDING
+
+    // 4. Increment buffer (ATOMIC with minting)
+    PendingConsolidationBalance.set(
+        PendingConsolidationBalance.get() + _expectedBalance
+    );
+
+    // 5. Mint LsETH to recipient at current conversion rate
+    uint256 mintedShares = SharesManagerV1._mintShares(request.recipient, _expectedBalance);
+
+    // 6. Submit consolidation request to CL system contract
+    //    via Withdraw contract (it's the withdrawal credentials address)
+    //    OR directly if the source's withdrawal credentials initiate
+    //    (depends on EIP-7251 exact mechanics)
+
+    emit ConsolidationExecuted(_requestId, request.recipient, _expectedBalance, mintedShares);
+}
+```
+
+### Step 6: River — modified _assetBalance()
+
+**File: `contracts/src/River.1.sol`** (line ~392)
+
+**Prerequisite:** V0 (ETH-based accounting) must be in place. `InFlightDepositBalance` replaces `(depositedCount - clCount) * 32`.
+
+```solidity
+function _assetBalance() internal view override returns (uint256) {
+    IOracleManagerV1.StoredConsensusLayerReport storage storedReport = LastConsensusLayerReport.get();
+    return storedReport.validatorsBalance
+        + BalanceToDeposit.get()
+        + CommittedBalance.get()
+        + BalanceToRedeem.get()
+        + PendingConsolidationBalance.get()   // NEW (V1)
+        + InFlightDepositBalance.get();        // from V0 (replaces count * 32)
+}
+```
+
+### Step 7: OracleManager — consolidation reconciliation in setConsensusLayerData
+
+**File: `contracts/src/components/OracleManager.1.sol`**
+
+In `setConsensusLayerData`, after pulling CL funds and before computing postReportUnderlyingBalance:
+
+```solidity
+// Reconcile consolidations
+{
+    uint256 lastConsolidatedBalance = lastStoredReport.validatorsConsolidatedBalance;
+    if (_report.validatorsConsolidatedBalance < lastConsolidatedBalance) {
+        revert InvalidDecreasingValidatorsConsolidatedBalance(
+            lastConsolidatedBalance, _report.validatorsConsolidatedBalance
+        );
+    }
+    uint256 consolidatedIncrease = _report.validatorsConsolidatedBalance - lastConsolidatedBalance;
+    if (consolidatedIncrease > 0) {
+        _reconcileConsolidations(consolidatedIncrease);
+    }
+}
+```
+
+New virtual function:
+```solidity
+function _reconcileConsolidations(uint256 _consolidatedIncrease) internal virtual;
+```
+
+Implemented in River.1.sol:
+```solidity
+function _reconcileConsolidations(uint256 _consolidatedIncrease) internal override {
+    uint256 currentPending = PendingConsolidationBalance.get();
+    uint256 reconcileAmount = LibUint256.min(_consolidatedIncrease, currentPending);
+    PendingConsolidationBalance.set(currentPending - reconcileAmount);
+    emit ConsolidationReconciled(_consolidatedIncrease, reconcileAmount);
+}
+```
+
+Update stored report to include `validatorsConsolidatedBalance`:
+```solidity
+storedReport.validatorsConsolidatedBalance = _report.validatorsConsolidatedBalance;
+```
+
+### Step 8: Interface updates
+
+**File: `contracts/src/interfaces/IRiver.1.sol`**
+
+Add:
+- `requestConsolidation()` signature
+- `executeConsolidation()` signature
+- `getConsolidationRequest(uint256 requestId)` view
+- `getPendingConsolidationBalance()` view
+- New events: `ConsolidationRequested`, `ConsolidationExecuted`, `ConsolidationReconciled`
+- New errors: `InvalidPublicKeyLength`, `InvalidConsolidationStatus`, `InvalidDecreasingValidatorsConsolidatedBalance`
+
+### Step 9: Version bump
+
+**File: `contracts/src/River.1.sol`**
+
+```solidity
+function version() external pure returns (string memory) {
+    return "1.3.0";
+}
+```
+
+Also Withdraw.1.sol if modified in V2.
+
+### Step 10: Tests
+
+1. **Unit: requestConsolidation**
+   - Allowlist check (CONSOLIDATION_MASK required, denied address reverts)
+   - Invalid pubkey length reverts
+   - Request stored correctly, ID incremented
+   - Event emitted
+
+2. **Unit: executeConsolidation**
+   - Only keeper can call
+   - Request must be in REQUESTED status
+   - PendingConsolidationBalance incremented by expectedBalance
+   - LsETH minted to recipient at correct conversion rate
+   - Request status updated to PENDING
+
+3. **Unit: _assetBalance()**
+   - Returns correct value with PendingConsolidationBalance > 0
+   - Combined with in-flight validators
+
+4. **Unit: oracle reconciliation**
+   - validatorsConsolidatedBalance delta decrements PendingConsolidationBalance
+   - Underflow protection (min with current pending)
+   - Conversion rate unaffected (delta cancels out)
+   - Bounds check not tripped by consolidation
+
+5. **Integration: full consolidation lifecycle**
+   - requestConsolidation → executeConsolidation → oracle report with validatorsConsolidatedBalance increase
+   - Verify: LsETH balance, conversion rate before/after, PendingConsolidationBalance = 0 after reconciliation
+
+6. **Edge: multiple concurrent consolidations**
+   - Two consolidations in flight, oracle reconciles both in one report
+
+7. **Edge: oracle reports more consolidated than pending**
+   - PendingConsolidationBalance floors at 0 (rogue/unexpected consolidation = gift to protocol)
+
+---
+
+## Files Created/Modified Summary
+
+| Action | File |
+|--------|------|
+| **Create** | `contracts/src/state/river/PendingConsolidationBalance.sol` |
+| **Create** | `contracts/src/state/river/ConsolidationRequests.sol` (struct + storage) |
+| **Create** | `contracts/src/state/river/ConsolidationRequestCount.sol` |
+| **Modify** | `contracts/src/libraries/LibAllowlistMasks.sol` — add `CONSOLIDATION_MASK` |
+| **Modify** | `contracts/src/interfaces/components/IOracleManager.1.sol` — extend report structs |
+| **Modify** | `contracts/src/interfaces/IRiver.1.sol` — add consolidation functions, events, errors |
+| **Modify** | `contracts/src/River.1.sol` — `requestConsolidation`, `executeConsolidation`, `_assetBalance`, `_reconcileConsolidations`, version bump |
+| **Modify** | `contracts/src/components/OracleManager.1.sol` — consolidation reconciliation in `setConsensusLayerData`, new virtual fn |
+| **Create** | Test files for consolidation lifecycle |

--- a/docs/V2-plan.md
+++ b/docs/V2-plan.md
@@ -1,0 +1,320 @@
+---
+shaping: true
+---
+
+# V2 Plan: Partial Exits via EIP-7002
+
+**Parts:** A6, A7
+**Demo:** Redeem demand → keeper triggers partial exits → funds arrive → redemption satisfied faster.
+**Independent of V1** — can be developed in parallel.
+
+---
+
+## Step-by-step Implementation
+
+### Step 1: New state storage
+
+**File: `contracts/src/state/river/PendingPartialExitBalance.sol`**
+```solidity
+library PendingPartialExitBalance {
+    bytes32 internal constant PENDING_PARTIAL_EXIT_BALANCE_SLOT =
+        bytes32(uint256(keccak256("river.state.pendingPartialExitBalance")) - 1);
+
+    function get() internal view returns (uint256) { ... }
+    function set(uint256 _newValue) internal { ... }
+}
+```
+
+### Step 2: Withdraw contract — requestWithdrawal()
+
+**File: `contracts/src/Withdraw.1.sol`**
+
+New constant for the EIP-7002 withdrawal request system contract address:
+```solidity
+address public constant WITHDRAWAL_REQUEST_CONTRACT = 0x0c15F14308530b7CDB8460094BbB9cC28b9AaaAA;
+// Actual address TBD — use the canonical Pectra system contract address
+```
+
+New function:
+```solidity
+/// @notice Submits a withdrawal request to the EIP-7002 system contract
+/// @param _pubkey The 48-byte validator public key
+/// @param _amountInGwei The withdrawal amount in gwei (0 = full exit)
+function requestWithdrawal(bytes calldata _pubkey, uint64 _amountInGwei) external onlyRiver {
+    if (_pubkey.length != 48) {
+        revert InvalidPublicKeyLength();
+    }
+
+    // Encode request: pubkey (48 bytes) ++ amount (8 bytes, little-endian)
+    bytes memory request = abi.encodePacked(_pubkey, _toLittleEndian64(_amountInGwei));
+
+    // Get the current fee from the system contract
+    // The fee is dynamic (EIP-1559-like) and must be read before calling
+    uint256 fee = _getWithdrawalRequestFee();
+
+    // Call the EIP-7002 system contract
+    (bool success,) = WITHDRAWAL_REQUEST_CONTRACT.call{value: fee}(request);
+    if (!success) {
+        revert WithdrawalRequestFailed();
+    }
+
+    emit WithdrawalRequested(_pubkey, _amountInGwei, fee);
+}
+
+/// @notice Get the current EIP-7002 withdrawal request fee
+function getWithdrawalRequestFee() external view returns (uint256) {
+    return _getWithdrawalRequestFee();
+}
+
+function _getWithdrawalRequestFee() internal view returns (uint256) {
+    // Read fee from system contract (first 32 bytes of static call return)
+    (bool success, bytes memory data) = WITHDRAWAL_REQUEST_CONTRACT.staticcall("");
+    if (!success || data.length < 32) {
+        revert CannotReadWithdrawalFee();
+    }
+    return abi.decode(data, (uint256));
+}
+
+function _toLittleEndian64(uint64 _value) internal pure returns (bytes8) {
+    // Convert uint64 to little-endian bytes8
+    // Implementation follows LibUint256.toLittleEndian64 pattern
+}
+```
+
+**File: `contracts/src/interfaces/IWithdraw.1.sol`**
+
+Add:
+- `requestWithdrawal(bytes calldata, uint64)` signature
+- `getWithdrawalRequestFee()` view
+- New events: `WithdrawalRequested`
+- New errors: `InvalidPublicKeyLength`, `WithdrawalRequestFailed`, `CannotReadWithdrawalFee`
+
+Version bump Withdraw to `1.3.0`.
+
+### Step 3: River — new requestExits() function
+
+**File: `contracts/src/River.1.sol`**
+
+New structs (in interface):
+```solidity
+struct PartialExitRequest {
+    bytes pubkey;       // 48 bytes
+    uint64 amountInGwei;
+}
+
+struct ExitRequest {
+    PartialExitRequest[] partialExits;
+    IOperatorsRegistryV1.OperatorAllocation[] fullExits;
+}
+```
+
+New function:
+```solidity
+/// @notice Keeper submits a mix of partial and full exit requests
+/// @param _request The combined exit request
+function requestExits(IRiverV1.ExitRequest calldata _request) external {
+    if (msg.sender != KeeperAddress.get()) {
+        revert OnlyKeeper();
+    }
+
+    uint256 totalPartialExitAmount = 0;
+
+    // Process partial exits via Withdraw → EIP-7002
+    IWithdrawV1 withdraw = IWithdrawV1(WithdrawalCredentials.getAddress());
+    for (uint256 i = 0; i < _request.partialExits.length; ++i) {
+        uint256 amount = uint256(_request.partialExits[i].amountInGwei) * 1 gwei;
+        withdraw.requestWithdrawal(
+            _request.partialExits[i].pubkey,
+            _request.partialExits[i].amountInGwei
+        );
+        totalPartialExitAmount += amount;
+    }
+
+    // Track pending partial exits
+    if (totalPartialExitAmount > 0) {
+        PendingPartialExitBalance.set(
+            PendingPartialExitBalance.get() + totalPartialExitAmount
+        );
+        emit PartialExitsRequested(totalPartialExitAmount, _request.partialExits.length);
+    }
+
+    // Process full exits via existing OperatorsRegistry flow
+    if (_request.fullExits.length > 0) {
+        IOperatorsRegistryV1(OperatorsRegistryAddress.get())
+            .requestValidatorExits(_request.fullExits);
+    }
+}
+```
+
+### Step 4: Oracle report structs — add validatorsPartiallyExitedBalance
+
+**File: `contracts/src/interfaces/components/IOracleManager.1.sol`**
+
+Extend `ConsensusLayerReport`:
+```solidity
+uint256 validatorsPartiallyExitedBalance; // NEW: cumulative, non-decreasing
+```
+
+Extend `StoredConsensusLayerReport`:
+```solidity
+uint256 validatorsPartiallyExitedBalance; // NEW
+```
+
+### Step 5: OracleManager — partial exit reconciliation
+
+**File: `contracts/src/components/OracleManager.1.sol`**
+
+In `setConsensusLayerData`, after existing validations:
+
+```solidity
+// Validate partiallyExitedBalance is non-decreasing
+if (_report.validatorsPartiallyExitedBalance < lastStoredReport.validatorsPartiallyExitedBalance) {
+    revert InvalidDecreasingValidatorsPartiallyExitedBalance(
+        lastStoredReport.validatorsPartiallyExitedBalance,
+        _report.validatorsPartiallyExitedBalance
+    );
+}
+
+uint256 partialExitIncrease = _report.validatorsPartiallyExitedBalance
+    - lastStoredReport.validatorsPartiallyExitedBalance;
+```
+
+After storing the new report, reconcile:
+```solidity
+if (partialExitIncrease > 0) {
+    _reconcilePartialExits(partialExitIncrease);
+}
+```
+
+New virtual function:
+```solidity
+function _reconcilePartialExits(uint256 _partialExitIncrease) internal virtual;
+```
+
+Implemented in River.1.sol:
+```solidity
+function _reconcilePartialExits(uint256 _partialExitIncrease) internal override {
+    uint256 currentPending = PendingPartialExitBalance.get();
+    uint256 reconcileAmount = LibUint256.min(_partialExitIncrease, currentPending);
+    PendingPartialExitBalance.set(currentPending - reconcileAmount);
+    emit PartialExitsReconciled(_partialExitIncrease, reconcileAmount);
+}
+```
+
+Update stored report:
+```solidity
+storedReport.validatorsPartiallyExitedBalance = _report.validatorsPartiallyExitedBalance;
+```
+
+### Step 6: Modified exit demand calculation
+
+**File: `contracts/src/River.1.sol`** — `_requestExitsBasedOnRedeemDemandAfterRebalancings()`
+
+**Prerequisite:** V0 (ETH-based accounting) must be in place. `PendingFullExitBalance` and `demandExitBalance(ethAmount)` replace count-based logic.
+
+```solidity
+// OLD (count-based):
+// preExitingBalance = (requestedExits - stopped) * DEPOSIT_SIZE;
+// validatorCountToExit = ceil(shortfall / DEPOSIT_SIZE);
+// or.demandValidatorExits(validatorCountToExit);
+
+// NEW (ETH-based, builds on V0):
+uint256 preExitingBalance = PendingFullExitBalance.get() + PendingPartialExitBalance.get();
+
+if (availableBalanceToRedeem + _exitingBalance + preExitingBalance < redeemManagerDemandInEth) {
+    uint256 exitDemand = redeemManagerDemandInEth
+        - (availableBalanceToRedeem + _exitingBalance + preExitingBalance);
+    or.demandExitBalance(exitDemand);
+}
+```
+
+Exit demand is now in ETH. The keeper fills the demand using a mix of partial + full exits with actual CL balances.
+
+### Step 7: Fund routing for partial exits
+
+**Important:** Partial exit funds arrive at the Withdraw contract as CL withdrawals (same as skimming/full exits). The oracle classifies them via `validatorsPartiallyExitedBalance`.
+
+Currently, `_pullCLFunds` routes:
+- Skimmed → `BalanceToDeposit`
+- Exited → `BalanceToRedeem`
+
+Partial exit funds should go to `BalanceToRedeem` (they're satisfying redeem demand). Two options:
+
+**Option A:** Oracle reports partial exit funds within `validatorsExitedBalance` (mixed with full exits). Funds automatically go to `BalanceToRedeem`. `validatorsPartiallyExitedBalance` is used only for reconciling `PendingPartialExitBalance`.
+
+**Option B:** Oracle reports partial exit funds as a separate flow, requiring `_pullCLFunds` to handle a third category.
+
+**Recommend Option A** — simpler, no change to `_pullCLFunds`. The oracle includes partial exit amounts in both `validatorsExitedBalance` (for fund routing) and `validatorsPartiallyExitedBalance` (for pending balance reconciliation).
+
+### Step 8: Interface updates
+
+**File: `contracts/src/interfaces/IRiver.1.sol`**
+
+Add:
+- `ExitRequest` struct, `PartialExitRequest` struct
+- `requestExits(ExitRequest)` signature
+- `getPendingPartialExitBalance()` view
+- New events: `PartialExitsRequested`, `PartialExitsReconciled`
+- New errors: `InvalidDecreasingValidatorsPartiallyExitedBalance`
+
+### Step 9: Withdraw contract — fund the EIP-7002 fee
+
+The Withdraw contract needs ETH to pay EIP-7002 fees. It already holds ETH (exit/skimming funds). The fee is negligible in normal conditions, so the existing balance is sufficient.
+
+If the Withdraw contract balance is too low to cover the fee (edge case), the `requestWithdrawal` call will revert. The keeper should check the fee before submitting.
+
+Add a convenience function on River for the keeper:
+```solidity
+function getWithdrawalRequestFee() external view returns (uint256) {
+    return IWithdrawV1(WithdrawalCredentials.getAddress()).getWithdrawalRequestFee();
+}
+```
+
+### Step 10: Tests
+
+1. **Unit: Withdraw.requestWithdrawal**
+   - Only River can call
+   - Invalid pubkey length reverts
+   - Correct encoding (pubkey + LE amount)
+   - Fee paid correctly
+   - Event emitted
+
+2. **Unit: River.requestExits**
+   - Only keeper can call
+   - Partial exits route through Withdraw
+   - PendingPartialExitBalance incremented correctly
+   - Full exits route through OperatorsRegistry
+   - Mixed partial + full in single call
+
+3. **Unit: Oracle partial exit reconciliation**
+   - validatorsPartiallyExitedBalance delta decrements PendingPartialExitBalance
+   - Non-decreasing validation
+   - Underflow protection
+
+4. **Unit: Modified preExitingBalance**
+   - Includes PendingPartialExitBalance
+   - Correctly reduces exit demand
+
+5. **Integration: partial exit lifecycle**
+   - Redeem demand created → keeper calls requestExits with partial exits → oracle reports → funds in BalanceToRedeem → redemption satisfied
+
+6. **Integration: mixed partial + full exits**
+   - Partial exits cover part of demand, full exits cover remainder
+
+7. **Edge: EIP-7002 fee too high**
+   - Keeper skips partial exits, only submits full exits
+
+---
+
+## Files Created/Modified Summary
+
+| Action | File |
+|--------|------|
+| **Create** | `contracts/src/state/river/PendingPartialExitBalance.sol` |
+| **Modify** | `contracts/src/Withdraw.1.sol` — `requestWithdrawal()`, `getWithdrawalRequestFee()`, version bump |
+| **Modify** | `contracts/src/interfaces/IWithdraw.1.sol` — add new function signatures, events, errors |
+| **Modify** | `contracts/src/interfaces/IRiver.1.sol` — add `ExitRequest` struct, `requestExits()`, events |
+| **Modify** | `contracts/src/interfaces/components/IOracleManager.1.sol` — extend report structs |
+| **Modify** | `contracts/src/components/OracleManager.1.sol` — partial exit reconciliation, new virtual fn |
+| **Modify** | `contracts/src/River.1.sol` — `requestExits()`, `_reconcilePartialExits()`, modified `_requestExitsBasedOnRedeemDemandAfterRebalancings()`, `getWithdrawalRequestFee()` |
+| **Create** | Test files for partial exit lifecycle |

--- a/docs/V3-plan.md
+++ b/docs/V3-plan.md
@@ -1,0 +1,324 @@
+---
+shaping: true
+---
+
+# V3 Plan: Insolvency Protection
+
+**Parts:** A8
+**Demo:** Consolidation fails → detected (oracle or timeout) → buffer written down → CoverageFund donation → recovery.
+**Depends on:** V1 (consolidation must be in place).
+
+---
+
+## Step-by-step Implementation
+
+### Step 1: New state storage for configuration
+
+**File: `contracts/src/state/river/MaxConsolidationDuration.sol`**
+```solidity
+library MaxConsolidationDuration {
+    bytes32 internal constant MAX_CONSOLIDATION_DURATION_SLOT =
+        bytes32(uint256(keccak256("river.state.maxConsolidationDuration")) - 1);
+
+    function get() internal view returns (uint256) { ... }
+    function set(uint256 _newValue) internal { ... }
+}
+```
+
+**File: `contracts/src/state/river/MaxSingleConsolidationAmount.sol`**
+```solidity
+library MaxSingleConsolidationAmount {
+    bytes32 internal constant MAX_SINGLE_CONSOLIDATION_AMOUNT_SLOT =
+        bytes32(uint256(keccak256("river.state.maxSingleConsolidationAmount")) - 1);
+
+    function get() internal view returns (uint256) { ... }
+    function set(uint256 _newValue) internal { ... }
+}
+```
+
+**File: `contracts/src/state/river/MaxTotalPendingConsolidation.sol`**
+```solidity
+library MaxTotalPendingConsolidation {
+    bytes32 internal constant MAX_TOTAL_PENDING_CONSOLIDATION_SLOT =
+        bytes32(uint256(keccak256("river.state.maxTotalPendingConsolidation")) - 1);
+
+    function get() internal view returns (uint256) { ... }
+    function set(uint256 _newValue) internal { ... }
+}
+```
+
+### Step 2: Oracle report — add failedConsolidationIds
+
+**File: `contracts/src/interfaces/components/IOracleManager.1.sol`**
+
+Extend `ConsensusLayerReport`:
+```solidity
+struct ConsensusLayerReport {
+    // ... existing fields (including V1 additions) ...
+    uint32[] failedConsolidationIds; // NEW: request IDs of failed consolidations
+}
+```
+
+Note: `StoredConsensusLayerReport` does NOT need this field — failed IDs are processed immediately and not stored.
+
+### Step 3: River — writeDownFailedConsolidation()
+
+**File: `contracts/src/River.1.sol`**
+
+```solidity
+/// @notice Write down a failed consolidation's pending balance
+/// @dev Callable by admin (timeout path) or internally from oracle report
+/// @param _requestId The consolidation request ID that failed
+function writeDownFailedConsolidation(uint256 _requestId) external {
+    // Allow admin or oracle
+    if (msg.sender != Administrable._getAdmin() && msg.sender != OracleAddress.get()) {
+        revert LibErrors.Unauthorized(msg.sender);
+    }
+
+    _writeDownConsolidation(_requestId);
+}
+
+function _writeDownConsolidation(uint256 _requestId) internal {
+    // Load request
+    ConsolidationRequest storage request = _getConsolidationRequest(_requestId);
+
+    // Must be in PENDING status
+    if (request.status != 1) { // 1 = PENDING
+        revert InvalidConsolidationStatus(_requestId, request.status);
+    }
+
+    // For admin path: enforce timeout
+    if (msg.sender == Administrable._getAdmin()) {
+        uint256 maxDuration = MaxConsolidationDuration.get();
+        if (block.timestamp < request.requestTimestamp + maxDuration) {
+            revert ConsolidationNotTimedOut(_requestId, request.requestTimestamp, maxDuration);
+        }
+    }
+
+    // Calculate failed amount (expected minus any already reconciled)
+    uint256 failedAmount = request.expectedBalance - request.reconciledBalance;
+
+    // Write down buffer
+    uint256 currentPending = PendingConsolidationBalance.get();
+    uint256 writedownAmount = LibUint256.min(failedAmount, currentPending);
+    PendingConsolidationBalance.set(currentPending - writedownAmount);
+
+    // Update request status
+    request.status = 3; // FAILED
+
+    emit ConsolidationFailed(_requestId, failedAmount, writedownAmount);
+}
+```
+
+### Step 4: OracleManager — process failed consolidations in report
+
+**File: `contracts/src/components/OracleManager.1.sol`**
+
+In `setConsensusLayerData`, after consolidation reconciliation (from V1):
+
+```solidity
+// Process failed consolidations reported by oracle
+if (_report.failedConsolidationIds.length > 0) {
+    _processFailedConsolidations(_report.failedConsolidationIds);
+}
+```
+
+New virtual function:
+```solidity
+function _processFailedConsolidations(uint32[] calldata _failedIds) internal virtual;
+```
+
+Implemented in River.1.sol:
+```solidity
+function _processFailedConsolidations(uint32[] calldata _failedIds) internal override {
+    for (uint256 i = 0; i < _failedIds.length; ++i) {
+        _writeDownConsolidation(uint256(_failedIds[i]));
+    }
+}
+```
+
+### Step 5: Consolidation caps — enforce in executeConsolidation()
+
+**File: `contracts/src/River.1.sol`**
+
+Add validation to `executeConsolidation()` (from V1):
+
+```solidity
+function executeConsolidation(uint256 _requestId, uint256 _expectedBalance) external {
+    if (msg.sender != KeeperAddress.get()) revert OnlyKeeper();
+
+    // NEW: Cap enforcement
+    uint256 maxSingle = MaxSingleConsolidationAmount.get();
+    if (maxSingle > 0 && _expectedBalance > maxSingle) {
+        revert ConsolidationAmountExceedsCap(_expectedBalance, maxSingle);
+    }
+
+    uint256 maxTotal = MaxTotalPendingConsolidation.get();
+    uint256 currentPending = PendingConsolidationBalance.get();
+    if (maxTotal > 0 && currentPending + _expectedBalance > maxTotal) {
+        revert TotalPendingConsolidationExceedsCap(currentPending + _expectedBalance, maxTotal);
+    }
+
+    // ... rest of executeConsolidation from V1 ...
+}
+```
+
+### Step 6: Admin configuration functions
+
+**File: `contracts/src/River.1.sol`**
+
+```solidity
+function setMaxConsolidationDuration(uint256 _duration) external onlyAdmin {
+    MaxConsolidationDuration.set(_duration);
+    emit SetMaxConsolidationDuration(_duration);
+}
+
+function setMaxSingleConsolidationAmount(uint256 _amount) external onlyAdmin {
+    MaxSingleConsolidationAmount.set(_amount);
+    emit SetMaxSingleConsolidationAmount(_amount);
+}
+
+function setMaxTotalPendingConsolidation(uint256 _amount) external onlyAdmin {
+    MaxTotalPendingConsolidation.set(_amount);
+    emit SetMaxTotalPendingConsolidation(_amount);
+}
+
+function getMaxConsolidationDuration() external view returns (uint256) {
+    return MaxConsolidationDuration.get();
+}
+
+function getMaxSingleConsolidationAmount() external view returns (uint256) {
+    return MaxSingleConsolidationAmount.get();
+}
+
+function getMaxTotalPendingConsolidation() external view returns (uint256) {
+    return MaxTotalPendingConsolidation.get();
+}
+```
+
+### Step 7: Initialization
+
+**File: `contracts/src/River.1.sol`**
+
+New init function for the Pectra upgrade:
+```solidity
+function initRiverV1_3(
+    uint256 _maxConsolidationDuration,
+    uint256 _maxSingleConsolidationAmount,
+    uint256 _maxTotalPendingConsolidation
+) external init(3) {
+    MaxConsolidationDuration.set(_maxConsolidationDuration);
+    emit SetMaxConsolidationDuration(_maxConsolidationDuration);
+
+    MaxSingleConsolidationAmount.set(_maxSingleConsolidationAmount);
+    emit SetMaxSingleConsolidationAmount(_maxSingleConsolidationAmount);
+
+    MaxTotalPendingConsolidation.set(_maxTotalPendingConsolidation);
+    emit SetMaxTotalPendingConsolidation(_maxTotalPendingConsolidation);
+}
+```
+
+Suggested defaults:
+- `maxConsolidationDuration`: 7 days (604800 seconds)
+- `maxSingleConsolidationAmount`: 2048 ether (max effective balance post-Pectra)
+- `maxTotalPendingConsolidation`: 10000 ether (adjustable based on CoverageFund capacity)
+
+### Step 8: Interface updates
+
+**File: `contracts/src/interfaces/IRiver.1.sol`**
+
+Add:
+- `writeDownFailedConsolidation(uint256)` signature
+- `setMaxConsolidationDuration(uint256)`, `setMaxSingleConsolidationAmount(uint256)`, `setMaxTotalPendingConsolidation(uint256)` signatures
+- Getter signatures for all three config values
+- `initRiverV1_3()` signature
+- New events: `ConsolidationFailed`, `SetMaxConsolidationDuration`, `SetMaxSingleConsolidationAmount`, `SetMaxTotalPendingConsolidation`
+- New errors: `ConsolidationAmountExceedsCap`, `TotalPendingConsolidationExceedsCap`, `ConsolidationNotTimedOut`, `InvalidConsolidationStatus`
+
+### Step 9: Tests
+
+1. **Unit: writeDownFailedConsolidation (admin path)**
+   - Only admin can call
+   - Requires PENDING status
+   - Enforces timeout (reverts if not expired)
+   - PendingConsolidationBalance decremented correctly
+   - Request status set to FAILED
+   - Event emitted
+
+2. **Unit: writeDownFailedConsolidation (oracle path)**
+   - Oracle can call without timeout check
+   - Processes failedConsolidationIds in report
+   - Multiple failures in single report
+
+3. **Unit: Consolidation caps**
+   - maxSingleConsolidationAmount: executeConsolidation reverts if exceeded
+   - maxTotalPendingConsolidation: executeConsolidation reverts if total would exceed
+   - Caps of 0 = no cap (disabled)
+
+4. **Unit: Admin configuration**
+   - Only admin can set caps and duration
+   - Events emitted
+   - Getter functions return correct values
+
+5. **Integration: full failure + recovery lifecycle**
+   - executeConsolidation → wait for timeout → writeDownFailedConsolidation
+   - Verify: _assetBalance() drops, conversion rate drops
+   - CoverageFund.donate() → oracle report pulls coverage → _assetBalance() recovers
+
+6. **Integration: oracle-detected failure**
+   - executeConsolidation → oracle report with failedConsolidationIds
+   - Verify: buffer written down, event emitted
+
+7. **Edge: partial reconciliation then failure**
+   - Consolidation partially reconciled (some ETH arrived) then reported failed
+   - failedAmount = expectedBalance - reconciledBalance (not full amount)
+
+8. **Edge: false positive recovery**
+   - Consolidation written down as failed, then ETH arrives in later report
+   - validatorsConsolidatedBalance increases → excess flows through as protocol gain
+
+---
+
+## Files Created/Modified Summary
+
+| Action | File |
+|--------|------|
+| **Create** | `contracts/src/state/river/MaxConsolidationDuration.sol` |
+| **Create** | `contracts/src/state/river/MaxSingleConsolidationAmount.sol` |
+| **Create** | `contracts/src/state/river/MaxTotalPendingConsolidation.sol` |
+| **Modify** | `contracts/src/interfaces/components/IOracleManager.1.sol` — add `failedConsolidationIds` to report |
+| **Modify** | `contracts/src/interfaces/IRiver.1.sol` — add writedown, config, init functions + events/errors |
+| **Modify** | `contracts/src/components/OracleManager.1.sol` — process `failedConsolidationIds`, new virtual fn |
+| **Modify** | `contracts/src/River.1.sol` — `writeDownFailedConsolidation()`, `_processFailedConsolidations()`, cap enforcement in `executeConsolidation()`, admin config setters/getters, `initRiverV1_3()` |
+| **Create** | Test files for insolvency protection |
+
+---
+
+## Recovery Timeline (Example)
+
+```
+Day 0:   executeConsolidation(id=5, 100 ETH)
+         PendingConsolidationBalance: 0 → 100 ETH
+         LsETH minted to user
+
+Day 1:   Expected balance transfer. Nothing arrives.
+         Oracle reports: validatorsConsolidatedBalance unchanged.
+         PendingConsolidationBalance: still 100 ETH (inflating _assetBalance)
+
+Day 7:   MAX_CONSOLIDATION_DURATION reached.
+         Admin calls writeDownFailedConsolidation(5)
+         PendingConsolidationBalance: 100 → 0 ETH
+         _assetBalance() drops by 100 ETH
+         Conversion rate drops proportionally (socialized loss)
+
+Day 8:   Insurance entity donates 100 ETH to CoverageFund
+         CoverageFund.donate{value: 100 ether}()
+
+Day 8+:  Next oracle report:
+         _pullCoverageFunds(availableAmountToUpperBound)
+         BalanceToDeposit += pulled amount
+         _assetBalance() partially recovers
+         (May take multiple reports to fully recover due to upper bound)
+
+Day ~14: Full recovery. Conversion rate restored.
+```

--- a/docs/pectra-upgrade-shaping.md
+++ b/docs/pectra-upgrade-shaping.md
@@ -1,0 +1,134 @@
+---
+shaping: true
+---
+
+# Pectra Upgrade — Shaping
+
+## Requirements (R)
+
+| ID | Requirement | Status |
+|----|-------------|--------|
+| **R0** | **Validator Consolidation (TVS):** External validators can consolidate into LC validators via EIP-7251 and receive LsETH | Core goal |
+| **R1** | **Partial Exits:** LC can withdraw excess balance above 32 ETH from validators without full exit (EIP-7002) | Core goal |
+| **R3** | **Allowlist-gated consolidation:** Only allowlisted addresses can initiate TVS consolidation | Must-have |
+| **R4** | **Conversion rate integrity:** Consolidation buffer reconciliation with oracle must not introduce conversion rate errors | Must-have |
+| **R6** | **Insolvency protection:** If a consolidation fails after LsETH minting, protocol must not become insolvent | Must-have |
+| **R7** | **Keeper-driven exit strategy:** Automated keeper decides optimal partial vs full exit strategy | Must-have |
+| **R10** | **Remove 32 ETH / validator count from accounting:** No accounting logic should depend on `DEPOSIT_SIZE` constant or validator counts. Track ETH amounts directly. (32 ETH remains valid for deposit mechanics only.) | Must-have |
+
+---
+
+## Shapes
+
+### CURRENT: Hardcoded 32 ETH, Full-Exit-Only Model
+
+| Part | Mechanism |
+|------|-----------|
+| **C1** | `DEPOSIT_SIZE = 32 ether` constant used for all deposit/balance math |
+| **C2** | `_assetBalance()` adds `(depositedValidatorCount - clValidatorCount) * 32 ether` for in-flight validators |
+| **C3** | `ConsensusLayerDepositManager` deposits exactly 32 ETH per validator via beacon deposit contract |
+| **C4** | Oracle reports aggregate `validatorsBalance` + `validatorsCount` — no per-validator granularity |
+| **C5** | Exit flow: operator exit request → full CL exit → funds to Withdraw contract → pulled by oracle report |
+| **C6** | Pre-exiting balance: `requestedExitsCount * DEPOSIT_SIZE` (assumes 32 ETH per exit) |
+| **C7** | Allowlist: bitmask system with DENY/DEPOSIT/REDEEM masks on Allowlist.1.sol |
+| **C8** | BYOV: Keeper provides `OperatorAllocation[]` for explicit per-operator validator distribution |
+
+---
+
+### A: Consolidation Buffer + EL-Triggered Partial Exits
+
+Extend existing contracts. Track pending consolidations in a buffer variable reconciled against the oracle's aggregate CL balance — no per-validator EB tracking. Add EL-triggered partial exits via EIP-7002.
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **A1** | **Consolidation buffer:** New `PendingConsolidationBalance` storage variable on River. Incremented when keeper executes consolidation. Decremented when oracle reports new `validatorsConsolidatedBalance` delta. Follows same cumulative/non-decreasing pattern as `validatorsSkimmedBalance` and `validatorsExitedBalance`. | |
+| **A2** | **Modified `_assetBalance()`:** Add `PendingConsolidationBalance` to total asset balance (`validatorsBalance + BalanceToDeposit + CommittedBalance + BalanceToRedeem + PendingConsolidationBalance + inFlightBalance`). When oracle reconciles, consolidated ETH moves from buffer into `validatorsBalance` — net `_assetBalance()` change = 0 for consolidation, only rewards remain as delta. | |
+| **A3** | **Consolidation entry point (two-step, keeper-attested):** Step 1: User calls `requestConsolidation(sourcePubkey, targetPubkey)` — allowlist-checked (`CONSOLIDATION_MASK`), records `ConsolidationRequest{source, target, recipient, status: REQUESTED}`. Step 2: Keeper calls `executeConsolidation(requestId, expectedBalance)` — keeper reads source validator's CL balance, records `expectedBalance`, atomically increments `PendingConsolidationBalance += expectedBalance`, mints LsETH to recipient at current conversion rate, submits consolidation request to CL system contract. See [spike-consolidation-entry-point.md](spike-consolidation-entry-point.md). | |
+| **A4** | **Oracle reconciliation:** New `validatorsConsolidatedBalance` field in `ConsensusLayerReport` (cumulative, non-decreasing). In `setConsensusLayerData`: compute `consolidatedDelta = new - old`, reduce `PendingConsolidationBalance` by delta. This happens after `_pullCLFunds` and before `postReportUnderlyingBalance = _assetBalance()`, so consolidation amount cancels out in the delta and bounds check sees only rewards. See [spike-buffer-reconciliation.md](spike-buffer-reconciliation.md). | |
+| **A5** | **LsETH minting on consolidation:** Minted atomically in keeper's `executeConsolidation()` call. At this point `PendingConsolidationBalance` is already incremented in the same tx, so `_assetBalance()` accounts for the incoming ETH and the conversion rate is correct. Amount is keeper-attested (read from CL data), not user-provided. | |
+| **A6** | **Partial exit via EIP-7002:** Keeper calls `River.requestExits()` with a mix of partial + full exits. River routes partial exits through Withdraw contract → EIP-7002 system contract (Withdraw is the withdrawal credentials address). New `PendingPartialExitBalance` storage variable tracks requested partial exit ETH not yet received. Oracle reports partial exit funds via new `validatorsPartiallyExitedBalance` field (cumulative, non-decreasing). Funds arrive at Withdraw → pulled by River → `BalanceToRedeem`. See [spike-partial-exits.md](spike-partial-exits.md). | |
+| **A7** | **Keeper exit strategy:** Keeper calculates shortfall (`redeemDemandInEth - availableBalance`). Step 1: Fill shortfall with partial exits from validators with excess >32 ETH (sorted by excess descending, skip if EIP-7002 fee too high). Step 2: If shortfall remains, request full exits for the remainder via existing OperatorsRegistry flow. Partial exits preferred: faster (~minutes vs ~27hrs), cheaper (no new validator needed), preserves validator count, sub-32 ETH granularity. See [spike-partial-exits.md](spike-partial-exits.md). | |
+| **A8** | 🟡 **Insolvency protection (two layers):** **Prevention:** Keeper validates source validator CL state before executing. Admin-configurable caps on single consolidation amount and total `PendingConsolidationBalance`. Allowlist vetting. **Detection:** Oracle reports `failedConsolidationIds[]` when source exits without balance transfer. Timeout fallback: consolidations pending > `MAX_CONSOLIDATION_DURATION` (e.g., 7 days) are flagged. **Recovery:** `PendingConsolidationBalance` written down by failed amount → `_assetBalance()` drops → loss socialized. Existing CoverageFund mechanism handles recovery: insurance/treasury donates lost amount, oracle pulls gradually via `availableAmountToUpperBound`. No new recovery mechanism needed — same pattern as slashing. See [spike-insolvency-protection.md](spike-insolvency-protection.md). | |
+| **A9** | 🟡 **ETH-based accounting (remove 32 ETH / count dependencies):** (1) New `InFlightDepositBalance` storage — incremented by 32 ETH on each deposit, decremented by `newValidatorCount * 32 ETH` when oracle reports activation. Replaces `(depositedCount - clCount) * 32` in `_assetBalance()`. (2) New `PendingFullExitBalance` storage — incremented by keeper-provided actual validator balance on full exit request, decremented when oracle reports exited funds. Combined with `PendingPartialExitBalance`: `preExitingBalance = PendingFullExitBalance + PendingPartialExitBalance`. (3) ETH-based exit demand: `demandExitBalance(ethAmount)` replaces `demandValidatorExits(count)`. Keeper fills demand using actual CL balances. `DEPOSIT_SIZE` retained only for deposit mechanics. See [spike-eth-based-accounting.md](spike-eth-based-accounting.md). | |
+
+---
+
+## A3: Consolidation Entry Point Alternatives
+
+Three alternatives were evaluated in the spike. See [spike-consolidation-entry-point.md](spike-consolidation-entry-point.md) for full details.
+
+| Req | Requirement | Status | A3-A | A3-B | A3-C |
+|-----|-------------|--------|------|------|------|
+| **R0** | External validators can consolidate into LC validators and receive LsETH | Core goal | ✅ | ✅ | ✅ |
+| **R3** | Only allowlisted addresses can initiate TVS consolidation | Must-have | ✅ | ✅ | ✅ |
+| **R4** | Buffer reconciliation must not introduce conversion rate errors | Must-have | ❌ | ✅ | ✅ |
+
+**Notes:**
+- **A3-A** (user-initiated, immediate mint): User provides `expectedBalance` — could be wrong/malicious. Relies entirely on oracle reconciliation + A8 after the fact. Fails R4 because a lying user inflates `_assetBalance()` immediately.
+- **A3-B** (keeper-attested, two-step): Keeper reads CL state, provides correct balance. Minting + buffer increment atomic. **Selected** — consistent with BYOV pattern (keeper already trusted for deposits).
+- **A3-C** (oracle-confirmed, delayed): Safest but delayed minting (waits for oracle report). Adds minting complexity inside `setConsensusLayerData`. Rejected — UX too slow.
+
+**Selected: A3-B** — Keeper-attested two-step consolidation.
+
+---
+
+## Fit Check: R × A
+
+| Req | Requirement | Status | A |
+|-----|-------------|--------|---|
+| **R0** | External validators can consolidate into LC validators via EIP-7251 and receive LsETH | Core goal | ✅ |
+| **R1** | LC can withdraw excess balance above 32 ETH without full exit (EIP-7002) | Core goal | ✅ |
+| **R3** | Only allowlisted addresses can initiate TVS consolidation | Must-have | ✅ |
+| **R4** | Consolidation buffer reconciliation with oracle must not introduce conversion rate errors | Must-have | ✅ |
+| **R6** | If a consolidation fails after LsETH minting, protocol must not become insolvent | Must-have | 🟡 ✅ |
+| **R7** | Automated keeper decides optimal partial vs full exit strategy | Must-have | ✅ |
+| **R10** | No accounting logic depends on `DEPOSIT_SIZE` constant or validator counts | Must-have | 🟡 ✅ |
+
+**Notes:**
+- R0 ✅: A1-A5 fully resolved. Keeper-attested two-step consolidation with atomic mint + buffer increment.
+- R1 ✅: A6 resolved — partial exits route through Withdraw → EIP-7002 system contract. See [spike-partial-exits.md](spike-partial-exits.md).
+- R3 ✅: `CONSOLIDATION_MASK` on allowlist, checked at `requestConsolidation()`.
+- R4 ✅: Buffer reconciliation resolved. See [spike-buffer-reconciliation.md](spike-buffer-reconciliation.md).
+- R6 🟡✅: A8 unflagged — two-layer protection: prevention (keeper validation, caps, allowlist) + recovery (oracle/timeout detection → buffer writedown → CoverageFund backstop). Uses existing slashing recovery pattern. See [spike-insolvency-protection.md](spike-insolvency-protection.md).
+- R7 ✅: A7 resolved — keeper prefers partial exits, falls back to full exits. See [spike-partial-exits.md](spike-partial-exits.md).
+- R10 🟡✅: A9 unflagged — three replacements: `InFlightDepositBalance` (in-flight deposits), `PendingFullExitBalance` (pre-exiting), `demandExitBalance` (exit demand). `DEPOSIT_SIZE` retained for deposit mechanics only. See [spike-eth-based-accounting.md](spike-eth-based-accounting.md).
+
+**All requirements pass. Shape A fully resolved.**
+
+---
+
+## Contract Changes Summary
+
+| Contract | Changes |
+|----------|---------|
+| **River.1.sol** | New `_assetBalance()` with `PendingConsolidationBalance`. New `requestConsolidation()`, `executeConsolidation()`, `requestExits()` (partial+full), `writeDownFailedConsolidation()`. Modified `_requestExitsBasedOnRedeemDemandAfterRebalancings()` with `PendingPartialExitBalance`. Modified `setConsensusLayerData` with consolidation reconciliation + partial exit reconciliation. |
+| **Withdraw.1.sol** | New `requestWithdrawal(pubkey, amountInGwei)` — calls EIP-7002 system contract. |
+| **Allowlist.1.sol** | New `CONSOLIDATION_MASK = 0x8` (bit 4). |
+| **IOracleManager.1.sol** | `ConsensusLayerReport` extended with `validatorsConsolidatedBalance`, `validatorsPartiallyExitedBalance`, `failedConsolidationIds[]`. `StoredConsensusLayerReport` extended with `validatorsConsolidatedBalance`, `validatorsPartiallyExitedBalance`. |
+| **OperatorsRegistry.1.sol** | Exit demand changes from count-based to ETH-based: `demandExitBalance(ethAmount)` replaces `demandValidatorExits(count)`. Keeper fills using actual validator balances. |
+| **State (new)** | `PendingConsolidationBalance.sol`, `PendingPartialExitBalance.sol`, `PendingFullExitBalance.sol`, `InFlightDepositBalance.sol`, `CurrentExitDemandBalance.sol`, `ConsolidationRequests.sol`. |
+
+## New Oracle Report Fields
+
+| Field | Type | Pattern | Purpose |
+|-------|------|---------|---------|
+| `validatorsConsolidatedBalance` | `uint256` | Cumulative, non-decreasing | Track ETH consolidated into LC validators |
+| `validatorsPartiallyExitedBalance` | `uint256` | Cumulative, non-decreasing | Track ETH withdrawn via EIP-7002 partial exits |
+| `failedConsolidationIds` | `uint32[]` | Per-report | Report consolidations that failed on CL |
+
+---
+
+## Open Questions
+
+1. ~~**Consolidation UX**~~ — ✅ Resolved. See [spike-consolidation-entry-point.md](spike-consolidation-entry-point.md).
+2. ~~**Conversion rate protection**~~ — ✅ Resolved. See [spike-insolvency-protection.md](spike-insolvency-protection.md).
+3. ~~**Partial exit fee economics**~~ — ✅ Resolved. See [spike-partial-exits.md](spike-partial-exits.md).
+4. ~~**Buffer reconciliation mechanics**~~ — ✅ Resolved. See [spike-buffer-reconciliation.md](spike-buffer-reconciliation.md).
+5. ~~**Pre-exiting balance with partial exits**~~ — ✅ Resolved. See [spike-partial-exits.md](spike-partial-exits.md).
+
+## Spike Documents
+
+1. [spike-buffer-reconciliation.md](spike-buffer-reconciliation.md) — How `PendingConsolidationBalance` integrates with oracle reporting
+2. [spike-consolidation-entry-point.md](spike-consolidation-entry-point.md) — Two-step keeper-attested consolidation flow (A3-B selected)
+3. [spike-partial-exits.md](spike-partial-exits.md) — EIP-7002 partial exits via Withdraw + keeper strategy
+4. [spike-insolvency-protection.md](spike-insolvency-protection.md) — Failed consolidation detection, writedown, and CoverageFund recovery

--- a/docs/pectra-upgrade-slices.md
+++ b/docs/pectra-upgrade-slices.md
@@ -1,0 +1,263 @@
+---
+shaping: true
+---
+
+# Pectra Upgrade — Slices
+
+Based on [Shape A](pectra-upgrade-shaping.md): Consolidation Buffer + EL-Triggered Partial Exits.
+
+## Dependency Graph
+
+```
+A1 (buffer) ──┐
+A2 (assetBalance) ──┤
+                    ├──→ V1: Consolidation
+A3 (entry point) ──┤
+A4 (oracle recon) ──┤
+A5 (minting) ──────┘
+                         A8 (insolvency) ──→ V3: Protection
+A6 (partial exits) ──┐
+A7 (keeper strategy) ┘──→ V2: Partial Exits
+```
+
+V1 and V2 are **independent** (no shared dependency beyond existing contracts). V3 depends on V1.
+
+---
+
+## V1: Validator Consolidation (Happy Path)
+
+**Parts:** A1, A2, A3, A4, A5
+
+**Demo:** User requests consolidation → keeper executes → LsETH minted immediately → oracle report reconciles buffer → conversion rate unchanged.
+
+### Contracts touched
+
+| Contract | What changes |
+|----------|-------------|
+| **River.1.sol** | `requestConsolidation()`, `executeConsolidation()`, modified `_assetBalance()` with `PendingConsolidationBalance`, consolidation reconciliation in `setConsensusLayerData` |
+| **Allowlist.1.sol** | New `CONSOLIDATION_MASK = 0x8` |
+| **IOracleManager.1.sol** | `ConsensusLayerReport` + `StoredConsensusLayerReport` extended with `validatorsConsolidatedBalance` |
+| **OracleManager.1.sol** | Reconciliation logic: `PendingConsolidationBalance -= consolidatedDelta` |
+| **State (new)** | `PendingConsolidationBalance.sol`, `ConsolidationRequests.sol` |
+
+### Non-UI Affordances
+
+| Affordance | Type | Wires Out |
+|------------|------|-----------|
+| `ConsolidationRequest` struct | Data store | Stored in `ConsolidationRequests` array |
+| `consolidationRequestBySource` mapping | Index | `bytes32 sourcePubkeyHash → uint256 requestId` |
+| `PendingConsolidationBalance` | Storage variable | Read by `_assetBalance()`, written by `executeConsolidation()` and `setConsensusLayerData` |
+| `requestConsolidation(sourcePubkey, targetPubkey)` | External fn (user) | → allowlist check → store request → emit event |
+| `executeConsolidation(requestId, expectedBalance)` | External fn (keeper) | → store expectedBalance → `PendingConsolidationBalance += amount` → `_mintShares()` → submit CL consolidation request |
+| `_reconcileConsolidations(consolidatedDelta)` | Internal fn | → `PendingConsolidationBalance -= delta` → update request statuses |
+| `validatorsConsolidatedBalance` | Oracle report field | Cumulative, non-decreasing. Delta used in reconciliation. |
+
+### Key flow
+
+```
+User → requestConsolidation(srcPubkey, tgtPubkey)
+  ├─ Allowlist: onlyAllowed(msg.sender, CONSOLIDATION_MASK)
+  ├─ Validate: targetPubkey ∈ OperatorsRegistry
+  ├─ Store: ConsolidationRequest{src, tgt, recipient, status: REQUESTED}
+  └─ Emit: ConsolidationRequested
+
+Keeper → executeConsolidation(requestId, expectedBalance)
+  ├─ OnlyKeeper
+  ├─ Store: request.expectedBalance = expectedBalance, status = PENDING
+  ├─ Buffer: PendingConsolidationBalance += expectedBalance
+  ├─ Mint: _mintShares(request.recipient, expectedBalance)
+  ├─ CL: submit consolidation request to system contract
+  └─ Emit: ConsolidationExecuted
+
+Oracle → setConsensusLayerData(report)
+  ├─ ... existing flow ...
+  ├─ consolidatedDelta = report.validatorsConsolidatedBalance - last.validatorsConsolidatedBalance
+  ├─ PendingConsolidationBalance -= min(consolidatedDelta, PendingConsolidationBalance)
+  ├─ Store: last.validatorsConsolidatedBalance = report.validatorsConsolidatedBalance
+  └─ ... postReportUnderlyingBalance = _assetBalance() (consolidation cancels out) ...
+```
+
+---
+
+## V2: Partial Exits via EIP-7002
+
+**Parts:** A6, A7
+
+**Demo:** Redeem demand exceeds available ETH → keeper triggers partial exits on validators with excess > 32 ETH → funds arrive at Withdraw → oracle reports → `BalanceToRedeem` increases → redemption satisfied faster than full exit.
+
+### Contracts touched
+
+| Contract | What changes |
+|----------|-------------|
+| **Withdraw.1.sol** | New `requestWithdrawal(pubkey, amountInGwei)` — calls EIP-7002 system contract |
+| **River.1.sol** | New `requestExits(ExitRequest)` replacing/extending current exit flow. Modified `_requestExitsBasedOnRedeemDemandAfterRebalancings()` to account for `PendingPartialExitBalance`. Partial exit reconciliation in `setConsensusLayerData`. |
+| **IOracleManager.1.sol** | `ConsensusLayerReport` + `StoredConsensusLayerReport` extended with `validatorsPartiallyExitedBalance` |
+| **OracleManager.1.sol** | Reconciliation logic: `PendingPartialExitBalance -= partialExitDelta` |
+| **State (new)** | `PendingPartialExitBalance.sol` |
+
+### Non-UI Affordances
+
+| Affordance | Type | Wires Out |
+|------------|------|-----------|
+| `PendingPartialExitBalance` | Storage variable | Read by exit demand calc, written by `requestExits()` and `setConsensusLayerData` |
+| `requestWithdrawal(pubkey, amountInGwei)` | External fn on Withdraw (River-only) | → encode request → call EIP-7002 system contract with fee |
+| `requestExits(ExitRequest)` | External fn on River (keeper) | → route partial exits through Withdraw → route full exits through OperatorsRegistry |
+| `PartialExitRequest` struct | Calldata | `{pubkey, amountInGwei}` |
+| `ExitRequest` struct | Calldata | `{PartialExitRequest[], OperatorAllocation[]}` |
+| `validatorsPartiallyExitedBalance` | Oracle report field | Cumulative, non-decreasing. Delta used in reconciliation. |
+
+### Key flow
+
+```
+Keeper → requestExits({partialExits, fullExits})
+  ├─ OnlyKeeper
+  ├─ For each partial exit:
+  │   ├─ Withdraw.requestWithdrawal(pubkey, amountInGwei)
+  │   │   └─ EIP-7002 system contract call
+  │   └─ PendingPartialExitBalance += amount
+  ├─ For full exits:
+  │   └─ OperatorsRegistry.requestValidatorExits(fullExits)
+  └─ Emit: ExitsRequested
+
+Oracle → setConsensusLayerData(report)
+  ├─ ... existing flow ...
+  ├─ partialExitDelta = report.validatorsPartiallyExitedBalance - last.validatorsPartiallyExitedBalance
+  ├─ PendingPartialExitBalance -= min(partialExitDelta, PendingPartialExitBalance)
+  ├─ ... _pullCLFunds routes exited funds to BalanceToRedeem ...
+  └─ Modified preExitingBalance:
+      preExiting = (requestedFullExits - stopped) * 32 ETH + PendingPartialExitBalance
+```
+
+### Keeper strategy (off-chain)
+
+```
+1. shortfall = redeemDemandInEth - (BalanceToRedeem + exitingBalance + preExitingBalance)
+2. if shortfall <= 0: DONE
+3. Sort validators by excess balance (excess = balance - 32 ETH) descending
+4. Fill shortfall with partial exits (skip if EIP-7002 fee > threshold)
+5. If shortfall remains: add full exits for ceil(remaining / 32 ETH)
+6. Call River.requestExits({partialExits, fullExits})
+```
+
+---
+
+## V3: Insolvency Protection
+
+**Parts:** A8
+
+**Depends on:** V1 (consolidation must be in place)
+
+**Demo:** Consolidation executed → times out / oracle reports failure → buffer written down → `_assetBalance()` drops → CoverageFund donation → oracle pulls → conversion rate recovers.
+
+### Contracts touched
+
+| Contract | What changes |
+|----------|-------------|
+| **River.1.sol** | New `writeDownFailedConsolidation(requestId)` (admin/oracle callable). Configurable `MAX_CONSOLIDATION_DURATION`, `maxSingleConsolidationAmount`, `maxTotalPendingConsolidation` caps. Cap enforcement in `executeConsolidation()`. |
+| **IOracleManager.1.sol** | `ConsensusLayerReport` extended with `failedConsolidationIds[]` |
+| **OracleManager.1.sol** | Process `failedConsolidationIds` in `setConsensusLayerData` → call writedown for each |
+
+### Non-UI Affordances
+
+| Affordance | Type | Wires Out |
+|------------|------|-----------|
+| `writeDownFailedConsolidation(requestId)` | External fn (admin/oracle) | → `PendingConsolidationBalance -= failedAmount` → request.status = FAILED → emit |
+| `MAX_CONSOLIDATION_DURATION` | Admin-configurable | Timeout for pending consolidations |
+| `maxSingleConsolidationAmount` | Admin-configurable | Cap per consolidation in `executeConsolidation()` |
+| `maxTotalPendingConsolidation` | Admin-configurable | Cap on total `PendingConsolidationBalance` in `executeConsolidation()` |
+| `failedConsolidationIds` | Oracle report field | Per-report array of failed request IDs |
+
+### Key flow
+
+```
+Detection Path A — Oracle:
+  Oracle → setConsensusLayerData(report with failedConsolidationIds)
+    └─ For each failedId:
+        ├─ failedAmount = request.expectedBalance - request.reconciledBalance
+        ├─ PendingConsolidationBalance -= failedAmount
+        ├─ request.status = FAILED
+        └─ Emit: ConsolidationFailed
+
+Detection Path B — Timeout:
+  Admin → writeDownFailedConsolidation(requestId)
+    ├─ Require: request.status == PENDING
+    ├─ Require: block.timestamp > request.requestTimestamp + MAX_CONSOLIDATION_DURATION
+    ├─ PendingConsolidationBalance -= failedAmount
+    ├─ request.status = FAILED
+    └─ Emit: ConsolidationFailed
+
+Recovery:
+  Treasury/Insurance → CoverageFund.donate{value: failedAmount}()
+  Next oracle reports → _pullCoverageFunds() → BalanceToDeposit ↑ → _assetBalance() recovers
+```
+
+---
+
+## V0: ETH-Based Accounting Foundation
+
+**Parts:** A9
+
+**Depends on:** Nothing (foundation for all other slices)
+
+**Demo:** `_assetBalance()` uses `InFlightDepositBalance` instead of `(depositedCount - clCount) * 32`. Exit demand tracks ETH amounts, not validator counts.
+
+### Contracts touched
+
+| Contract | What changes |
+|----------|-------------|
+| **River.1.sol** | `_assetBalance()` uses `InFlightDepositBalance` instead of count-based calc. Exit demand uses `PendingFullExitBalance + PendingPartialExitBalance` for `preExitingBalance`. Calls `demandExitBalance(ethAmount)` instead of `demandValidatorExits(count)`. |
+| **ConsensusLayerDepositManager.1.sol** | `_depositValidator()` increments `InFlightDepositBalance += DEPOSIT_SIZE` |
+| **OracleManager.1.sol** | Decrements `InFlightDepositBalance` when new validators activated. Reconciles `PendingFullExitBalance` from exited balance delta. |
+| **OperatorsRegistry.1.sol** | New `demandExitBalance(ethAmount)` replaces `demandValidatorExits(count)`. New `CurrentExitDemandBalance` replaces `CurrentValidatorExitsDemand`. `requestValidatorExits()` updated to track ETH amounts via `FullExitRequest{pubkey, expectedBalance}`. |
+| **State (new)** | `InFlightDepositBalance.sol`, `PendingFullExitBalance.sol`, `CurrentExitDemandBalance.sol` |
+
+### Key changes
+
+```
+_assetBalance():
+  OLD: validatorsBalance + deposits + committed + redeem + (depositedCount - clCount) * 32
+  NEW: validatorsBalance + deposits + committed + redeem + InFlightDepositBalance
+
+preExitingBalance:
+  OLD: (requestedExits - stopped) * 32
+  NEW: PendingFullExitBalance + PendingPartialExitBalance
+
+Exit demand:
+  OLD: demandValidatorExits(ceil(shortfall / 32))
+  NEW: demandExitBalance(shortfall)
+```
+
+### Migration (initRiverV1_3)
+
+```
+InFlightDepositBalance = (DepositedValidatorCount - lastReport.validatorsCount) * 32 ether
+CurrentExitDemandBalance = CurrentValidatorExitsDemand * 32 ether
+PendingFullExitBalance = 0
+```
+
+See [spike-eth-based-accounting.md](spike-eth-based-accounting.md) for full details.
+
+---
+
+## Implementation Order
+
+```
+V0 (ETH Accounting) ──→ V1 (Consolidation) ──→ V3 (Protection)
+                    ──→ V2 (Partial Exits)
+```
+
+**Recommended order:** V0 → V1 + V2 (parallel) → V3
+
+- **V0 first:** Foundation — removes 32 ETH / count dependencies. All other slices build on this.
+- **V1 next:** Highest value — enables institutional validator onboarding.
+- **V2 in parallel with V1:** Independent of V1, uses V0's ETH-based exit demand.
+- **V3 last:** Depends on V1. Adds recovery backstop.
+
+---
+
+## Slice Plans
+
+- [V0-plan.md](V0-plan.md) — ETH-based accounting foundation: 12 implementation steps, ~9 files touched
+- [V1-plan.md](V1-plan.md) — Validator Consolidation: 10 implementation steps, ~9 files touched
+- [V2-plan.md](V2-plan.md) — Partial Exits via EIP-7002: 10 implementation steps, ~7 files touched
+- [V3-plan.md](V3-plan.md) — Insolvency Protection: 9 implementation steps, ~7 files touched

--- a/docs/spike-buffer-reconciliation.md
+++ b/docs/spike-buffer-reconciliation.md
@@ -1,0 +1,118 @@
+---
+shaping: true
+---
+
+# Buffer Reconciliation Spike
+
+## Context
+
+Shape A proposes a `PendingConsolidationBalance` buffer to track ETH "in transit" from consolidations. This buffer must be reconciled against the oracle's aggregate CL balance so that:
+- Consolidated ETH isn't double-counted in `_assetBalance()`
+- Consolidated ETH isn't mistaken for rewards (which would trigger fee minting)
+- The `annualAprUpperBound` check isn't tripped by large consolidation-driven balance increases
+
+## Goal
+
+Understand the exact mechanics of how `PendingConsolidationBalance` integrates into the existing oracle reporting flow (`setConsensusLayerData`) and `_assetBalance()`.
+
+## Questions
+
+| # | Question | Answer |
+|---|----------|--------|
+| **Q1** | How does the oracle currently distinguish between different sources of `validatorsBalance` change (rewards, skimming, exits)? | It doesn't distinguish within `validatorsBalance` itself. Instead it uses **separate cumulative fields**: `validatorsSkimmedBalance` (cumulative, non-decreasing) and `validatorsExitedBalance` (cumulative, non-decreasing). The delta between reports gives the new skimmed/exited amounts. `validatorsBalance` is the live CL balance (can decrease). Rewards are derived implicitly: `_assetBalance()` delta after applying all report values = rewards. |
+| **Q2** | What happens to `_assetBalance()` when a consolidation completes on CL (i.e., balance transfers from source to target LC validator)? | **Without a buffer:** `validatorsBalance` jumps by the consolidated amount → `_assetBalance()` jumps → treated as rewards → fee shares minted on non-reward ETH → conversion rate distorted. Also likely trips `annualAprUpperBound`. **This is the core problem.** |
+| **Q3** | How can the oracle report consolidation transfers so River can reconcile the buffer? | **Same pattern as skimmed/exited:** Add a new cumulative field `validatorsConsolidatedBalance` to `ConsensusLayerReport`. The oracle tracks all ETH transferred into LC validators via consolidation. Delta between reports = new consolidation transfers. This is the cleanest approach — consistent with existing patterns. |
+| **Q4** | Where in the `setConsensusLayerData` flow should reconciliation happen? | Between `_pullCLFunds` (step 2) and the `_assetBalance()` post-report read (step 4). Specifically: after updating `LastConsensusLayerReport` (which updates `validatorsBalance`), reduce `PendingConsolidationBalance` by the consolidation delta. Then when `postReportUnderlyingBalance = _assetBalance()` runs, the consolidation portion cancels out (higher `validatorsBalance` offset by lower `PendingConsolidationBalance`), leaving only real rewards in the delta. |
+| **Q5** | Does this work with multiple in-flight consolidations? | Yes. `PendingConsolidationBalance` is a **sum** of all pending consolidations. `validatorsConsolidatedBalance` is **cumulative** across all consolidations. Each report reconciles whatever portion of pending consolidations has completed, regardless of count or order. |
+| **Q6** | What about the bounds checking? Does the buffer prevent false `TotalValidatorBalanceIncreaseOutOfBound` reverts? | Yes. The math: `preReport = validatorsBalance(old) + ... + PendingConsolidation(old)`. `postReport = validatorsBalance(new, includes consolidated) + ... + PendingConsolidation(old) - consolidatedDelta`. The consolidation amount cancels: `+consolidated in validatorsBalance` and `-consolidatedDelta from buffer`. Only rewards remain in `postReport - preReport`. Bounds check passes. |
+| **Q7** | When is `PendingConsolidationBalance` incremented — at initiation or at CL acceptance? | **At CL acceptance** (when oracle confirms source validator's exit_epoch is set). This is when the protocol is certain the consolidation is proceeding. Adding to buffer at initiation would risk inflating `_assetBalance()` for consolidations that get rejected on CL. |
+
+## Concrete Mechanism
+
+### 1. New oracle report field
+
+```solidity
+struct ConsensusLayerReport {
+    // ... existing fields ...
+
+    // NEW: cumulative sum of all ETH consolidated into LC validators
+    // follows same pattern as validatorsSkimmedBalance / validatorsExitedBalance
+    // non-decreasing across reports
+    uint256 validatorsConsolidatedBalance;
+}
+```
+
+### 2. New storage variable
+
+```solidity
+// PendingConsolidationBalance — total ETH expected from in-flight consolidations
+// Incremented when oracle confirms CL acceptance (source exit_epoch set)
+// Decremented when oracle reports consolidation transfer complete
+```
+
+### 3. Modified `_assetBalance()`
+
+```solidity
+function _assetBalance() internal view returns (uint256) {
+    // ... existing logic ...
+    return storedReport.validatorsBalance
+        + BalanceToDeposit.get()
+        + CommittedBalance.get()
+        + BalanceToRedeem.get()
+        + PendingConsolidationBalance.get()   // ← NEW
+        + inFlightValidatorBalance;            // (depositedCount - clCount) * 32 ETH
+}
+```
+
+### 4. Modified `setConsensusLayerData` flow
+
+```
+Step 1: preReportUnderlyingBalance = _assetBalance()
+           → includes PendingConsolidationBalance(old)
+
+Step 2: Pull CL funds (skimmed + exited) — unchanged
+
+Step 3: Compute consolidation delta:
+           consolidatedIncrease = report.validatorsConsolidatedBalance
+                                - lastReport.validatorsConsolidatedBalance
+           PendingConsolidationBalance -= consolidatedIncrease
+
+Step 4: Update LastConsensusLayerReport (new validatorsBalance, etc.)
+
+Step 5: postReportUnderlyingBalance = _assetBalance()
+           → validatorsBalance now includes consolidated ETH
+           → PendingConsolidationBalance is reduced by same amount
+           → NET DELTA = rewards only (consolidation cancels out)
+
+Step 6: Bounds check, fee minting, etc. — unchanged, works correctly
+```
+
+### 5. Consolidation lifecycle
+
+```
+Initiation (EL tx)          → consolidation request recorded, NO buffer change yet
+CL Acceptance (oracle)      → PendingConsolidationBalance += expectedBalance
+                               LsETH minted to consolidator
+Balance Transfer (oracle)   → validatorsConsolidatedBalance increases
+                               PendingConsolidationBalance -= transferredAmount
+                               (net _assetBalance() change = 0)
+```
+
+## Edge Cases
+
+| Case | What happens |
+|------|--------------|
+| **Consolidation fails after CL acceptance** | PendingConsolidationBalance remains inflated. Oracle reports no increase in `validatorsConsolidatedBalance`. Need a timeout/admin mechanism to write down the buffer → triggers insolvency protection (R6). |
+| **Partial consolidation** (less ETH arrives than expected) | `validatorsConsolidatedBalance` delta < expected. Buffer remains partially inflated. Same writedown mechanism needed. |
+| **Consolidation completes across report boundaries** | Works naturally — cumulative `validatorsConsolidatedBalance` captures the transfer whenever it happens. Buffer reconciles in the report where transfer completes. |
+| **Multiple consolidations in same report window** | All captured in single `validatorsConsolidatedBalance` delta. Buffer decrements by total. |
+| **Oracle reports consolidation but no matching pending** (rogue) | `consolidatedIncrease > PendingConsolidationBalance` → underflow. Need a guard: `min(consolidatedIncrease, PendingConsolidationBalance)`. Excess is unmatched consolidated ETH — effectively a gift to the protocol (increases `_assetBalance()` → treated as rewards). |
+
+## Conclusion
+
+The buffer reconciliation follows the **exact same pattern** as the existing skimmed/exited balance tracking:
+- Cumulative, non-decreasing oracle field
+- Delta computed between reports
+- River adjusts internal state based on delta
+
+The key insight is that `PendingConsolidationBalance` in `_assetBalance()` pre-accounts for incoming ETH (so LsETH can be minted immediately at correct conversion rate), and the oracle's `validatorsConsolidatedBalance` delta reconciles it (so it's not double-counted once ETH arrives on CL).

--- a/docs/spike-consolidation-entry-point.md
+++ b/docs/spike-consolidation-entry-point.md
@@ -1,0 +1,147 @@
+---
+shaping: true
+---
+
+# A3 Spike: Consolidation Entry Point
+
+## Context
+
+We need a `consolidate()` entry point on River that:
+- Allows an external validator to consolidate into an LC validator
+- Records the expected consolidation amount so it can be reconciled in the oracle report
+- Mints LsETH at the correct conversion rate
+- Is gated by the allowlist
+
+The key constraint from the buffer reconciliation spike: **when minting happens, the expected consolidation amount must be atomically recorded in `PendingConsolidationBalance`** so that `_assetBalance()` immediately reflects the incoming ETH and the conversion rate is correct.
+
+## Goal
+
+Determine the concrete mechanics of the consolidation entry point: who calls what, when minting happens, what data is stored, and how the oracle interacts.
+
+## Questions
+
+| # | Question | Answer |
+|---|----------|--------|
+| **Q1** | How does a consolidation request reach the CL? What EL contract is involved? | EIP-7251 introduces a system contract at a predefined address (the consolidation request contract). To request a consolidation, an EL transaction is sent to this contract with `source_pubkey ++ target_pubkey` (96 bytes). The request must come from the source validator's withdrawal credentials address. On CL, the request is processed: if valid, the source validator's `exit_epoch` is set, and eventually its balance transfers to the target. |
+| **Q2** | Who can initiate a consolidation into LC? | The **owner of the source validator** (the address set as the source validator's withdrawal credentials). They must be allowlisted on LC. They call River, which then submits the consolidation request to the CL system contract. **River must be the one calling the system contract**, because consolidation requests can also be triggered by the withdrawal credentials address of the source — but for LC the target validator's withdrawal credentials point to the Withdraw contract, so the request routing matters. |
+| **Q3** | When does LsETH get minted — at consolidation request time or at CL acceptance? | **At consolidation request time (same tx as the EL call).** Rationale: (1) The user expects immediate LsETH, similar to `deposit()` which mints immediately. (2) The consolidation amount is known at request time (user provides it, keyed to their source validator's CL balance). (3) `PendingConsolidationBalance` is incremented in the same tx, so `_assetBalance()` is immediately correct. (4) Waiting for oracle introduces delay and complexity. The risk (user provides wrong amount) is handled by oracle reconciliation + insolvency protection (A8). |
+| **Q4** | What if the user lies about the expected consolidation amount? | **Two protections:** (1) The oracle reconciliation (A4) will detect the mismatch — `validatorsConsolidatedBalance` delta won't match `PendingConsolidationBalance`. The buffer will remain partially inflated, which dilutes the conversion rate for all holders. (2) Insolvency protection (A8) handles the writedown. **Mitigation at entry:** The keeper/oracle could provide the expected balance as a signed attestation, or the consolidation could require a two-step process where the oracle confirms the source validator's balance before minting. See alternatives below. |
+| **Q5** | What data needs to be stored per consolidation request? | A `ConsolidationRequest` struct for each pending consolidation. Needed for: (a) oracle to match CL events to pending requests, (b) reconciliation to know which requests completed/failed, (c) insolvency protection to know what to write down. |
+| **Q6** | How does this interact with `_assetBalance()` during the oracle report? | At request time: `PendingConsolidationBalance += expectedAmount` → `_assetBalance()` goes up → LsETH minted at correct rate. At oracle reconciliation: `PendingConsolidationBalance -= consolidatedDelta` and `validatorsBalance` increases by same delta → `_assetBalance()` net change = 0 for the consolidation portion. See [spike-buffer-reconciliation.md](spike-buffer-reconciliation.md). |
+| **Q7** | Does the source validator need to change its withdrawal credentials to LC's Withdraw contract first? | **No.** In EIP-7251 consolidation, the source validator is consumed (exits). Its balance is transferred to the target validator on the CL. The source validator's withdrawal credentials are irrelevant after the transfer — the funds end up under the target validator, which already has LC's withdrawal credentials. The source just needs to sign the consolidation request (or have its withdrawal credentials address initiate it from EL). |
+
+## Consolidation Entry Point Alternatives
+
+### A3-A: User-initiated, immediate mint (single tx)
+
+```
+User calls: River.consolidate(sourcePubkey, targetPubkey, expectedBalance)
+
+1. Allowlist check: onlyAllowed(msg.sender, CONSOLIDATION_MASK)
+2. Validate: targetPubkey belongs to an LC operator (check OperatorsRegistry)
+3. Record: ConsolidationRequests.push({
+     sourcePubkey, targetPubkey, recipient: msg.sender,
+     expectedBalance, status: PENDING, requestEpoch: currentEpoch
+   })
+4. Buffer: PendingConsolidationBalance += expectedBalance
+5. Mint: _mintShares(msg.sender, expectedBalance)  // uses current conversion rate
+6. Submit: Call CL consolidation request system contract with source ++ target
+7. Emit: ConsolidationRequested(requestId, msg.sender, sourcePubkey, targetPubkey, expectedBalance)
+```
+
+**Pros:** Simple UX (one tx), immediate LsETH, mirrors `deposit()` pattern.
+**Cons:** User provides `expectedBalance` — could be wrong or malicious. Relies on oracle reconciliation + A8 for safety.
+
+### A3-B: Keeper-attested, immediate mint (two tx)
+
+```
+Step 1 — User calls: River.requestConsolidation(sourcePubkey, targetPubkey)
+  1. Allowlist check
+  2. Record: ConsolidationRequests.push({
+       sourcePubkey, targetPubkey, recipient: msg.sender,
+       expectedBalance: 0, status: REQUESTED
+     })
+  3. Emit: ConsolidationRequested(requestId, msg.sender, sourcePubkey, targetPubkey)
+
+Step 2 — Keeper calls: River.executeConsolidation(requestId, expectedBalance, keeperSig?)
+  1. Only keeper
+  2. Validate: keeper confirms source validator balance from CL data
+  3. Update: request.expectedBalance = expectedBalance, status = PENDING
+  4. Buffer: PendingConsolidationBalance += expectedBalance
+  5. Mint: _mintShares(request.recipient, expectedBalance)
+  6. Submit: Call CL consolidation request system contract
+  7. Emit: ConsolidationExecuted(requestId, expectedBalance)
+```
+
+**Pros:** Keeper verifies CL balance before minting — much safer. No trust in user-provided amount.
+**Cons:** Two tx, user waits for keeper. Keeper becomes a bottleneck/trust point (but already trusted for deposits via BYOV).
+
+### A3-C: Oracle-confirmed mint (two tx, delayed)
+
+```
+Step 1 — User calls: River.requestConsolidation(sourcePubkey, targetPubkey)
+  1. Allowlist check
+  2. Record request
+  3. Submit CL consolidation request immediately
+
+Step 2 — Oracle reports CL acceptance in next report:
+  Oracle includes: confirmedConsolidations[] = [{requestId, confirmedBalance}]
+  River in setConsensusLayerData:
+  1. For each confirmed consolidation:
+     - PendingConsolidationBalance += confirmedBalance
+     - _mintShares(request.recipient, confirmedBalance)
+     - request.status = ACCEPTED
+```
+
+**Pros:** Oracle provides authoritative CL balance. No trust in user or keeper for the amount.
+**Cons:** Delayed minting (waits for next oracle report — could be hours). Minting inside oracle report adds complexity and gas. Complex oracle report structure.
+
+## Concrete Data Structures
+
+### ConsolidationRequest storage
+
+```solidity
+struct ConsolidationRequest {
+    bytes32 sourcePubkeyHash;   // keccak256 of source pubkey (for lookup)
+    bytes32 targetPubkeyHash;   // keccak256 of target pubkey
+    address recipient;          // LsETH recipient
+    uint256 expectedBalance;    // ETH expected from consolidation
+    uint256 reconciledBalance;  // ETH actually reconciled by oracle (0 until reconciled)
+    uint64 requestTimestamp;    // when initiated
+    uint8 status;               // REQUESTED(0), PENDING(1), COMPLETED(2), FAILED(3)
+}
+```
+
+### Storage: ConsolidationRequests array + mapping
+
+```solidity
+// Array of all consolidation requests (append-only)
+ConsolidationRequest[] consolidationRequests;
+
+// Map sourcePubkeyHash → requestId for oracle lookup
+mapping(bytes32 => uint256) consolidationRequestBySource;
+```
+
+### New Allowlist mask
+
+```solidity
+uint256 internal constant CONSOLIDATION_MASK = 0x8;  // bit 4
+```
+
+## Recommendation
+
+**A3-B (Keeper-attested)** is the best fit because:
+
+1. **Consistent with BYOV pattern** — the keeper is already trusted for validator allocation decisions. Adding consolidation attestation is a natural extension.
+2. **No user trust for amounts** — the keeper reads CL state and provides the correct expected balance.
+3. **Immediate-ish minting** — user waits for keeper (seconds to minutes), not for oracle report (hours).
+4. **Clean separation** — user expresses intent (step 1), keeper validates and executes (step 2).
+5. **`PendingConsolidationBalance` and minting are atomic in step 2** — the amount recorded in the buffer is exactly the amount used for minting, and it's provided by a trusted party.
+
+The keeper already has CL visibility (it does BYOV allocation). Adding "read source validator balance" is trivial.
+
+## Acceptance
+
+Spike is complete when we can describe the consolidation entry point flow, data structures, and how the expected amount gets recorded atomically with minting.
+
+**✅ Complete** — A3-B (keeper-attested two-step) is the recommended approach. The expected consolidation amount is recorded by the keeper (who reads CL state) at execution time, atomically with LsETH minting and `PendingConsolidationBalance` increment. Oracle reconciles later via `validatorsConsolidatedBalance` delta.

--- a/docs/spike-eth-based-accounting.md
+++ b/docs/spike-eth-based-accounting.md
@@ -1,0 +1,189 @@
+---
+shaping: true
+---
+
+# A9 Spike: ETH-Based Accounting (Remove 32 ETH / Count Dependencies)
+
+## Context
+
+The protocol currently uses `DEPOSIT_SIZE (32 ETH)` and validator counts in three accounting calculations:
+1. In-flight deposit balance in `_assetBalance()`
+2. Pre-exiting balance in exit demand calculation
+3. Exit demand quantity (validators to exit)
+
+Post-Pectra, validators can have >32 ETH (via consolidation). These count-based calculations become incorrect. We need to replace them with direct ETH amount tracking.
+
+## Goal
+
+Determine the concrete replacement mechanism for each of the three 32 ETH / count dependencies, ensuring `_assetBalance()` and exit demand calculations use actual ETH amounts.
+
+## Questions
+
+| # | Question | Answer |
+|---|----------|--------|
+| **Q1** | What does the in-flight calculation `(depositedCount - clCount) * 32 ETH` represent? | ETH that has left River (sent to beacon deposit contract) but isn't yet reflected in the oracle's `validatorsBalance`. Between deposit and validator activation on CL, there's a gap. Without this term, `_assetBalance()` would drop by 32 ETH per deposit and recover when the oracle reports the new validator — causing conversion rate fluctuations. |
+| **Q2** | How do we track in-flight ETH without using counts? | New `InFlightDepositBalance` storage variable. **Incremented** by 32 ETH each time `_depositValidator()` is called in `ConsensusLayerDepositManager`. **Decremented** when the oracle reports new validators. Currently the oracle reports `validatorsCount` increases. When count goes up by N, `InFlightDepositBalance -= N * 32 ETH`. This still uses 32 ETH per new validator, but that's correct — each new deposit IS 32 ETH. The key difference: in-flight balance is tracked as an ETH variable, not derived from count arithmetic. |
+| **Q3** | Wait — if new deposits are always 32 ETH, isn't `InFlightDepositBalance` always `(deposited - cl) * 32`? | Yes, for new deposits it's mathematically equivalent. But the **decrement** side is where it matters. Currently it relies on `clValidatorCount` matching `depositedValidatorCount` over time. With consolidation, `validatorsCount` may not increase the same way (a consolidation doesn't create a new validator, it merges into an existing one). By tracking the actual ETH amount, we decouple from count semantics entirely. Also, if future deposit sizes change, the variable still works. |
+| **Q4** | How does `preExitingBalance` work without `(requested - stopped) * 32`? | Currently `preExitingBalance` estimates how much ETH is "on the way" from exit requests that haven't completed yet. Replace with: `PendingFullExitBalance` — a storage variable tracking ETH expected from pending full exits. **Incremented** when keeper requests full exits — keeper provides the actual validator balance for each exit (from CL data). **Decremented** when oracle reports the exited balance via `validatorsExitedBalance`. Combined with `PendingPartialExitBalance` (from V2): `preExitingBalance = PendingFullExitBalance + PendingPartialExitBalance`. |
+| **Q5** | How does exit demand change from count-based to ETH-based? | Currently: `demandValidatorExits(validatorCount, depositedCount)` on OperatorsRegistry — tracks demand as a count. Replace with: `demandExitBalance(ethAmount)` — tracks demand as ETH. New `CurrentExitDemandBalance` replaces `CurrentValidatorExitsDemand`. The keeper then fills this demand using a mix of partial exits (specific ETH amounts) and full exits (actual validator balances from CL). The on-chain math works in ETH throughout — no count-based assumptions. |
+| **Q6** | How does the keeper know validator balances for full exits? | The keeper already has CL visibility (for BYOV deposit allocation). When requesting full exits, the keeper provides the actual balance per validator. This is already how the keeper works for partial exits (A6/A7). For full exits: keeper calls `requestExits()` with `FullExitRequest{pubkey, expectedBalance}` where `expectedBalance` comes from CL data. |
+| **Q7** | Does `validatorsCount` in the oracle report still serve a purpose? | Yes, but only for **CL validation**, not accounting. The oracle still reports validator count for sanity checks (e.g., can't exceed deposited count, can't decrease). But it's no longer used in `_assetBalance()` or exit demand calculations. |
+
+## Concrete Changes
+
+### 1. InFlightDepositBalance — replaces `(depositedCount - clCount) * 32`
+
+**Storage:** `contracts/src/state/river/InFlightDepositBalance.sol`
+
+**Increment** in `ConsensusLayerDepositManager._depositValidator()`:
+```solidity
+// After each successful deposit to beacon chain
+InFlightDepositBalance.set(InFlightDepositBalance.get() + DEPOSIT_SIZE);
+```
+
+**Decrement** in `OracleManager.setConsensusLayerData()`:
+```solidity
+// When oracle reports new validators activated
+uint32 newValidators = _report.validatorsCount - lastStoredReport.validatorsCount;
+if (newValidators > 0) {
+    uint256 activatedBalance = uint256(newValidators) * _DEPOSIT_SIZE;
+    uint256 current = InFlightDepositBalance.get();
+    // Guard against underflow (shouldn't happen, but defensive)
+    InFlightDepositBalance.set(current > activatedBalance ? current - activatedBalance : 0);
+}
+```
+
+**Modified `_assetBalance()`:**
+```solidity
+function _assetBalance() internal view override returns (uint256) {
+    IOracleManagerV1.StoredConsensusLayerReport storage storedReport = LastConsensusLayerReport.get();
+    return storedReport.validatorsBalance
+        + BalanceToDeposit.get()
+        + CommittedBalance.get()
+        + BalanceToRedeem.get()
+        + PendingConsolidationBalance.get()
+        + InFlightDepositBalance.get();     // replaces (depositedCount - clCount) * 32
+}
+```
+
+**Note:** `DepositedValidatorCount` and `CLValidatorCount` (from oracle) are still maintained for CL validation and event reporting, but no longer used in `_assetBalance()`.
+
+### 2. PendingFullExitBalance — replaces `(requested - stopped) * 32`
+
+**Storage:** `contracts/src/state/river/PendingFullExitBalance.sol`
+
+**Increment** in `River.requestExits()` — when keeper requests full exits:
+```solidity
+struct FullExitRequest {
+    bytes pubkey;
+    uint256 expectedBalance;  // actual CL balance, provided by keeper
+}
+
+struct ExitRequest {
+    PartialExitRequest[] partialExits;
+    FullExitRequest[] fullExits;  // CHANGED from OperatorAllocation[]
+}
+
+// In requestExits():
+for each fullExit in _request.fullExits:
+    PendingFullExitBalance += fullExit.expectedBalance;
+    // Also route to OperatorsRegistry for operator accounting
+```
+
+**Decrement** in oracle report — when exited funds arrive:
+```solidity
+// exitedAmountIncrease includes both full and partial exits
+// Partial exits are reconciled via PendingPartialExitBalance
+// Full exits are reconciled via PendingFullExitBalance
+// We need to distinguish them — use validatorsPartiallyExitedBalance delta for partial
+// Remainder of exitedAmountIncrease = full exit funds
+
+uint256 fullExitReconcile = exitedAmountIncrease - partialExitIncrease;
+PendingFullExitBalance -= min(fullExitReconcile, PendingFullExitBalance);
+```
+
+**Modified preExitingBalance:**
+```solidity
+// OLD: (requestedExits - stopped) * DEPOSIT_SIZE
+// NEW:
+uint256 preExitingBalance = PendingFullExitBalance.get() + PendingPartialExitBalance.get();
+```
+
+### 3. ETH-based exit demand — replaces count-based demand
+
+**OperatorsRegistry changes:**
+
+Replace:
+- `CurrentValidatorExitsDemand` (count) → `CurrentExitDemandBalance` (ETH)
+- `demandValidatorExits(count, depositedCount)` → `demandExitBalance(ethAmount)`
+
+```solidity
+function demandExitBalance(uint256 _ethAmount) external onlyRiver {
+    CurrentExitDemandBalance.set(CurrentExitDemandBalance.get() + _ethAmount);
+    emit SetCurrentExitDemandBalance(CurrentExitDemandBalance.get());
+}
+```
+
+**River exit demand calculation:**
+```solidity
+// OLD:
+// validatorCountToExit = ceil(shortfall / DEPOSIT_SIZE);
+// or.demandValidatorExits(validatorCountToExit, DepositedValidatorCount.get());
+
+// NEW:
+uint256 preExitingBalance = PendingFullExitBalance.get() + PendingPartialExitBalance.get();
+if (availableBalanceToRedeem + _exitingBalance + preExitingBalance < redeemManagerDemandInEth) {
+    uint256 exitDemand = redeemManagerDemandInEth
+        - (availableBalanceToRedeem + _exitingBalance + preExitingBalance);
+    or.demandExitBalance(exitDemand);
+}
+```
+
+**Keeper fills the demand:**
+```solidity
+// Keeper reads CurrentExitDemandBalance
+// Decides mix of partial + full exits based on CL state
+// Calls River.requestExits() with actual amounts
+// CurrentExitDemandBalance decremented by filled amount
+```
+
+### 4. Summary of where DEPOSIT_SIZE is still used (deposit mechanics only)
+
+| Location | Use | Why it stays |
+|----------|-----|-------------|
+| `_commitBalanceToDeposit` rounding | `amount / DEPOSIT_SIZE * DEPOSIT_SIZE` | Deposits must be exact multiples of 32 ETH |
+| `depositToConsensusLayer` | `committedBalance / DEPOSIT_SIZE` | Each CL deposit is exactly 32 ETH |
+| `_depositValidator` | `value = DEPOSIT_SIZE` | Beacon deposit contract requires 32 ETH |
+| `InFlightDepositBalance` increment | `+= DEPOSIT_SIZE` | Each deposit adds exactly 32 ETH to in-flight |
+| Oracle: new validator activation | `newCount * DEPOSIT_SIZE` for decrementing InFlightDepositBalance | Each activated validator was deposited at 32 ETH |
+
+These are all **deposit mechanics** — the physical act of depositing is 32 ETH. This is a protocol/beacon chain constraint, not an accounting assumption.
+
+## Migration
+
+On upgrade (`initRiverV1_3`):
+```solidity
+// Initialize InFlightDepositBalance from current state
+uint256 depositedCount = DepositedValidatorCount.get();
+uint256 clCount = LastConsensusLayerReport.get().validatorsCount;
+if (depositedCount > clCount) {
+    InFlightDepositBalance.set((depositedCount - clCount) * 32 ether);
+}
+
+// Initialize PendingFullExitBalance = 0 (no pending exits at upgrade time)
+// Initialize CurrentExitDemandBalance from CurrentValidatorExitsDemand
+uint256 currentDemand = CurrentValidatorExitsDemand.get();
+CurrentExitDemandBalance.set(currentDemand * 32 ether); // conservative estimate
+```
+
+## Conclusion
+
+Three replacements, all following the same principle — **track ETH amounts directly instead of deriving from counts**:
+
+| Old (count-based) | New (ETH-based) |
+|---|---|
+| `(depositedCount - clCount) * 32` | `InFlightDepositBalance` |
+| `(requestedExits - stopped) * 32` | `PendingFullExitBalance + PendingPartialExitBalance` |
+| `ceil(shortfall / 32)` validators → `demandValidatorExits(count)` | `shortfall` ETH → `demandExitBalance(ethAmount)` |
+
+`DEPOSIT_SIZE` and validator counts remain for deposit mechanics and CL validation only — never for balance accounting.

--- a/docs/spike-insolvency-protection.md
+++ b/docs/spike-insolvency-protection.md
@@ -1,0 +1,156 @@
+---
+shaping: true
+---
+
+# A8 Spike: Insolvency Protection for Failed Consolidations
+
+## Context
+
+When a consolidation is executed (A3), LsETH is minted immediately and `PendingConsolidationBalance` is incremented. If the consolidation subsequently fails on CL (source validator exits but balance doesn't transfer to the target), the protocol has minted LsETH backed by ETH that never arrives. `PendingConsolidationBalance` stays inflated, `_assetBalance()` overstates the real value, and every LsETH holder is exposed to dilution.
+
+We need a mechanism to detect failure, write down the buffer, and recover the loss.
+
+## Goal
+
+Determine the concrete mechanics of insolvency protection: how failure is detected, how the buffer is written down, how the loss is covered, and what the impact is on LsETH holders.
+
+## Questions
+
+| # | Question | Answer |
+|---|----------|--------|
+| **Q1** | How does the CoverageFund currently work? | Simple donation-based fund. Authorized entities (treasury, insurance) call `donate()` to deposit ETH. River pulls from it during oracle reports, after EL fees, if there's headroom under the `annualAprUpperBound`. Coverage funds go to `BalanceToDeposit` — no fee minted on them. Funds are pulled gradually across multiple reports due to the upper bound constraint. Designed for slashing recovery with a 365-day target for injection. |
+| **Q2** | How can a consolidation fail? | Several failure modes: (1) CL rejects the consolidation request (source validator ineligible, target ineligible). (2) Source validator gets slashed during the consolidation window. (3) Source validator exits before balance transfers to target. (4) Unknown CL bug prevents transfer. In all cases: the source validator's balance doesn't arrive at the target LC validator, but LsETH has already been minted. |
+| **Q3** | When can we detect failure? | The oracle can detect failure when: (1) The consolidation has been pending for longer than a maximum expected duration (timeout). After CL acceptance, balance transfer typically takes ~27 hours (exit queue). If no `validatorsConsolidatedBalance` increase is reported after N epochs (e.g., 2x the expected window), it's likely failed. (2) The oracle detects the source validator has exited without a corresponding consolidation transfer. The oracle has CL visibility and can match source exit events to pending consolidation records. |
+| **Q4** | What happens between failure and recovery? | `PendingConsolidationBalance` remains inflated → `_assetBalance()` is higher than actual → conversion rate is inflated → all LsETH holders get slightly less ETH per share than they should. The consolidator's LsETH is worth more than the ETH they actually contributed. This is the **insolvency window**. |
+| **Q5** | Can we burn the consolidator's LsETH to recover? | Technically possible but undesirable: (1) The consolidator may have already transferred or sold the LsETH. (2) Forced burning would require tracking per-consolidation LsETH recipients and having admin authority to burn — introduces censorship/seizure risk. (3) Institutional users would not accept a protocol that can seize their tokens. **Not recommended.** |
+| **Q6** | How does the CoverageFund recover the loss? | Same mechanism as slashing recovery: (1) Admin/oracle writes down `PendingConsolidationBalance` by the failed amount. (2) `_assetBalance()` drops → conversion rate drops (loss socialized across all holders). (3) Alluvial/insurance donates the lost amount to CoverageFund. (4) On subsequent oracle reports, CoverageFund is pulled → `BalanceToDeposit` increases → `_assetBalance()` recovers → conversion rate recovers. The recovery is rate-limited by `availableAmountToUpperBound` (same as slashing recovery). |
+
+## Concrete Mechanism
+
+### 1. Failure detection: Oracle-reported + timeout
+
+Two complementary detection paths:
+
+**Path A: Oracle detects explicitly**
+```
+Oracle monitors pending consolidations:
+  - Source validator exited (withdrawable_epoch reached, balance swept)
+  - No corresponding increase in validatorsConsolidatedBalance for the target
+  - Oracle includes failed consolidation data in report:
+    failedConsolidationIds[] in ConsensusLayerReport
+```
+
+**Path B: Timeout-based**
+```
+Each ConsolidationRequest has a requestTimestamp (set at executeConsolidation).
+If currentTimestamp > requestTimestamp + MAX_CONSOLIDATION_DURATION:
+  - Consolidation considered failed
+  - Admin or oracle can trigger writedown
+```
+
+`MAX_CONSOLIDATION_DURATION` should be generous (e.g., 7 days) to account for CL delays, but bounded to limit insolvency window.
+
+### 2. Buffer writedown
+
+```solidity
+// Called by oracle (via report) or admin
+function writeDownFailedConsolidation(uint256 _requestId) external {
+    // Only oracle or admin
+    ConsolidationRequest storage request = consolidationRequests[_requestId];
+    require(request.status == PENDING);
+
+    // Write down the buffer
+    uint256 failedAmount = request.expectedBalance - request.reconciledBalance;
+    PendingConsolidationBalance -= failedAmount;
+
+    request.status = FAILED;
+
+    emit ConsolidationFailed(_requestId, failedAmount);
+}
+```
+
+**Impact on `_assetBalance()`:**
+- Before writedown: `_assetBalance()` includes the phantom `failedAmount` → conversion rate inflated
+- After writedown: `_assetBalance()` drops by `failedAmount` → conversion rate drops
+- Loss is immediately socialized across all LsETH holders
+
+### 3. Recovery via CoverageFund
+
+```
+Timeline:
+  T=0:   Consolidation executed, LsETH minted, PendingConsolidationBalance += X
+  T+27h: Expected completion. Balance doesn't arrive.
+  T+7d:  Timeout triggers. Admin/oracle writes down PendingConsolidationBalance -= X.
+         _assetBalance() drops by X. Conversion rate drops. Loss socialized.
+  T+?:   Alluvial/insurance donates X ETH to CoverageFund.
+         Next oracle reports gradually pull CoverageFund → BalanceToDeposit.
+         _assetBalance() recovers. Conversion rate recovers.
+```
+
+**No new mechanism needed** — the existing CoverageFund donation + pull flow handles recovery. The only new pieces are:
+1. Detection logic (oracle reporting failed consolidations or timeout)
+2. Writedown function on River
+
+### 4. Impact analysis
+
+For a failed consolidation of amount X, with total `_assetBalance()` of T:
+
+```
+Conversion rate impact = X / T
+
+Example: 100 ETH failed consolidation, 100,000 ETH total assets
+  → 0.1% conversion rate drop
+  → Each LsETH holder loses 0.1% value temporarily
+  → Recovered when CoverageFund is replenished
+```
+
+### 5. Risk mitigation (reduce probability of failure)
+
+The insolvency protection is a backstop. The primary defense is **preventing failures**:
+
+| Mitigation | Mechanism |
+|------------|-----------|
+| **Keeper validates CL state** | Keeper checks source validator is eligible for consolidation before calling `executeConsolidation()`. Checks: active status, not slashed, not exiting, sufficient balance. |
+| **Oracle confirms CL acceptance** | Before minting could be deferred to oracle confirmation (A3-C). Rejected for UX reasons, but remains an option for high-value consolidations. |
+| **Consolidation amount cap** | Admin-configurable maximum single consolidation amount. Limits exposure per consolidation. |
+| **Total pending cap** | Admin-configurable maximum total `PendingConsolidationBalance`. Limits total protocol exposure. |
+| **Allowlist vetting** | Only allowlisted institutional validators can consolidate. Reduces risk of malicious or unreliable source validators. |
+
+### 6. Oracle report extension for failure detection
+
+```solidity
+struct ConsensusLayerReport {
+    // ... existing fields ...
+    uint256 validatorsConsolidatedBalance;     // from buffer reconciliation spike
+
+    // NEW: failed consolidation reporting
+    uint32[] failedConsolidationIds;           // request IDs of consolidations that failed on CL
+}
+```
+
+In `setConsensusLayerData`:
+```
+// After reconciling successful consolidations...
+for each failedId in report.failedConsolidationIds:
+    writeDownFailedConsolidation(failedId)
+```
+
+## Edge Cases
+
+| Case | What happens |
+|------|--------------|
+| **Partial failure** (some ETH arrives, not all) | `validatorsConsolidatedBalance` delta < expected. Remaining amount stays in buffer. Eventually detected as partial failure if no further reconciliation. Writedown only for the unreconciled portion. |
+| **CoverageFund is empty** | Loss remains socialized until fund is replenished. Conversion rate stays depressed. This is the same as current slashing behavior — there's no instant guarantee. |
+| **Multiple simultaneous failures** | Each writedown is independent. Total impact = sum of failed amounts. Cumulative cap on `PendingConsolidationBalance` limits maximum exposure. |
+| **False positive timeout** (consolidation is just slow) | Use a generous timeout (7+ days). If consolidation completes after writedown, the `validatorsConsolidatedBalance` delta will arrive as unexpected income — treated as a gain, gradually absorbed. Admin can also manually adjust. |
+| **Consolidation fails before CL acceptance** | If the CL rejects the request entirely, the source validator never exits. Oracle detects no change. Timeout triggers writedown. |
+
+## Conclusion
+
+Insolvency protection for failed consolidations requires two new pieces:
+1. **Detection:** Oracle reports `failedConsolidationIds[]` + timeout-based fallback
+2. **Writedown:** `PendingConsolidationBalance -= failedAmount`, loss socialized to all holders
+
+Recovery uses the **existing CoverageFund mechanism** unchanged — donate ETH, oracle pulls it gradually, `_assetBalance()` recovers.
+
+Primary defense is **prevention** (keeper CL validation, amount caps, allowlist vetting), with CoverageFund as the backstop. This is architecturally consistent with how slashing losses are already handled.

--- a/docs/spike-partial-exits.md
+++ b/docs/spike-partial-exits.md
@@ -1,0 +1,247 @@
+---
+shaping: true
+---
+
+# A6/A7 Spike: Partial Exits + Keeper Exit Strategy
+
+## Context
+
+Currently, the only way to satisfy redemption demand that exceeds available ETH buffers is full validator exits (32 ETH each, ~27 hour exit queue). EIP-7002 introduces EL-triggered withdrawal requests, enabling partial withdrawals (withdraw some ETH from a validator without fully exiting it). This spike investigates the concrete mechanics of integrating partial exits into the existing exit flow and the keeper's decision-making strategy.
+
+## Goal
+
+Understand how EIP-7002 partial exits integrate with: (1) the existing exit demand / pre-exiting balance tracking, (2) the oracle reporting flow, (3) the Withdraw contract, and (4) how the keeper decides between partial and full exits.
+
+## Questions
+
+| # | Question | Answer |
+|---|----------|--------|
+| **Q1** | How does EIP-7002 work mechanically? | A system contract at a predefined address accepts withdrawal requests. Call it with `validator_pubkey (48 bytes) ++ amount (8 bytes, LE gwei)`. If `amount == 0` or `amount >= validator_balance` → full exit. If `amount < validator_balance` → partial withdrawal. The call must come from the validator's **withdrawal credentials address**. A dynamic fee (similar to EIP-1559) must be paid in ETH with the call. For LC validators, the withdrawal credentials address is the **Withdraw contract**. |
+| **Q2** | Who calls the EIP-7002 system contract? | The **Withdraw contract** — because it IS the withdrawal credentials address for all LC validators. River calls Withdraw, Withdraw calls the system contract. This requires a new function on Withdraw: `requestWithdrawal(pubkey, amount)`, callable only by River. River exposes a keeper-callable function that routes through Withdraw. |
+| **Q3** | How do partial exit funds arrive and get classified by the oracle? | Partial exit funds arrive at the Withdraw contract as CL withdrawals (same as skimming and full exits). The oracle can classify them via `validatorsExitedBalance` (cumulative, non-decreasing). This works because: (1) `_pullCLFunds` routes exited funds to `BalanceToRedeem` — correct for satisfying redemptions. (2) The decrease in `validatorsBalance` + increase in `validatorsExitedBalance` cancel out in `_assetBalance()` — bounds check sees only rewards. (3) Stopped validator counts are tracked separately and are unaffected. **No new oracle field needed for partial exits.** |
+| **Q4** | How does partial exit tracking differ from full exit tracking? | Full exits are tracked by **validator count**: `CurrentValidatorExitsDemand`, `TotalValidatorExitsRequested`, `stoppedValidatorCountPerOperator`. Partial exits must be tracked by **ETH amount**: a new `PendingPartialExitBalance` variable (or similar) tracks how much ETH has been requested via partial exits but not yet received. This is used in the exit demand calculation to avoid over-requesting. |
+| **Q5** | How does `preExitingBalance` change with partial exits? | Currently: `preExitingBalance = (requestedExits - stoppedValidators) * DEPOSIT_SIZE`. With partial exits, it becomes: `preExitingBalance = (requestedFullExits - stoppedValidators) * DEPOSIT_SIZE + PendingPartialExitBalance`. The partial exit amount is added directly (it's already in ETH), the full exit portion stays count-based at 32 ETH per validator. |
+| **Q6** | How does the keeper decide between partial and full exits? | **Decision tree:** (1) Calculate shortfall: `redeemDemandInEth - (BalanceToRedeem + exitingBalance + preExitingBalance)`. (2) If shortfall <= available excess balance across validators → **partial exits only** (faster, cheaper, no validator loss). (3) If shortfall > available excess but can be partially covered → **partial exits + full exits** for the remainder. (4) If no excess balance → **full exits only**. The keeper needs CL visibility to know which validators have excess balance above 32 ETH. |
+| **Q7** | What's the EIP-7002 fee model? Is it economically viable? | The fee uses an EIP-1559-like mechanism: starts low, increases exponentially with demand. In normal conditions the fee is negligible (< 1 gwei). It only becomes expensive under extreme network-wide exit demand. For LC's purposes, the fee is almost always trivially small and should not be a barrier. The fee is paid from River's ETH balance (or from Withdraw contract balance). |
+| **Q8** | Can the keeper trigger both full exits and partial exits in the same call? | Ideally yes — for efficiency. A single keeper call could specify a mix of full and partial exits. The contract would loop through, calling the EIP-7002 system contract for each. |
+
+## Concrete Mechanism
+
+### 1. Withdraw contract upgrade
+
+```solidity
+// New function on WithdrawV1
+// Calls the EIP-7002 withdrawal request system contract
+function requestWithdrawal(
+    bytes calldata _pubkey,     // 48 bytes
+    uint64 _amountInGwei        // 0 = full exit, >0 = partial withdrawal amount in gwei
+) external onlyRiver {
+    // Encode: pubkey (48 bytes) ++ amount (8 bytes, little-endian)
+    bytes memory request = abi.encodePacked(_pubkey, _toLittleEndian64(_amountInGwei));
+
+    // Call EIP-7002 system contract (predefined address)
+    // Fee is paid from Withdraw contract's ETH balance
+    (bool success,) = WITHDRAWAL_REQUEST_CONTRACT.call{value: fee}(request);
+    require(success);
+}
+```
+
+### 2. River: keeper-callable partial exit function
+
+```solidity
+struct PartialExitRequest {
+    bytes pubkey;          // 48 bytes - validator to partially exit
+    uint64 amountInGwei;   // amount to withdraw in gwei
+}
+
+struct ExitRequest {
+    PartialExitRequest[] partialExits;
+    OperatorAllocation[] fullExits;      // existing pattern
+}
+
+// Keeper calls this to request a mix of partial and full exits
+function requestExits(ExitRequest calldata _request) external onlyKeeper {
+    uint256 totalPartialExitAmount = 0;
+
+    // Process partial exits via Withdraw → EIP-7002 system contract
+    for (uint256 i = 0; i < _request.partialExits.length; i++) {
+        uint256 amount = uint256(_request.partialExits[i].amountInGwei) * 1 gwei;
+        IWithdrawV1(WithdrawalCredentials.getAddress()).requestWithdrawal(
+            _request.partialExits[i].pubkey,
+            _request.partialExits[i].amountInGwei
+        );
+        totalPartialExitAmount += amount;
+    }
+
+    // Track pending partial exits
+    PendingPartialExitBalance += totalPartialExitAmount;
+
+    // Process full exits via existing OperatorsRegistry flow
+    if (_request.fullExits.length > 0) {
+        IOperatorsRegistryV1(OperatorsRegistryAddress.get())
+            .requestValidatorExits(_request.fullExits);
+    }
+}
+```
+
+### 3. New storage variable
+
+```solidity
+// PendingPartialExitBalance — total ETH requested via partial exits, not yet received
+// Incremented when keeper submits partial exit requests
+// Decremented when oracle reconciles (partial exit funds arrive via validatorsExitedBalance)
+```
+
+### 4. Modified exit demand calculation (River._requestExitsBasedOnRedeemDemandAfterRebalancings)
+
+```
+CURRENT:
+  preExitingBalance = (requestedExits - stoppedValidators) * 32 ETH
+  shortfall = redeemDemandInEth - (BalanceToRedeem + exitingBalance + preExitingBalance)
+  validatorCountToExit = ceil(shortfall / 32 ETH)
+  → demandValidatorExits(validatorCountToExit)
+
+NEW:
+  preExitingFullBalance = (requestedExits - stoppedValidators) * 32 ETH
+  preExitingBalance = preExitingFullBalance + PendingPartialExitBalance
+  shortfall = redeemDemandInEth - (BalanceToRedeem + exitingBalance + preExitingBalance)
+
+  // System still demands in validator counts for full exits
+  // Keeper decides how to fill the demand (partial vs full)
+  // The demandValidatorExits remains count-based
+  // But the keeper has flexibility to use partial exits BEFORE demanding full exits
+```
+
+### 5. Oracle reconciliation of partial exits
+
+```
+Oracle reports:
+  validatorsExitedBalance += partialExitAmount  (arrives as CL withdrawal)
+  validatorsBalance -= partialExitAmount          (validator balance decreased)
+
+In setConsensusLayerData:
+  exitedAmountIncrease = new.validatorsExitedBalance - old.validatorsExitedBalance
+  _pullCLFunds(skimmedIncrease, exitedAmountIncrease)
+    → BalanceToRedeem += exitedAmountIncrease  (partial exit funds available for redemptions)
+
+  // Reconcile PendingPartialExitBalance
+  // The oracle needs to report how much of the exited balance is from partial exits
+  // OR: we simply decrement PendingPartialExitBalance as funds arrive
+  // Simplest: new oracle field validatorsPartiallyExitedBalance (cumulative)
+  // Delta used to decrement PendingPartialExitBalance
+```
+
+**Wait — reconciliation subtlety:** We need to know which portion of `validatorsExitedBalance` increase is from partial exits vs full exits. Without this, we can't properly decrement `PendingPartialExitBalance`.
+
+**Two options:**
+
+**Option A: New oracle field `validatorsPartiallyExitedBalance`**
+- Cumulative, non-decreasing (same pattern as skimmed/exited)
+- Oracle distinguishes partial exit withdrawals from full exit withdrawals on CL
+- Delta used to decrement `PendingPartialExitBalance`
+- Clean, explicit
+
+**Option B: Trust the keeper's accounting**
+- Keeper tracks which partial exits have been submitted
+- When `validatorsExitedBalance` increases, the keeper tells the system how much was partial
+- Less robust — relies on keeper being correct
+
+**Recommendation: Option A** — consistent with the pattern established in the buffer reconciliation spike. The oracle already distinguishes skimmed vs exited; adding partially-exited is a natural extension.
+
+### 6. Keeper exit strategy (A7)
+
+```
+KEEPER DECISION LOGIC (off-chain):
+
+Input:
+  - redeemDemandInEth (from RedeemManager)
+  - availableBalanceToRedeem (BalanceToRedeem)
+  - exitingBalance (from oracle report)
+  - preExitingBalance (pending full + partial exits)
+  - validatorExcessBalances[] (from CL data: per-validator balance - 32 ETH)
+  - EIP-7002 fee (from system contract)
+
+Step 1: Calculate shortfall
+  shortfall = redeemDemandInEth - (availableBalanceToRedeem + exitingBalance + preExitingBalance)
+  if shortfall <= 0: DONE (no exits needed)
+
+Step 2: Try partial exits first
+  Sort validators by excess balance (descending)
+  partialExitAmount = 0
+  partialExitRequests = []
+  for each validator with excess > 0:
+    withdrawable = min(validator.excess, shortfall - partialExitAmount)
+    if withdrawable > EIP_7002_FEE * MIN_FEE_RATIO:  // only if economically viable
+      partialExitRequests.push({pubkey, withdrawable})
+      partialExitAmount += withdrawable
+    if partialExitAmount >= shortfall: BREAK
+
+Step 3: If partial exits insufficient, add full exits
+  remainingShortfall = shortfall - partialExitAmount
+  if remainingShortfall > 0:
+    fullExitCount = ceil(remainingShortfall / 32 ETH)
+    fullExitAllocations = selectOperatorAllocations(fullExitCount)
+
+Step 4: Submit combined request
+  River.requestExits({partialExits, fullExits})
+```
+
+**Key insight:** The keeper prefers partial exits because:
+- **Faster:** No exit queue wait (~minutes vs ~27 hours)
+- **Cheaper:** No need to fund a new validator later
+- **Preserves validator count:** Validator stays active, keeps earning rewards
+- **Smaller unit:** Can exactly match redemption demand (no 32 ETH granularity)
+
+**Fallback to full exits when:**
+- No validators have excess balance (all at exactly 32 ETH)
+- Partial exit fee is unreasonably high (extreme network demand)
+- Redemption demand exceeds total available excess across all validators
+
+### 7. Updated flow: Redeem demand → Exit → Completion
+
+```
+Phase 1: User requests redemption (UNCHANGED)
+  → RedeemDemand increases
+
+Phase 2: Oracle report triggers exit demand calculation
+  → Modified to account for PendingPartialExitBalance in preExitingBalance
+  → demandValidatorExits() may demand fewer full exits because partial exits cover some demand
+
+Phase 3: Keeper decides strategy (NEW)
+  → Reads CL state for validator excess balances
+  → Calculates optimal mix of partial + full exits
+  → Calls River.requestExits() with combined request
+  → River routes partial exits through Withdraw → EIP-7002 system contract
+  → River routes full exits through OperatorsRegistry (existing flow)
+
+Phase 4: Partial exit funds arrive (NEW)
+  → CL processes partial withdrawal → funds at Withdraw contract
+  → Oracle reports validatorsPartiallyExitedBalance increase
+  → River pulls funds → BalanceToRedeem += partialExitAmount
+  → PendingPartialExitBalance -= partialExitAmount
+
+Phase 5-7: (UNCHANGED)
+  → reportWithdrawToRedeemManager, user claims
+```
+
+## Edge Cases
+
+| Case | What happens |
+|------|--------------|
+| **Partial exit processed but less ETH arrives than requested** | `validatorsPartiallyExitedBalance` delta < requested. `PendingPartialExitBalance` remains partially inflated. Resolves on subsequent reports or via admin writedown. |
+| **Validator slashed after partial exit request** | Partial exit may return less ETH. Handled same as above. |
+| **EIP-7002 fee spikes during high demand** | Keeper checks fee before submitting. If fee > threshold, skips partial exits and falls back to full exits (which don't use EIP-7002 — operators do the CL exit voluntarily). |
+| **Multiple partial exits on same validator** | Valid — a validator with 100 ETH excess could receive multiple partial exit requests. Keeper tracks cumulative requested amount per validator. |
+| **Partial exit on validator that's also been requested for full exit** | The full exit takes precedence on CL. The partial exit amount should not be double-counted. Keeper should avoid this situation. |
+| **No excess balance on any validators (all at 32 ETH)** | Partial exits impossible. Keeper falls back to full exits only. After Pectra + consolidations, validators will commonly have >32 ETH, making this less likely. |
+
+## Conclusion
+
+Partial exits via EIP-7002 slot cleanly into the existing architecture:
+- **Call path:** Keeper → River → Withdraw → EIP-7002 system contract
+- **Fund flow:** CL withdrawal → Withdraw contract → River (`_pullCLFunds`) → `BalanceToRedeem`
+- **Tracking:** New `PendingPartialExitBalance` variable + oracle's `validatorsPartiallyExitedBalance` field
+- **Demand calculation:** `preExitingBalance` now includes both full and partial pending exits
+- **Keeper strategy:** Partial first (faster, cheaper), full exit as fallback
+
+The keeper's role expands: in addition to BYOV deposit allocation and exit allocation, it now decides the optimal partial/full exit mix based on CL state.


### PR DESCRIPTION
## Description

This pull request introduces ETH-based accounting for validator exits and in-flight deposits, significantly enhancing the precision and transparency of exit and deposit tracking in the protocol. The changes add new state variables and methods to manage ETH balances for pending validator exits and deposits, refactor related logic to use these balances, and introduce new events for improved observability. The update also includes migration and initialization logic to support seamless upgrades.

**ETH-based Exit Demand and Full Exit Handling:**

- Added `CurrentExitDemandBalance` state and related logic to track and manage the ETH-based exit demand, including new methods (`demandExitBalance`, `fillExitDemandBalance`, `getCurrentExitDemandBalance`) and events (`SetCurrentExitDemandBalance`) in `OperatorsRegistryV1` and its interface. Exit demand is now decremented based on actual ETH amounts rather than validator counts. [[1]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabR18) [[2]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabR693-R702) [[3]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabR749-R782) [[4]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90R391-R409)

- Introduced `PendingFullExitBalance` and new methods in `RiverV1` for requesting full validator exits by ETH amount, reconciling pending exits, and querying the pending exit balance. Added events for full exit requests and reconciliations. [[1]](diffhunk://#diff-34420a68f2d8aba02b8bc93ba4306dcb459547b0c3a4815dfa1737a16c14665eR131-R142) [[2]](diffhunk://#diff-34420a68f2d8aba02b8bc93ba4306dcb459547b0c3a4815dfa1737a16c14665eR299-R332) [[3]](diffhunk://#diff-b60cd97fe270d3777949b4d10e8f36471d394d54ea1275f115684e056a639063R106-R119)

**ETH-based In-Flight Deposit Tracking:**

- Added `InFlightDepositBalance` state and associated logic to track ETH amounts for validators deposited but not yet activated. Updated deposit and activation flows to increase or decrease this balance accordingly, and exposed it via the interface. [[1]](diffhunk://#diff-34420a68f2d8aba02b8bc93ba4306dcb459547b0c3a4815dfa1737a16c14665eL394-R473) [[2]](diffhunk://#diff-7b338638aeefb6f1e264218c49aab994b7c0b9b06328f2d95b74a82b9a9cc702R17) [[3]](diffhunk://#diff-7b338638aeefb6f1e264218c49aab994b7c0b9b06328f2d95b74a82b9a9cc702R42-R46) [[4]](diffhunk://#diff-7b338638aeefb6f1e264218c49aab994b7c0b9b06328f2d95b74a82b9a9cc702R99-R103) [[5]](diffhunk://#diff-7b338638aeefb6f1e264218c49aab994b7c0b9b06328f2d95b74a82b9a9cc702R164)

- Refactored the internal accounting in `RiverV1` and `ConsensusLayerDepositManagerV1` to use the new in-flight deposit balance, replacing previous logic based on validator count differences. [[1]](diffhunk://#diff-34420a68f2d8aba02b8bc93ba4306dcb459547b0c3a4815dfa1737a16c14665eL394-R473) [[2]](diffhunk://#diff-7b338638aeefb6f1e264218c49aab994b7c0b9b06328f2d95b74a82b9a9cc702R164)

**Protocol Upgradability and Initialization:**

- Added initialization functions (`initOperatorsRegistryV1_3`, `initRiverV1_3`) to migrate existing state to the new ETH-based accounting system during upgrades. [[1]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabR749-R782) [[2]](diffhunk://#diff-34420a68f2d8aba02b8bc93ba4306dcb459547b0c3a4815dfa1737a16c14665eR131-R142)

**Internal Refactoring and Consistency:**

- Refactored logic for exit demand and pending exits in `RiverV1` to use ETH-based balances throughout, replacing validator count-based calculations and ensuring consistency across the protocol.

**Versioning:**

- Updated the protocol version to `1.3.0` in both `OperatorsRegistryV1` and `RiverV1` to reflect these significant changes. [[1]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabR749-R782) [[2]](diffhunk://#diff-34420a68f2d8aba02b8bc93ba4306dcb459547b0c3a4815dfa1737a16c14665eL613-R674)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->