### PR TITLE
fix: add fundedETH array length bounding (#432, #411)

### DIFF
--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -164,6 +164,9 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
         if (fundedETHLength == 0) {
             revert InvalidEmptyArray();
         }
+        if (fundedETHLength > OperatorsV3.getCount()) {
+            revert FundedETHArrayLengthExceedsOperatorCount();
+        }
         for (uint256 idx = 0; idx < fundedETHLength; ++idx) {
             // We have this check to avoid unnecessary storage reads for operators with no funded ETH
             if (_fundedETH[idx] == 0) {

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -122,6 +122,9 @@ interface IOperatorsRegistryV1 {
     /// @notice Thrown when the number of exited ETH is too high compared to operator count
     error ExitedETHArrayLengthExceedsOperatorCount();
 
+    /// @notice Thrown when the funded ETH array length exceeds the operator count
+    error FundedETHArrayLengthExceedsOperatorCount();
+
     /// @notice Thrown when no exit requests can be performed
     error NoExitRequestsToPerform();
 

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -1579,6 +1579,21 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         reg.incrementFundedETH(empty, new bytes[][](0));
     }
 
+    /// Asserts that incrementFundedETH reverts when the array length exceeds operator count.
+    function testIncrementFundedETHRevertsWhenArrayExceedsOperatorCount() public {
+        reg.initOperatorsRegistryV1(admin, river);
+        vm.prank(admin);
+        reg.addOperator("Op0", makeAddr("op0"));
+        uint256[] memory oversized = new uint256[](2);
+        oversized[0] = 32 ether;
+        oversized[1] = 32 ether;
+        bytes[][] memory keys = new bytes[][](2);
+        keys[0] = new bytes[](0);
+        keys[1] = new bytes[](0);
+        vm.expectRevert(abi.encodeWithSignature("FundedETHArrayLengthExceedsOperatorCount()"));
+        reg.incrementFundedETH(oversized, keys);
+    }
+
     /// Asserts that requestETHExits reverts with OnlyKeeper when caller is not the keeper.
     function testrequestETHExitsRevertsIfNotKeeper() public {
         reg.initOperatorsRegistryV1(admin, river);


### PR DESCRIPTION
## Summary
- Adds a `FundedETHArrayLengthExceedsOperatorCount` error and check in `incrementFundedETH` to prevent OOG DoS from oversized calldata arrays
- Bounds the `_fundedETH` array length against `OperatorsV3.getCount()` before iterating
- Adds a test verifying the revert when array exceeds operator count

Closes #432
Closes #411

## Test plan
- [x] `forge test --match-test testIncrementFundedETH -vvv` — both new and existing tests pass
- [ ] Full test suite: `forge test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)