### PR TITLE
fix: redundant loop in building LibFundingDeltas (BS-3684)

### DIFF
--- a/contracts/src/libraries/LibFundingDeltas.sol
+++ b/contracts/src/libraries/LibFundingDeltas.sol
@@ -32,38 +32,30 @@ library LibFundingDeltas {
             return new IOperatorsRegistryV1.OperatorFundingDelta[](0);
         }
 
-        // Pass 1: cache operator indices, validate them, find highestOpIdx.
-        uint256[] memory opIndices = new uint256[](len);
-        uint256 highestOpIdx = 0;
+        // Pass 1 (over deposits): validate operator indices and bucket-aggregate amounts and key
+        // counts per operator. Buckets are sized to operatorCount rather than highestOpIdx+1 so
+        // the previous index-caching pass over `deposits` is no longer needed.
+        uint256[] memory amountPerOp = new uint256[](operatorCount);
+        uint256[] memory keyCountPerOp = new uint256[](operatorCount);
         for (uint256 i = 0; i < len; i++) {
             uint256 opIdx = deposits[i].operatorIdx;
             if (opIdx >= operatorCount) revert InvalidOperatorIndex(opIdx, operatorCount);
-            opIndices[i] = opIdx;
-            if (opIdx > highestOpIdx) highestOpIdx = opIdx;
-        }
-
-        // Pass 2: bucket-aggregate amounts and key counts per operator.
-        uint256 buckets = highestOpIdx + 1;
-        uint256[] memory amountPerOp = new uint256[](buckets);
-        uint256[] memory keyCountPerOp = new uint256[](buckets);
-        for (uint256 i = 0; i < len; i++) {
-            uint256 opIdx = opIndices[i];
             amountPerOp[opIdx] += deposits[i].amount;
             keyCountPerOp[opIdx]++;
         }
 
         // Count populated buckets to size the deltas array.
         uint256 nonEmpty = 0;
-        for (uint256 j = 0; j < buckets; j++) {
+        for (uint256 j = 0; j < operatorCount; j++) {
             if (keyCountPerOp[j] > 0) ++nonEmpty;
         }
 
-        // Pass 3: allocate sparse deltas in ascending operator-index order.
+        // Pass 2 (over buckets): allocate sparse deltas in ascending operator-index order.
         deltas = new IOperatorsRegistryV1.OperatorFundingDelta[](nonEmpty);
-        uint256[] memory deltaIdxByOp = new uint256[](buckets);
-        uint256[] memory keyCursors = new uint256[](buckets);
+        uint256[] memory deltaIdxByOp = new uint256[](operatorCount);
+        uint256[] memory keyCursors = new uint256[](operatorCount);
         uint256 di = 0;
-        for (uint256 j = 0; j < buckets; j++) {
+        for (uint256 j = 0; j < operatorCount; j++) {
             if (keyCountPerOp[j] > 0) {
                 deltas[di].operatorIndex = j;
                 deltas[di].fundedETH = amountPerOp[j];
@@ -73,9 +65,9 @@ library LibFundingDeltas {
             }
         }
 
-        // Pass 4: fill per-operator pubkeys in deposit order.
+        // Pass 3 (over deposits): fill per-operator pubkeys in deposit order.
         for (uint256 i = 0; i < len; i++) {
-            uint256 opIdx = opIndices[i];
+            uint256 opIdx = deposits[i].operatorIdx;
             uint256 d = deltaIdxByOp[opIdx];
             deltas[d].newPublicKeys[keyCursors[opIdx]++] = deposits[i].pubkey;
         }


### PR DESCRIPTION
Relates to #497 

## Description

Change: contracts/src/libraries/LibFundingDeltas.sol — collapsed the 4-pass build() 
  into 3 passes by sizing the bucket arrays to operatorCount directly (instead of     
  discovering highestOpIdx first). This drops the entire pre-pass over deposits and   
  the opIndices memory allocation.

  Deposit-pass count in the full flow:
  - Before: 6 passes over deposits
  - After: 5 passes over deposits 
This pull request refactors the aggregation logic in the `LibFundingDeltas` library to simplify and optimize how operator funding deltas are calculated from deposits. The main improvement is the removal of an unnecessary pass and intermediate index caching, which streamlines the process and reduces memory usage.

**Aggregation logic simplification and optimization:**

* Replaced the two-pass approach (first caching operator indices and finding the highest index, then aggregating) with a single pass that validates operator indices and aggregates amounts and key counts directly into fixed-size buckets sized by `operatorCount`, eliminating the need for an intermediate `opIndices` array.
* Simplified the allocation and population of per-operator deltas and related arrays to use `operatorCount` as the bucket size, ensuring more efficient and clearer memory usage.
* Updated the final pass to fill per-operator public keys directly from the `deposits` array, removing the dependency on the now-removed `opIndices` array.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal funding delta calculations for improved efficiency and reduced memory allocation overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liquid-collective/liquid-collective-protocol/pull/503)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->