### PR TITLE
Block WLSETH denylist bypasses in mint and burn

### DIFF
--- a/contracts/src/WLSETH.1.sol
+++ b/contracts/src/WLSETH.1.sol
@@ -124,8 +124,11 @@ contract WLSETHV1 is IWLSETHV1, Initializable, ReentrancyGuardUpgradeable {
 
     /// @inheritdoc IWLSETHV1
     function mint(address _recipient, uint256 _shares) external nonReentrant {
-        BalanceOf.set(_recipient, BalanceOf.get(_recipient) + _shares);
         IRiverV1 river = IRiverV1(payable(RiverAddress.get()));
+        if (IAllowlistV1(river.getAllowlist()).isDenied(_recipient)) {
+            revert Denied(_recipient);
+        }
+        BalanceOf.set(_recipient, BalanceOf.get(_recipient) + _shares);
         if (!river.transferFrom(msg.sender, address(this), _shares)) {
             revert TokenTransferError();
         }
@@ -139,8 +142,11 @@ contract WLSETHV1 is IWLSETHV1, Initializable, ReentrancyGuardUpgradeable {
         if (_shares > shares) {
             revert BalanceTooLow();
         }
-        BalanceOf.set(msg.sender, shares - _shares);
         IRiverV1 river = IRiverV1(payable(RiverAddress.get()));
+        if (IAllowlistV1(river.getAllowlist()).isDenied(msg.sender)) {
+            revert Denied(msg.sender);
+        }
+        BalanceOf.set(msg.sender, shares - _shares);
         if (!river.transfer(_recipient, _shares)) {
             revert TokenTransferError();
         }

--- a/contracts/test/WLSETH.1.t.sol
+++ b/contracts/test/WLSETH.1.t.sol
@@ -963,4 +963,34 @@ contract WLSETHV1DenyTests is WLSETHV1TestBase {
             assert(wlseth.balanceOf(_recipient) == guyBalance);
         }
     }
+
+    function testMintDeniedRecipient(uint256 _senderSalt, uint256 _recipientSalt, uint32 _sum) external {
+        address _sender = uf._new(_senderSalt);
+        address _recipient = uf._new(_recipientSalt);
+        if (_sum > 0) {
+            RiverTokenMock(address(river)).sudoSetBalance(_sender, _sum);
+            allowlistMock.sudoSetDenied(_recipient, true);
+
+            vm.startPrank(_sender);
+            RiverTokenMock(address(river)).approve(address(wlseth), _sum);
+            vm.expectRevert(abi.encodeWithSignature("Denied(address)", _recipient));
+            wlseth.mint(_recipient, _sum);
+            vm.stopPrank();
+        }
+    }
+
+    function testBurnDeniedSender(uint256 _senderSalt, uint256 _recipientSalt, uint32 _sum) external {
+        address _sender = uf._new(_senderSalt);
+        address _recipient = uf._new(_recipientSalt);
+        if (_sum > 0) {
+            _mint(_sender, _sum);
+            uint256 senderShares = wlseth.sharesOf(_sender);
+            allowlistMock.sudoSetDenied(_sender, true);
+
+            vm.startPrank(_sender);
+            vm.expectRevert(abi.encodeWithSignature("Denied(address)", _sender));
+            wlseth.burn(_recipient, senderShares);
+            vm.stopPrank();
+        }
+    }
 }


### PR DESCRIPTION
Closes #365

This closes two remaining denylist bypasses in `WLSETHV1`.

- reject minting to a denylisted recipient
- reject burning from a denylisted holder before value can be moved out
- add regression coverage for both paths

Step | Before fix | After fix
--- | --- | ---
Reproduction command | `forge test --match-contract WLSETHV1DenyTests --match-test 'test(MintDeniedRecipient|BurnDeniedSender)' -vv` | `forge test --match-contract WLSETHV1DenyTests --match-test 'test(MintDeniedRecipient|BurnDeniedSender)' -vv`
Key output | `2 failing tests` and `next call did not revert as expected` | `2 tests passed, 0 failed`
Test result | `0 passed, 2 failed, 0 skipped` | `forge test --match-path contracts/test/WLSETH.1.t.sol` -> `40 tests passed, 0 failed, 0 skipped`

Additional verification:
- `yarn link_contracts && npx hardhat compile`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Minting operations now validate that recipients are not denied in the allowlist system.
  * Burning operations now validate that senders are not denied in the allowlist system.

* **Tests**
  * Added comprehensive test coverage for denial scenarios, ensuring minting and burning operations properly revert when initiated by or for denied addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->