### PR TITLE
chore: bump version number post audit

### DIFF
--- a/contracts/src/Allowlist.1.sol
+++ b/contracts/src/Allowlist.1.sol
@@ -155,6 +155,6 @@ contract AllowlistV1 is IAllowlistV1, Initializable, Administrable, IProtocolVer
     }
 
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/CoverageFund.1.sol
+++ b/contracts/src/CoverageFund.1.sol
@@ -74,6 +74,6 @@ contract CoverageFundV1 is Initializable, ICoverageFundV1, IProtocolVersion {
     }
 
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/ELFeeRecipient.1.sol
+++ b/contracts/src/ELFeeRecipient.1.sol
@@ -45,6 +45,6 @@ contract ELFeeRecipientV1 is Initializable, IELFeeRecipientV1, IProtocolVersion 
     }
 
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/Firewall.sol
+++ b/contracts/src/Firewall.sol
@@ -116,6 +116,6 @@ contract Firewall is IFirewall, IProtocolVersion, Administrable {
 
     /// @inheritdoc IProtocolVersion
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -739,6 +739,6 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
 
     /// @inheritdoc IProtocolVersion
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/Oracle.1.sol
+++ b/contracts/src/Oracle.1.sol
@@ -275,6 +275,6 @@ contract OracleV1 is IOracleV1, Initializable, Administrable, IProtocolVersion {
     }
 
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -586,6 +586,6 @@ contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IP
     }
 
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -645,6 +645,6 @@ contract RiverV1 is
     }
 
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/src/Withdraw.1.sol
+++ b/contracts/src/Withdraw.1.sol
@@ -56,6 +56,6 @@ contract WithdrawV1 is IWithdrawV1, Initializable, IProtocolVersion {
 
     /// @inheritdoc IProtocolVersion
     function version() external pure returns (string memory) {
-        return "1.2.1";
+        return "1.3.0";
     }
 }

--- a/contracts/test/Allowlist.1.t.sol
+++ b/contracts/test/Allowlist.1.t.sol
@@ -395,6 +395,6 @@ contract AllowlistV1Tests is AllowlistV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(allowlist.version(), "1.2.1");
+        assertEq(allowlist.version(), "1.3.0");
     }
 }

--- a/contracts/test/CoverageFund.1.t.sol
+++ b/contracts/test/CoverageFund.1.t.sol
@@ -225,6 +225,6 @@ contract CoverageFundTestV1 is CoverageFundV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(coverageFund.version(), "1.2.1");
+        assertEq(coverageFund.version(), "1.3.0");
     }
 }

--- a/contracts/test/ELFeeRecipient.1.t.sol
+++ b/contracts/test/ELFeeRecipient.1.t.sol
@@ -146,6 +146,6 @@ contract ELFeeRecipientV1Test is ELFeeRecipientV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(feeRecipient.version(), "1.2.1");
+        assertEq(feeRecipient.version(), "1.3.0");
     }
 }

--- a/contracts/test/Firewall.t.sol
+++ b/contracts/test/Firewall.t.sol
@@ -506,6 +506,6 @@ contract FirewallTests is BytesGenerator, OperatorAllocationTestBase {
     }
 
     function testVersion() external {
-        assertEq(riverFirewall.version(), "1.2.1");
+        assertEq(riverFirewall.version(), "1.3.0");
     }
 }

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -4529,7 +4529,7 @@ contract OperatorsRegistryV1TestDistribution is OperatorAllocationTestBase {
     }
 
     function testVersion() external {
-        assertEq(operatorsRegistry.version(), "1.2.1");
+        assertEq(operatorsRegistry.version(), "1.3.0");
     }
 
     function testGetNextValidatorsToDepositFromActiveOperatorsRevertsWithEmptyAllocation() public {

--- a/contracts/test/Oracle.1.t.sol
+++ b/contracts/test/Oracle.1.t.sol
@@ -744,6 +744,6 @@ contract OracleV1Tests is OracleV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(oracle.version(), "1.2.1");
+        assertEq(oracle.version(), "1.3.0");
     }
 }

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -2110,7 +2110,7 @@ contract RedeemManagerV1Tests is RedeeManagerV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(redeemManager.version(), "1.2.1");
+        assertEq(redeemManager.version(), "1.3.0");
     }
 }
 

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -242,7 +242,7 @@ contract RiverV1Tests is RiverV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(river.version(), "1.2.1");
+        assertEq(river.version(), "1.3.0");
     }
 
     function testOnlyAdminCanSetKeeper() public {

--- a/contracts/test/Withdraw.1.t.sol
+++ b/contracts/test/Withdraw.1.t.sol
@@ -166,6 +166,6 @@ contract WithdrawV1Tests is WithdrawV1TestBase {
     }
 
     function testVersion() external {
-        assertEq(withdraw.version(), "1.2.1");
+        assertEq(withdraw.version(), "1.3.0");
     }
 }


### PR DESCRIPTION
This pull request updates the protocol version across all core contracts and their corresponding tests from "1.2.1" to "1.3.0". This ensures consistency in version reporting throughout the codebase and test suite.

**Protocol Version Update:**

* Updated the `version()` function in the following contracts to return "1.3.0" instead of "1.2.1":
  - `AllowlistV1` (`contracts/src/Allowlist.1.sol`)
  - `CoverageFundV1` (`contracts/src/CoverageFund.1.sol`)
  - `ELFeeRecipientV1` (`contracts/src/ELFeeRecipient.1.sol`)
  - `Firewall` (`contracts/src/Firewall.sol`)
  - `OperatorsRegistryV1` (`contracts/src/OperatorsRegistry.1.sol`)
  - `OracleV1` (`contracts/src/Oracle.1.sol`)
  - `RedeemManagerV1` (`contracts/src/RedeemManager.1.sol`)
  - `RiverV1` (`contracts/src/River.1.sol`)
  - `WithdrawV1` (`contracts/src/Withdraw.1.sol`)

**Test Suite Update:**

* Updated all related test cases to assert the new version string "1.3.0" in:
  - `AllowlistV1Tests` (`contracts/test/Allowlist.1.t.sol`)
  - `CoverageFundTestV1` (`contracts/test/CoverageFund.1.t.sol`)
  - `ELFeeRecipientV1Test` (`contracts/test/ELFeeRecipient.1.t.sol`)
  - `FirewallTests` (`contracts/test/Firewall.t.sol`)
  - `OperatorsRegistryV1TestDistribution` (`contracts/test/OperatorsRegistry.1.t.sol`)
  - `OracleV1Tests` (`contracts/test/Oracle.1.t.sol`)
  - `RedeemManagerV1Tests` (`contracts/test/RedeemManager.1.t.sol`)
  - `RiverV1Tests` (`contracts/test/River.1.t.sol`)
  - `WithdrawV1Tests` (`contracts/test/Withdraw.1.t.sol`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped protocol version from 1.2.1 to 1.3.0 across all core contracts and corresponding test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->