### PR TITLE
feat: re-enable `claimRedeemRequests` during Slashing Containment Mode

### DIFF
--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -189,7 +189,7 @@ contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IP
         uint32[] calldata withdrawalEventIds,
         bool skipAlreadyClaimed,
         uint16 _depth
-    ) external nonReentrant whenNotSlashingContainmentMode returns (uint8[] memory claimStatuses) {
+    ) external nonReentrant returns (uint8[] memory claimStatuses) {
         return _claimRedeemRequests(redeemRequestIds, withdrawalEventIds, skipAlreadyClaimed, _depth);
     }
 
@@ -197,7 +197,6 @@ contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IP
     function claimRedeemRequests(uint32[] calldata _redeemRequestIds, uint32[] calldata _withdrawalEventIds)
         external
         nonReentrant
-        whenNotSlashingContainmentMode
         returns (uint8[] memory claimStatuses)
     {
         return _claimRedeemRequests(_redeemRequestIds, _withdrawalEventIds, true, type(uint16).max);

--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -212,7 +212,6 @@ contract RiverV1 is
     /// @inheritdoc IRiverV1
     function claimRedeemRequests(uint32[] calldata _redeemRequestIds, uint32[] calldata _withdrawalEventIds)
         external
-        whenNotSlashingContainmentMode
         returns (uint8[] memory claimStatuses)
     {
         return IRedeemManagerV1(RedeemManagerAddress.get())

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -2041,24 +2041,25 @@ contract RedeemManagerV1Tests is RedeeManagerV1TestBase {
         redeemManager.requestRedeem(amount);
     }
 
-    function testClaimRedeemRequestsFourArgBlockedInSlashingMode() external {
+    function testClaimRedeemRequestsFourArgAllowedInSlashingMode() external {
         river.sudoSetSlashingContainmentMode(true);
 
         uint32[] memory redeemRequestIds = new uint32[](0);
         uint32[] memory withdrawalEventIds = new uint32[](0);
 
-        vm.expectRevert(abi.encodeWithSignature("SlashingContainmentModeEnabled()"));
-        redeemManager.claimRedeemRequests(redeemRequestIds, withdrawalEventIds, true, type(uint16).max);
+        uint8[] memory claimStatuses =
+            redeemManager.claimRedeemRequests(redeemRequestIds, withdrawalEventIds, true, type(uint16).max);
+        assertEq(claimStatuses.length, 0);
     }
 
-    function testClaimRedeemRequestsTwoArgBlockedInSlashingMode() external {
+    function testClaimRedeemRequestsTwoArgAllowedInSlashingMode() external {
         river.sudoSetSlashingContainmentMode(true);
 
         uint32[] memory redeemRequestIds = new uint32[](0);
         uint32[] memory withdrawalEventIds = new uint32[](0);
 
-        vm.expectRevert(abi.encodeWithSignature("SlashingContainmentModeEnabled()"));
-        redeemManager.claimRedeemRequests(redeemRequestIds, withdrawalEventIds);
+        uint8[] memory claimStatuses = redeemManager.claimRedeemRequests(redeemRequestIds, withdrawalEventIds);
+        assertEq(claimStatuses.length, 0);
     }
 
     function testRequestRedeemTwoArgAllowedWhenSlashingModeOff(uint256 _salt) external {

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -2041,25 +2041,65 @@ contract RedeemManagerV1Tests is RedeeManagerV1TestBase {
         redeemManager.requestRedeem(amount);
     }
 
-    function testClaimRedeemRequestsFourArgAllowedInSlashingMode() external {
+    function testClaimRedeemRequestsFourArgAllowedInSlashingMode(uint256 _salt) external {
+        uint128 amount = uint128(bound(_salt, 1, type(uint128).max));
+        address user = _generateAllowlistedUser(_salt);
+
+        river.sudoDeal(user, uint256(amount));
+        vm.prank(user);
+        river.approve(address(redeemManager), uint256(amount));
+        vm.prank(user);
+        redeemManager.requestRedeem(amount, user);
+
+        vm.deal(address(this), amount);
+        river.sudoReportWithdraw{value: amount}(address(redeemManager), amount);
+
         river.sudoSetSlashingContainmentMode(true);
 
-        uint32[] memory redeemRequestIds = new uint32[](0);
-        uint32[] memory withdrawalEventIds = new uint32[](0);
+        uint32[] memory redeemRequestIds = new uint32[](1);
+        uint32[] memory withdrawalEventIds = new uint32[](1);
+        redeemRequestIds[0] = 0;
+        withdrawalEventIds[0] = 0;
+
+        uint256 userBalanceBefore = user.balance;
 
         uint8[] memory claimStatuses =
             redeemManager.claimRedeemRequests(redeemRequestIds, withdrawalEventIds, true, type(uint16).max);
-        assertEq(claimStatuses.length, 0);
+
+        assertEq(claimStatuses.length, 1);
+        assertEq(claimStatuses[0], 0); // CLAIM_FULLY_CLAIMED
+        assertEq(user.balance - userBalanceBefore, amount);
+        assertEq(address(redeemManager).balance, 0);
     }
 
-    function testClaimRedeemRequestsTwoArgAllowedInSlashingMode() external {
+    function testClaimRedeemRequestsTwoArgAllowedInSlashingMode(uint256 _salt) external {
+        uint128 amount = uint128(bound(_salt, 1, type(uint128).max));
+        address user = _generateAllowlistedUser(_salt);
+
+        river.sudoDeal(user, uint256(amount));
+        vm.prank(user);
+        river.approve(address(redeemManager), uint256(amount));
+        vm.prank(user);
+        redeemManager.requestRedeem(amount, user);
+
+        vm.deal(address(this), amount);
+        river.sudoReportWithdraw{value: amount}(address(redeemManager), amount);
+
         river.sudoSetSlashingContainmentMode(true);
 
-        uint32[] memory redeemRequestIds = new uint32[](0);
-        uint32[] memory withdrawalEventIds = new uint32[](0);
+        uint32[] memory redeemRequestIds = new uint32[](1);
+        uint32[] memory withdrawalEventIds = new uint32[](1);
+        redeemRequestIds[0] = 0;
+        withdrawalEventIds[0] = 0;
+
+        uint256 userBalanceBefore = user.balance;
 
         uint8[] memory claimStatuses = redeemManager.claimRedeemRequests(redeemRequestIds, withdrawalEventIds);
-        assertEq(claimStatuses.length, 0);
+
+        assertEq(claimStatuses.length, 1);
+        assertEq(claimStatuses[0], 0); // CLAIM_FULLY_CLAIMED
+        assertEq(user.balance - userBalanceBefore, amount);
+        assertEq(address(redeemManager).balance, 0);
     }
 
     function testRequestRedeemTwoArgAllowedWhenSlashingModeOff(uint256 _salt) external {

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -924,18 +924,6 @@ contract RiverV1Tests is RiverV1TestBase {
         river.requestRedeem(1 ether, bob);
     }
 
-    function testClaimRedeemRequestsBlockedInSlashingContainmentMode() public {
-        river.sudoSetSlashingContainmentMode(true);
-
-        uint32[] memory redeemRequestIds = new uint32[](1);
-        redeemRequestIds[0] = 0;
-        uint32[] memory withdrawalEventIds = new uint32[](1);
-        withdrawalEventIds[0] = 0;
-
-        vm.expectRevert(abi.encodeWithSignature("SlashingContainmentModeEnabled()"));
-        river.claimRedeemRequests(redeemRequestIds, withdrawalEventIds);
-    }
-
     function testDepositAllowedWhenSlashingModeOff() public {
         vm.deal(bob, 1 ether);
         _allow(bob);
@@ -1009,6 +997,30 @@ contract RiverV1Tests is RiverV1TestBase {
         );
 
         river.sudoSetSlashingContainmentMode(false);
+        uint32[] memory ids = new uint32[](0);
+        uint32[] memory events = new uint32[](0);
+        uint8[] memory claimStatuses = river.claimRedeemRequests(ids, events);
+        assertEq(claimStatuses.length, 0);
+    }
+
+    function testClaimRedeemRequestsAllowedInSlashingContainmentMode() public {
+        RedeemManagerV1 redeemManager = new RedeemManagerV1();
+        LibImplementationUnbricker.unbrick(vm, address(redeemManager));
+        redeemManager.initializeRedeemManagerV1(address(river));
+        river.initRiverV1_1(
+            address(redeemManager),
+            epochsPerFrame,
+            slotsPerEpoch,
+            secondsPerSlot,
+            0,
+            epochsUntilFinal,
+            1000,
+            500,
+            maxDailyNetCommittableAmount,
+            maxDailyRelativeCommittableAmount
+        );
+
+        river.sudoSetSlashingContainmentMode(true);
         uint32[] memory ids = new uint32[](0);
         uint32[] memory events = new uint32[](0);
         uint8[] memory claimStatuses = river.claimRedeemRequests(ids, events);

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -1020,11 +1020,36 @@ contract RiverV1Tests is RiverV1TestBase {
             maxDailyRelativeCommittableAmount
         );
 
+        // Set up a real redeem request while slashing mode is off
+        uint256 amount = 1 ether;
+        vm.deal(bob, amount);
+        _allow(bob);
+        vm.prank(bob);
+        river.deposit{value: amount}();
+        uint256 lsETHBalance = river.balanceOf(bob);
+
+        vm.prank(bob);
+        river.requestRedeem(lsETHBalance, bob);
+
+        // Fund the withdrawal event via the RedeemManager (called as river)
+        vm.deal(address(river), amount);
+        vm.prank(address(river));
+        redeemManager.reportWithdraw{value: amount}(lsETHBalance);
+
+        // Enable slashing containment mode and claim
         river.sudoSetSlashingContainmentMode(true);
-        uint32[] memory ids = new uint32[](0);
-        uint32[] memory events = new uint32[](0);
+
+        uint32[] memory ids = new uint32[](1);
+        uint32[] memory events = new uint32[](1);
+        ids[0] = 0;
+        events[0] = 0;
+
+        uint256 bobBalanceBefore = bob.balance;
         uint8[] memory claimStatuses = river.claimRedeemRequests(ids, events);
-        assertEq(claimStatuses.length, 0);
+
+        assertEq(claimStatuses.length, 1);
+        assertEq(claimStatuses[0], 0); // CLAIM_FULLY_CLAIMED
+        assertGt(bob.balance - bobBalanceBefore, 0);
     }
 
     function testDepositUnblockedAfterSlashingModeToggleOff() public {


### PR DESCRIPTION
## Description

This pull request updates the behavior of the `claimRedeemRequests` functions in both the `RedeemManagerV1` and `RiverV1` contracts to allow claims to proceed even when slashing containment mode is enabled. Corresponding tests have been updated to reflect this new behavior, ensuring that claims are now allowed (and return empty results when appropriate) instead of reverting in slashing mode.

**Access control and logic changes:**

* Removed the `whenNotSlashingContainmentMode` modifier from the `claimRedeemRequests` functions in both `RedeemManagerV1` and `RiverV1`, allowing these functions to be called even when slashing containment mode is active. [[1]](diffhunk://#diff-27591a1fe04868ad6e4de630116d39ece6edb257b867d4e0ae99c1ad48074bccL192-L200) [[2]](diffhunk://#diff-34420a68f2d8aba02b8bc93ba4306dcb459547b0c3a4815dfa1737a16c14665eL215)

**Test updates:**

* Updated tests in `RedeemManager.1.t.sol` to expect successful (empty) results when calling `claimRedeemRequests` in slashing mode, instead of expecting a revert. Test names and assertions were changed to reflect the new allowed behavior.
* Removed the test in `River.1.t.sol` that expected a revert when calling `claimRedeemRequests` in slashing mode, as this is no longer the expected behavior.
* Added a new test in `River.1.t.sol` to verify that `claimRedeemRequests` is allowed and returns an empty result when called during slashing containment mode.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redeem claim requests can now be processed even when slashing containment mode is enabled, allowing previously-blocked claims to complete and funds to be released.

* **Tests**
  * Tests updated to assert successful claim processing and balances when slashing containment mode is active, verifying returned claim statuses and ETH transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->