### PR TITLE
feat: consolidation attestation in AttestationVerifierV1

### DIFF
--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -6,12 +6,17 @@ import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.s
 import "./Initializable.sol";
 import "./interfaces/IAdministrable.sol";
 import "./interfaces/IAttestationVerifier.1.sol";
+import "./interfaces/IConsolidationDataBuffer.sol";
 import "./interfaces/IDepositContract.sol";
 import "./interfaces/IDepositDataBuffer.sol";
 
 import "./libraries/BLS12_381.sol";
 import "./libraries/LibErrors.sol";
 
+import "./state/attestationVerifier/ConsolidationCommitteeAttestationQuorum.sol";
+import "./state/attestationVerifier/ConsolidationCommitteeAttesters.sol";
+import "./state/attestationVerifier/ConsolidationDataBufferAddress.sol";
+import "./state/attestationVerifier/ConsolidationDomainSeparator.sol";
 import "./state/attestationVerifier/DepositCommitteeAttestationQuorum.sol";
 import "./state/attestationVerifier/DepositCommitteeAttesters.sol";
 import "./state/attestationVerifier/DepositDataBufferAddress.sol";
@@ -40,15 +45,30 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
     bytes32 internal constant ATTEST_TYPEHASH =
         keccak256("Attest(bytes32 depositDataBufferId,bytes32 depositRootHash)");
 
+    /// @notice EIP-712 name used by the consolidation-attestation domain separator.
+    /// @dev    Distinct from `NAME_HASH` so attestor signatures cannot be replayed
+    ///         across the deposit and consolidation flows even if the rest of the
+    ///         domain (chainId, verifyingContract, version) were identical.
+    bytes32 internal constant CONSOLIDATION_NAME_HASH = keccak256("ConsolidationValidation");
+
+    bytes32 internal constant ATTEST_CONSOLIDATION_TYPEHASH =
+        keccak256("AttestConsolidation(bytes32 consolidationDataBufferId)");
+
     /// @notice Maximum number of signatures accepted. Bounds the O(n^2) duplicate-detection loop.
     uint256 public constant MAX_SIGNATURES = 20;
 
     /// @notice Maximum number of registered deposit-committee attesters. Defensive cap to bound storage growth.
     uint256 public constant MAX_DEPOSIT_COMMITTEE_ATTESTERS = 32;
 
+    /// @notice Maximum number of registered consolidation-committee attesters. Defensive cap to bound storage growth.
+    uint256 public constant MAX_CONSOLIDATION_COMMITTEE_ATTESTERS = 32;
+
     /// @dev Expected lengths for fixed BLS-related fields in a DepositObject.
     uint256 internal constant DEPOSIT_PUBKEY_LENGTH = 48;
     uint256 internal constant DEPOSIT_SIGNATURE_LENGTH = 96;
+
+    /// @dev Expected length for BLS pubkeys in a ConsolidationObject (source or target).
+    uint256 internal constant CONSOLIDATION_PUBKEY_LENGTH = 48;
 
     // -----------------------------------------------------------------------
     // Modifiers
@@ -117,6 +137,54 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
         emit SetDomainSeparator(domainSeparator);
     }
 
+    /// @inheritdoc IAttestationVerifierV1
+    /// @dev Future initializers must use `init(2)` etc. — the version counter advances by one per init.
+    function initAttestationVerifierV1_1(
+        address _consolidationDataBuffer,
+        address[] calldata _consolidationCommitteeAttesters,
+        uint256 _quorum
+    ) external init(1) {
+        if (
+            _consolidationCommitteeAttesters.length == 0
+                || _consolidationCommitteeAttesters.length > MAX_CONSOLIDATION_COMMITTEE_ATTESTERS
+        ) {
+            revert LibErrors.InvalidArgument();
+        }
+        if (_quorum == 0) revert ZeroQuorum();
+        if (_quorum > MAX_SIGNATURES) revert QuorumExceedsMaxSignatures(_quorum, MAX_SIGNATURES);
+
+        ConsolidationDataBufferAddress.set(_consolidationDataBuffer);
+        emit SetConsolidationDataBuffer(_consolidationDataBuffer);
+
+        for (uint256 i = 0; i < _consolidationCommitteeAttesters.length; i++) {
+            if (
+                !ConsolidationCommitteeAttesters.isConsolidationCommitteeAttester(_consolidationCommitteeAttesters[i])
+            ) {
+                ConsolidationCommitteeAttesters.setConsolidationCommitteeAttester(
+                    _consolidationCommitteeAttesters[i], true
+                );
+                ConsolidationCommitteeAttesters.setCount(ConsolidationCommitteeAttesters.getCount() + 1);
+                emit SetConsolidationCommitteeAttester(_consolidationCommitteeAttesters[i], true);
+            }
+        }
+        uint256 attesterCount = ConsolidationCommitteeAttesters.getCount();
+        if (_quorum > attesterCount) {
+            revert QuorumExceedsConsolidationCommitteeAttesterCount(_quorum, attesterCount);
+        }
+        ConsolidationCommitteeAttestationQuorum.set(_quorum);
+        emit SetConsolidationCommitteeAttestationQuorum(_quorum);
+
+        // Distinct EIP-712 domain (different NAME_HASH) anchored to the same River address
+        // as the deposit flow. Replay across the two flows is prevented at both the domain
+        // separator level AND the typehash level (defense in depth).
+        address river = RiverAddress.get();
+        bytes32 consolidationDomainSeparator = keccak256(
+            abi.encode(EIP712_DOMAIN_TYPEHASH, CONSOLIDATION_NAME_HASH, VERSION_HASH, block.chainid, river)
+        );
+        ConsolidationDomainSeparator.set(consolidationDomainSeparator);
+        emit SetConsolidationDomainSeparator(consolidationDomainSeparator);
+    }
+
     // -----------------------------------------------------------------------
     // Admin setters
     // -----------------------------------------------------------------------
@@ -159,6 +227,49 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
         emit SetDepositCommitteeAttestationQuorum(newQuorum);
     }
 
+    /// @inheritdoc IAttestationVerifierV1
+    function setConsolidationDataBuffer(address _consolidationDataBuffer) external onlyRiverAdmin {
+        ConsolidationDataBufferAddress.set(_consolidationDataBuffer);
+        emit SetConsolidationDataBuffer(_consolidationDataBuffer);
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function setConsolidationCommitteeAttester(address consolidationCommitteeAttester, bool value)
+        external
+        onlyRiverAdmin
+    {
+        bool current = ConsolidationCommitteeAttesters.isConsolidationCommitteeAttester(consolidationCommitteeAttester);
+        if (current == value) {
+            revert ConsolidationCommitteeAttesterStatusUnchanged(consolidationCommitteeAttester, value);
+        }
+
+        uint256 count = ConsolidationCommitteeAttesters.getCount();
+        uint256 newCount = value ? count + 1 : count - 1;
+        if (value && newCount > MAX_CONSOLIDATION_COMMITTEE_ATTESTERS) {
+            revert TooManyConsolidationCommitteeAttesters(newCount, MAX_CONSOLIDATION_COMMITTEE_ATTESTERS);
+        }
+        uint256 currentQuorum = ConsolidationCommitteeAttestationQuorum.get();
+        if (!value && currentQuorum > newCount) {
+            revert QuorumExceedsConsolidationCommitteeAttesterCount(currentQuorum, newCount);
+        }
+
+        ConsolidationCommitteeAttesters.setCount(newCount);
+        ConsolidationCommitteeAttesters.setConsolidationCommitteeAttester(consolidationCommitteeAttester, value);
+        emit SetConsolidationCommitteeAttester(consolidationCommitteeAttester, value);
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function setConsolidationCommitteeAttestationQuorum(uint256 newQuorum) external onlyRiverAdmin {
+        if (newQuorum == 0) revert ZeroQuorum();
+        uint256 attesterCount = ConsolidationCommitteeAttesters.getCount();
+        if (newQuorum > attesterCount) {
+            revert QuorumExceedsConsolidationCommitteeAttesterCount(newQuorum, attesterCount);
+        }
+        if (newQuorum > MAX_SIGNATURES) revert QuorumExceedsMaxSignatures(newQuorum, MAX_SIGNATURES);
+        ConsolidationCommitteeAttestationQuorum.set(newQuorum);
+        emit SetConsolidationCommitteeAttestationQuorum(newQuorum);
+    }
+
     // -----------------------------------------------------------------------
     // Views
     // -----------------------------------------------------------------------
@@ -197,6 +308,31 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
     /// @inheritdoc IAttestationVerifierV1
     function getRiver() external view returns (address) {
         return RiverAddress.get();
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function isConsolidationCommitteeAttester(address account) external view returns (bool) {
+        return ConsolidationCommitteeAttesters.isConsolidationCommitteeAttester(account);
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function getConsolidationCommitteeAttesterCount() external view returns (uint256) {
+        return ConsolidationCommitteeAttesters.getCount();
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function getConsolidationCommitteeAttestationQuorum() external view returns (uint256) {
+        return ConsolidationCommitteeAttestationQuorum.get();
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function getConsolidationDataBuffer() external view returns (address) {
+        return ConsolidationDataBufferAddress.get();
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function getConsolidationDomainSeparator() external view returns (bytes32) {
+        return ConsolidationDomainSeparator.get();
     }
 
     // -----------------------------------------------------------------------
@@ -244,6 +380,51 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
 
         // 6. Verify BLS signatures against canonical River WC (heaviest step — last so cheap checks fail fast)
         _verifyBLSSignatures(deposits, depositYs, withdrawalCredentials);
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function validateConsolidation(bytes32 consolidationDataBufferId)
+        external
+        view
+        returns (IConsolidationDataBuffer.ConsolidationObject memory consolidation, uint256 totalAmount)
+    {
+        // 1. Fetch consolidation from buffer
+        consolidation =
+            IConsolidationDataBuffer(ConsolidationDataBufferAddress.get()).getConsolidationData(consolidationDataBufferId);
+
+        // 2. Structural checks (cheapest first — fail fast)
+        uint256 sourceLen = consolidation.sourcePubkeys.length;
+        uint256 targetLen = consolidation.targetPubkeys.length;
+        if (sourceLen == 0) revert NoConsolidations();
+        if (sourceLen != targetLen) revert ConsolidationArrayLengthMismatch(sourceLen, targetLen);
+        if (consolidation.totalAmount == 0) revert ZeroConsolidationTotalAmount();
+        if (consolidation.user == address(0)) revert ZeroConsolidationUser();
+
+        // 3. Per-pair pubkey length checks
+        for (uint256 i = 0; i < sourceLen; i++) {
+            if (consolidation.sourcePubkeys[i].length != CONSOLIDATION_PUBKEY_LENGTH) {
+                revert InvalidConsolidationPubkeyLength(i, consolidation.sourcePubkeys[i].length, true);
+            }
+            if (consolidation.targetPubkeys[i].length != CONSOLIDATION_PUBKEY_LENGTH) {
+                revert InvalidConsolidationPubkeyLength(i, consolidation.targetPubkeys[i].length, false);
+            }
+        }
+
+        // 4. Re-compute and check the bufferId binding so the buffer cannot tamper post-attestation.
+        //    Signatures are DELIBERATELY excluded from the hash — see IConsolidationDataBuffer.
+        bytes32 computedId = keccak256(
+            abi.encode(
+                consolidation.user, consolidation.sourcePubkeys, consolidation.targetPubkeys, consolidation.totalAmount
+            )
+        );
+        if (computedId != consolidationDataBufferId) {
+            revert ConsolidationBufferIdMismatch(consolidationDataBufferId, computedId);
+        }
+
+        // 5. Verify the consolidation attestation quorum from signatures read off the buffer
+        _verifyConsolidationAttestationQuorum(consolidationDataBufferId, consolidation.signatures);
+
+        totalAmount = consolidation.totalAmount;
     }
 
     // -----------------------------------------------------------------------
@@ -299,6 +480,55 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
         }
 
         if (validCount < quorum) revert InsufficientAttestations(validCount, quorum);
+    }
+
+    /// @notice Verify the consolidation-attestation quorum from signatures read off the buffer.
+    /// @dev    Mirrors `_verifyAttestationQuorum` but with three structural differences:
+    ///         (1) signatures arrive as `bytes memory` (sourced from the buffer's returned struct)
+    ///             so we use `_recoverMemory` instead of the calldata-optimized `_recover`;
+    ///         (2) no `depositRootHash` co-sign — consolidations have no front-runnable shared
+    ///             on-chain root, so the typehash hashes only the bufferId;
+    ///         (3) uses the consolidation-specific committee set, quorum, and domain separator.
+    /// @param consolidationDataBufferId The bufferId co-signed by consolidation-committee attesters
+    /// @param signatures                The signatures read off the buffer (bytes memory)
+    function _verifyConsolidationAttestationQuorum(bytes32 consolidationDataBufferId, bytes[] memory signatures)
+        internal
+        view
+    {
+        uint256 sigLen = signatures.length;
+        if (sigLen > MAX_SIGNATURES) revert TooManySignatures(sigLen, MAX_SIGNATURES);
+
+        uint256 quorum = ConsolidationCommitteeAttestationQuorum.get();
+        if (quorum == 0) revert ZeroQuorum();
+        if (sigLen < quorum) revert InsufficientConsolidationAttestations(sigLen, quorum);
+
+        bytes32 domainSep = ConsolidationDomainSeparator.get();
+        if (domainSep == bytes32(0)) revert ZeroConsolidationDomainSeparator();
+        bytes32 structHash = keccak256(abi.encode(ATTEST_CONSOLIDATION_TYPEHASH, consolidationDataBufferId));
+        bytes32 digest = ECDSA.toTypedDataHash(domainSep, structHash);
+
+        uint256 validCount = 0;
+        address[] memory seen = new address[](sigLen);
+
+        for (uint256 i = 0; i < sigLen; i++) {
+            address signer = _recoverMemory(digest, signatures[i]);
+            if (signer == address(0)) continue;
+            if (!ConsolidationCommitteeAttesters.isConsolidationCommitteeAttester(signer)) continue;
+
+            bool duplicate = false;
+            for (uint256 j = 0; j < validCount; j++) {
+                if (seen[j] == signer) {
+                    duplicate = true;
+                    break;
+                }
+            }
+            if (duplicate) continue;
+
+            seen[validCount] = signer;
+            validCount++;
+        }
+
+        if (validCount < quorum) revert InsufficientConsolidationAttestations(validCount, quorum);
     }
 
     /// @notice Verify the BLS signatures against the canonical River withdrawal credentials.
@@ -374,6 +604,33 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
         assembly {
             r := calldataload(sig.offset)
             s := calldataload(add(sig.offset, 0x20))
+        }
+
+        (address recovered, ECDSA.RecoverError err) = ECDSA.tryRecover(digest, v, r, s);
+        if (err != ECDSA.RecoverError.NoError) return address(0);
+        return recovered;
+    }
+
+    /// @dev Recover signer from a 65-byte EIP-712 signature held in memory, normalizing v.
+    ///      A `bytes memory` variant of `_recover` for signatures that arrive via a memory
+    ///      struct (e.g. read from the consolidation buffer's `ConsolidationObject.signatures`).
+    ///      Keeping this separate from the calldata-optimized `_recover` avoids touching the
+    ///      deposit hot path.
+    /// @param digest The digest.
+    /// @param sig The signature (memory).
+    /// @return The recovered signer.
+    function _recoverMemory(bytes32 digest, bytes memory sig) internal pure returns (address) {
+        if (sig.length != 65) return address(0);
+
+        uint8 v = uint8(sig[64]);
+        if (v < 27) v += 27;
+        if (v != 27 && v != 28) return address(0);
+
+        bytes32 r;
+        bytes32 s;
+        assembly {
+            r := mload(add(sig, 0x20))
+            s := mload(add(sig, 0x40))
         }
 
         (address recovered, ECDSA.RecoverError err) = ECDSA.tryRecover(digest, v, r, s);

--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -92,28 +92,49 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
         address _river,
         address _depositDataBuffer,
         address[] calldata _depositCommitteeAttesters,
-        uint256 _quorum,
-        bytes4 _genesisForkVersion
+        uint256 _depositQuorum,
+        bytes4 _genesisForkVersion,
+        address _consolidationDataBuffer,
+        address[] calldata _consolidationCommitteeAttesters,
+        uint256 _consolidationQuorum
     ) external init(0) {
+        // ---- Validate deposit-side parameters ----
         if (
             _depositCommitteeAttesters.length == 0
                 || _depositCommitteeAttesters.length > MAX_DEPOSIT_COMMITTEE_ATTESTERS
         ) {
             revert LibErrors.InvalidArgument();
         }
-        if (_quorum == 0) revert ZeroQuorum();
-        if (_quorum > MAX_SIGNATURES) revert QuorumExceedsMaxSignatures(_quorum, MAX_SIGNATURES);
+        if (_depositQuorum == 0) revert ZeroQuorum();
+        if (_depositQuorum > MAX_SIGNATURES) revert QuorumExceedsMaxSignatures(_depositQuorum, MAX_SIGNATURES);
 
+        // ---- Validate consolidation-side parameters ----
+        if (
+            _consolidationCommitteeAttesters.length == 0
+                || _consolidationCommitteeAttesters.length > MAX_CONSOLIDATION_COMMITTEE_ATTESTERS
+        ) {
+            revert LibErrors.InvalidArgument();
+        }
+        if (_consolidationQuorum == 0) revert ZeroQuorum();
+        if (_consolidationQuorum > MAX_SIGNATURES) {
+            revert QuorumExceedsMaxSignatures(_consolidationQuorum, MAX_SIGNATURES);
+        }
+
+        // ---- River + buffers + BLS deposit domain ----
         RiverAddress.set(_river);
         emit SetRiver(_river);
 
         DepositDataBufferAddress.set(_depositDataBuffer);
         emit SetDepositDataBuffer(_depositDataBuffer);
 
+        ConsolidationDataBufferAddress.set(_consolidationDataBuffer);
+        emit SetConsolidationDataBuffer(_consolidationDataBuffer);
+
         bytes32 depositDomain = BLS12_381.computeDepositDomain(_genesisForkVersion);
         DepositDomainValue.set(depositDomain);
         emit SetDepositDomain(depositDomain);
 
+        // ---- Deposit committee + quorum ----
         for (uint256 i = 0; i < _depositCommitteeAttesters.length; i++) {
             if (!DepositCommitteeAttesters.isDepositCommitteeAttester(_depositCommitteeAttesters[i])) {
                 DepositCommitteeAttesters.setDepositCommitteeAttester(_depositCommitteeAttesters[i], true);
@@ -122,40 +143,13 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
             }
         }
         uint256 depositCommitteeAttesterCount = DepositCommitteeAttesters.getCount();
-        if (_quorum > depositCommitteeAttesterCount) {
-            revert QuorumExceedsDepositCommitteeAttesterCount(_quorum, depositCommitteeAttesterCount);
+        if (_depositQuorum > depositCommitteeAttesterCount) {
+            revert QuorumExceedsDepositCommitteeAttesterCount(_depositQuorum, depositCommitteeAttesterCount);
         }
-        DepositCommitteeAttestationQuorum.set(_quorum);
-        emit SetDepositCommitteeAttestationQuorum(_quorum);
+        DepositCommitteeAttestationQuorum.set(_depositQuorum);
+        emit SetDepositCommitteeAttestationQuorum(_depositQuorum);
 
-        // EIP-712 domain separator binds verifyingContract to River's address, not this
-        // verifier's own address. This preserves deposit-committee attester signing tooling that
-        // signs against River's identity even if the verifier is later redeployed.
-        bytes32 domainSeparator =
-            keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, _river));
-        DomainSeparator.set(domainSeparator);
-        emit SetDomainSeparator(domainSeparator);
-    }
-
-    /// @inheritdoc IAttestationVerifierV1
-    /// @dev Future initializers must use `init(2)` etc. — the version counter advances by one per init.
-    function initAttestationVerifierV1_1(
-        address _consolidationDataBuffer,
-        address[] calldata _consolidationCommitteeAttesters,
-        uint256 _quorum
-    ) external init(1) {
-        if (
-            _consolidationCommitteeAttesters.length == 0
-                || _consolidationCommitteeAttesters.length > MAX_CONSOLIDATION_COMMITTEE_ATTESTERS
-        ) {
-            revert LibErrors.InvalidArgument();
-        }
-        if (_quorum == 0) revert ZeroQuorum();
-        if (_quorum > MAX_SIGNATURES) revert QuorumExceedsMaxSignatures(_quorum, MAX_SIGNATURES);
-
-        ConsolidationDataBufferAddress.set(_consolidationDataBuffer);
-        emit SetConsolidationDataBuffer(_consolidationDataBuffer);
-
+        // ---- Consolidation committee + quorum ----
         for (uint256 i = 0; i < _consolidationCommitteeAttesters.length; i++) {
             if (
                 !ConsolidationCommitteeAttesters.isConsolidationCommitteeAttester(_consolidationCommitteeAttesters[i])
@@ -167,19 +161,21 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1 {
                 emit SetConsolidationCommitteeAttester(_consolidationCommitteeAttesters[i], true);
             }
         }
-        uint256 attesterCount = ConsolidationCommitteeAttesters.getCount();
-        if (_quorum > attesterCount) {
-            revert QuorumExceedsConsolidationCommitteeAttesterCount(_quorum, attesterCount);
+        uint256 consolidationAttesterCount = ConsolidationCommitteeAttesters.getCount();
+        if (_consolidationQuorum > consolidationAttesterCount) {
+            revert QuorumExceedsConsolidationCommitteeAttesterCount(_consolidationQuorum, consolidationAttesterCount);
         }
-        ConsolidationCommitteeAttestationQuorum.set(_quorum);
-        emit SetConsolidationCommitteeAttestationQuorum(_quorum);
+        ConsolidationCommitteeAttestationQuorum.set(_consolidationQuorum);
+        emit SetConsolidationCommitteeAttestationQuorum(_consolidationQuorum);
 
-        // Distinct EIP-712 domain (different NAME_HASH) anchored to the same River address
-        // as the deposit flow. Replay across the two flows is prevented at both the domain
-        // separator level AND the typehash level (defense in depth).
-        address river = RiverAddress.get();
+        // ---- EIP-712 domain separators (distinct NAME_HASH per flow, both anchored to River) ----
+        bytes32 depositDomainSeparator =
+            keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, _river));
+        DomainSeparator.set(depositDomainSeparator);
+        emit SetDomainSeparator(depositDomainSeparator);
+
         bytes32 consolidationDomainSeparator = keccak256(
-            abi.encode(EIP712_DOMAIN_TYPEHASH, CONSOLIDATION_NAME_HASH, VERSION_HASH, block.chainid, river)
+            abi.encode(EIP712_DOMAIN_TYPEHASH, CONSOLIDATION_NAME_HASH, VERSION_HASH, block.chainid, _river)
         );
         ConsolidationDomainSeparator.set(consolidationDomainSeparator);
         emit SetConsolidationDomainSeparator(consolidationDomainSeparator);

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.34;
 
+import "./IConsolidationDataBuffer.sol";
 import "./IDepositDataBuffer.sol";
 import "../libraries/BLS12_381.sol";
 
@@ -31,6 +32,18 @@ interface IAttestationVerifierV1 {
 
     /// @notice Emitted when the River address is set on this verifier
     event SetRiver(address indexed river);
+
+    /// @notice Emitted when the ConsolidationDataBuffer address is updated
+    event SetConsolidationDataBuffer(address indexed consolidationDataBuffer);
+
+    /// @notice Emitted when a consolidation-committee attester is added or removed
+    event SetConsolidationCommitteeAttester(address indexed consolidationCommitteeAttester, bool value);
+
+    /// @notice Emitted when the consolidation-committee attestation quorum is updated
+    event SetConsolidationCommitteeAttestationQuorum(uint256 quorum);
+
+    /// @notice Emitted when the EIP-712 consolidation domain separator is (re)cached
+    event SetConsolidationDomainSeparator(bytes32 consolidationDomainSeparator);
 
     // -----------------------------------------------------------------------
     // Errors
@@ -106,6 +119,56 @@ interface IAttestationVerifierV1 {
     /// @param value The requested status (matches current status)
     error DepositCommitteeAttesterStatusUnchanged(address depositCommitteeAttester, bool value);
 
+    // -- Consolidation-side errors --
+
+    /// @notice The number of valid, unique consolidation-committee attester signatures is below the configured quorum
+    /// @param valid The count of valid, unique consolidation-committee attester signatures recovered
+    /// @param quorum The required quorum
+    error InsufficientConsolidationAttestations(uint256 valid, uint256 quorum);
+
+    /// @notice The ConsolidationDataBuffer returned a consolidation with zero source pubkeys
+    error NoConsolidations();
+
+    /// @notice The source and target pubkey arrays have different lengths
+    /// @param sourceLength The length of the source pubkey array
+    /// @param targetLength The length of the target pubkey array
+    error ConsolidationArrayLengthMismatch(uint256 sourceLength, uint256 targetLength);
+
+    /// @notice A pubkey field has an unexpected byte length
+    /// @param index The pair index
+    /// @param length The observed length
+    /// @param isSource True if the offending pubkey is the source pubkey, false if it is the target pubkey
+    error InvalidConsolidationPubkeyLength(uint256 index, uint256 length, bool isSource);
+
+    /// @notice The recomputed consolidation bufferId does not match the attested bufferId
+    /// @param expected The bufferId co-signed by consolidation-committee attesters
+    /// @param actual The bufferId recomputed from the buffer's returned content
+    error ConsolidationBufferIdMismatch(bytes32 expected, bytes32 actual);
+
+    /// @notice The EIP-712 consolidation domain separator has not been initialized
+    error ZeroConsolidationDomainSeparator();
+
+    /// @notice The consolidation's totalAmount is zero
+    error ZeroConsolidationTotalAmount();
+
+    /// @notice The consolidation's user is the zero address
+    error ZeroConsolidationUser();
+
+    /// @notice The supplied quorum is greater than the current consolidation-committee attester count
+    /// @param quorum The supplied quorum
+    /// @param consolidationCommitteeAttesterCount The current consolidation-committee attester count
+    error QuorumExceedsConsolidationCommitteeAttesterCount(uint256 quorum, uint256 consolidationCommitteeAttesterCount);
+
+    /// @notice Adding a consolidation-committee attester would exceed MAX_CONSOLIDATION_COMMITTEE_ATTESTERS
+    /// @param count The would-be consolidation-committee attester count
+    /// @param max The MAX_CONSOLIDATION_COMMITTEE_ATTESTERS bound
+    error TooManyConsolidationCommitteeAttesters(uint256 count, uint256 max);
+
+    /// @notice setConsolidationCommitteeAttester was called with the attester already in the requested state
+    /// @param consolidationCommitteeAttester The consolidation-committee attester address
+    /// @param value The requested status (matches current status)
+    error ConsolidationCommitteeAttesterStatusUnchanged(address consolidationCommitteeAttester, bool value);
+
     // -----------------------------------------------------------------------
     // Initialization
     // -----------------------------------------------------------------------
@@ -123,6 +186,19 @@ interface IAttestationVerifierV1 {
         address[] calldata _depositCommitteeAttesters,
         uint256 _quorum,
         bytes4 _genesisForkVersion
+    ) external;
+
+    /// @notice One-shot initializer for the consolidation-attestation extension.
+    /// @dev    Must be called after `initAttestationVerifierV1`. Uses `init(1)` so the River
+    ///         address and admin lookup configured by the v1 init are reused unchanged.
+    /// @param _consolidationDataBuffer    The pre-commit consolidation buffer the keeper reads from.
+    /// @param _consolidationCommitteeAttesters Initial set of consolidation-committee attester EOAs.
+    /// @param _quorum                     Initial consolidation-attestation quorum
+    ///                                    (1 ≤ quorum ≤ consolidationCommitteeAttesters.length).
+    function initAttestationVerifierV1_1(
+        address _consolidationDataBuffer,
+        address[] calldata _consolidationCommitteeAttesters,
+        uint256 _quorum
     ) external;
 
     // -----------------------------------------------------------------------
@@ -156,6 +232,20 @@ interface IAttestationVerifierV1 {
         uint256 committedBalance
     ) external view returns (IDepositDataBuffer.DepositObject[] memory deposits, uint256 totalAmount);
 
+    /// @notice Validate consolidation-committee attestations over a buffered consolidation request
+    ///         and return the trusted struct + totalAmount for the caller to act on.
+    /// @dev    Signatures are read from the buffer's `ConsolidationObject.signatures` field, not
+    ///         supplied as calldata. The bufferId binding excludes signatures so signers can sign
+    ///         the bufferId without a circular dependency. This function does NOT enforce any
+    ///         financial cap — that lives in the eventual River integration.
+    /// @param consolidationDataBufferId The bufferId co-signed by consolidation-committee attesters
+    /// @return consolidation            The validated consolidation object
+    /// @return totalAmount              Sum of the consolidation's totalAmount (mirrored from struct)
+    function validateConsolidation(bytes32 consolidationDataBufferId)
+        external
+        view
+        returns (IConsolidationDataBuffer.ConsolidationObject memory consolidation, uint256 totalAmount);
+
     // -----------------------------------------------------------------------
     // Admin setters
     // -----------------------------------------------------------------------
@@ -172,6 +262,19 @@ interface IAttestationVerifierV1 {
     /// @notice Update the DepositDataBuffer address. Only callable by River's admin.
     /// @param _depositDataBuffer The new buffer address
     function setDepositDataBuffer(address _depositDataBuffer) external;
+
+    /// @notice Add or remove a consolidation-committee attester. Only callable by River's admin.
+    /// @param consolidationCommitteeAttester The consolidation-committee attester address to update
+    /// @param value True to register, false to deregister
+    function setConsolidationCommitteeAttester(address consolidationCommitteeAttester, bool value) external;
+
+    /// @notice Update the consolidation-committee attestation quorum. Only callable by River's admin.
+    /// @param newQuorum The new quorum (1 ≤ newQuorum ≤ consolidationCommitteeAttesterCount, ≤ MAX_SIGNATURES)
+    function setConsolidationCommitteeAttestationQuorum(uint256 newQuorum) external;
+
+    /// @notice Update the ConsolidationDataBuffer address. Only callable by River's admin.
+    /// @param _consolidationDataBuffer The new buffer address
+    function setConsolidationDataBuffer(address _consolidationDataBuffer) external;
 
     // -----------------------------------------------------------------------
     // Views
@@ -207,4 +310,27 @@ interface IAttestationVerifierV1 {
     /// @notice The River address this verifier is bound to (verifyingContract + admin source)
     /// @return The River address
     function getRiver() external view returns (address);
+
+    // -- Consolidation-side views --
+
+    /// @notice Check whether an address is a registered consolidation-committee attester
+    /// @param account The address to check
+    /// @return True if account is a registered consolidation-committee attester
+    function isConsolidationCommitteeAttester(address account) external view returns (bool);
+
+    /// @notice Retrieve the current number of registered consolidation-committee attesters
+    /// @return The consolidation-committee attester count
+    function getConsolidationCommitteeAttesterCount() external view returns (uint256);
+
+    /// @notice Retrieve the current consolidation-committee attestation quorum
+    /// @return The required number of valid, unique consolidation-committee attester signatures
+    function getConsolidationCommitteeAttestationQuorum() external view returns (uint256);
+
+    /// @notice Retrieve the configured ConsolidationDataBuffer address
+    /// @return The ConsolidationDataBuffer address
+    function getConsolidationDataBuffer() external view returns (address);
+
+    /// @notice Retrieve the cached EIP-712 consolidation domain separator
+    /// @return The EIP-712 consolidation domain separator
+    function getConsolidationDomainSeparator() external view returns (bytes32);
 }

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -174,31 +174,31 @@ interface IAttestationVerifierV1 {
     // -----------------------------------------------------------------------
 
     /// @notice One-shot initializer for v1 of the AttestationVerifier.
-    /// @param _river                The River proxy address; used for the EIP-712 verifyingContract
-    ///                              binding and for the cross-contract admin lookup.
-    /// @param _depositDataBuffer    The pre-commit buffer the keeper writes to.
-    /// @param _depositCommitteeAttesters Initial set of deposit-committee attester EOAs.
-    /// @param _quorum               Initial attestation quorum (1 ≤ quorum ≤ depositCommitteeAttesters.length).
-    /// @param _genesisForkVersion   Genesis fork version used to derive the BLS deposit domain.
+    /// @dev    Configures both the deposit and consolidation attestation flows in a single call.
+    ///         Each flow has its own committee, quorum, buffer, and EIP-712 domain separator
+    ///         (distinct NAME_HASH per flow); they share only the River anchor and the admin
+    ///         lookup. Quorum and committee constraints are validated independently per flow.
+    /// @param _river                            The River proxy address; used for both
+    ///                                          EIP-712 domain separators and for the cross-
+    ///                                          contract admin lookup.
+    /// @param _depositDataBuffer                The pre-commit deposit buffer the keeper writes to.
+    /// @param _depositCommitteeAttesters        Initial set of deposit-committee attester EOAs.
+    /// @param _depositQuorum                    Initial deposit-attestation quorum
+    ///                                          (1 ≤ q ≤ depositCommitteeAttesters.length, ≤ MAX_SIGNATURES).
+    /// @param _genesisForkVersion               Genesis fork version used to derive the BLS deposit domain.
+    /// @param _consolidationDataBuffer          The consolidation buffer the keeper reads from.
+    /// @param _consolidationCommitteeAttesters  Initial set of consolidation-committee attester EOAs.
+    /// @param _consolidationQuorum              Initial consolidation-attestation quorum
+    ///                                          (1 ≤ q ≤ consolidationCommitteeAttesters.length, ≤ MAX_SIGNATURES).
     function initAttestationVerifierV1(
         address _river,
         address _depositDataBuffer,
         address[] calldata _depositCommitteeAttesters,
-        uint256 _quorum,
-        bytes4 _genesisForkVersion
-    ) external;
-
-    /// @notice One-shot initializer for the consolidation-attestation extension.
-    /// @dev    Must be called after `initAttestationVerifierV1`. Uses `init(1)` so the River
-    ///         address and admin lookup configured by the v1 init are reused unchanged.
-    /// @param _consolidationDataBuffer    The pre-commit consolidation buffer the keeper reads from.
-    /// @param _consolidationCommitteeAttesters Initial set of consolidation-committee attester EOAs.
-    /// @param _quorum                     Initial consolidation-attestation quorum
-    ///                                    (1 ≤ quorum ≤ consolidationCommitteeAttesters.length).
-    function initAttestationVerifierV1_1(
+        uint256 _depositQuorum,
+        bytes4 _genesisForkVersion,
         address _consolidationDataBuffer,
         address[] calldata _consolidationCommitteeAttesters,
-        uint256 _quorum
+        uint256 _consolidationQuorum
     ) external;
 
     // -----------------------------------------------------------------------

--- a/contracts/src/interfaces/IConsolidationDataBuffer.sol
+++ b/contracts/src/interfaces/IConsolidationDataBuffer.sol
@@ -1,0 +1,96 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+/// @title IConsolidationDataBuffer
+/// @notice Interface for the ConsolidationDataBuffer contract that stores pre-committed
+///         EIP-7251 consolidation requests.
+/// @dev    Two intentional departures from the deposit buffer pattern:
+///           1. Attestor signatures live INSIDE the buffer (the `signatures` field of
+///              ConsolidationObject). The verifier reads them on-chain rather than receiving
+///              them as calldata. This keeps the keeper call to a single bufferId argument.
+///           2. The buffer holds ONE `ConsolidationObject` per id (not an array). The
+///              array-ness lives inside the struct (`sourcePubkeys[]`, `targetPubkeys[]`)
+///              because a consolidation request bundles many (source, target) pairs under
+///              a single initiating user.
+interface IConsolidationDataBuffer {
+    /// @notice A single consolidation request stored in the buffer.
+    /// @dev `sourcePubkeys[i]` is consolidated INTO `targetPubkeys[i]` — same-index pairing.
+    ///      `signatures` are the consolidation-committee attestor EIP-712 ECDSA signatures
+    ///      over the bufferId. The bufferId itself is computed as
+    ///          keccak256(abi.encode(user, sourcePubkeys, targetPubkeys, totalAmount))
+    ///      with signatures EXCLUDED — this breaks the circular dependency that would
+    ///      otherwise exist if signers had to sign a hash that included their own sigs.
+    struct ConsolidationObject {
+        /// @dev Initiator of the consolidation request; eventual recipient of LsETH.
+        address user;
+        /// @dev Source validator BLS pubkeys (48 bytes each). Paired by index with targetPubkeys.
+        bytes[] sourcePubkeys;
+        /// @dev Target validator BLS pubkeys (48 bytes each). Paired by index with sourcePubkeys.
+        bytes[] targetPubkeys;
+        /// @dev Total ETH being consolidated, in wei.
+        uint256 totalAmount;
+        /// @dev Consolidation-committee attestor EIP-712 ECDSA signatures (65 bytes each).
+        ///      EXCLUDED from the bufferId hash.
+        bytes[] signatures;
+    }
+
+    // -----------------------------------------------------------------------
+    // Events
+    // -----------------------------------------------------------------------
+
+    /// @notice Emitted when a new consolidation request is submitted to the buffer.
+    /// @param consolidationDataBufferId  The deterministic identifier (keccak256 of ABI-encoded
+    ///                                   user + sourcePubkeys + targetPubkeys + totalAmount)
+    /// @param user                       Consolidation initiator
+    /// @param pairCount                  Number of (source, target) pubkey pairs
+    event ConsolidationDataSubmitted(
+        bytes32 indexed consolidationDataBufferId, address indexed user, uint256 pairCount
+    );
+
+    // -----------------------------------------------------------------------
+    // Errors
+    // -----------------------------------------------------------------------
+
+    /// @notice Reverts when attempting to submit a consolidation with zero source/target pubkeys
+    error EmptyConsolidationData();
+
+    /// @notice Reverts when the computed ID already exists in the buffer
+    error ConsolidationDataBufferIdAlreadyExists(bytes32 consolidationDataBufferId);
+
+    /// @notice Reverts when a requested ID does not exist
+    error ConsolidationDataBufferIdNotFound(bytes32 consolidationDataBufferId);
+
+    /// @notice Reverts when caller is not the authorized writer
+    error OnlyWriter();
+
+    // -----------------------------------------------------------------------
+    // Functions
+    // -----------------------------------------------------------------------
+
+    /// @notice Submit a consolidation request to the buffer.
+    /// @dev The bufferId is computed deterministically as
+    ///      keccak256(abi.encode(user, sourcePubkeys, targetPubkeys, totalAmount)).
+    ///      Signatures are excluded so attestors can sign the bufferId.
+    /// @param consolidationDataBufferId  The expected bufferId
+    /// @param consolidation              The consolidation object including signatures
+    function submitConsolidationData(
+        bytes32 consolidationDataBufferId,
+        ConsolidationObject calldata consolidation
+    ) external;
+
+    /// @notice Retrieve a stored consolidation request by its ID.
+    /// @param consolidationDataBufferId  The bufferId
+    /// @return consolidation             The stored consolidation object
+    function getConsolidationData(bytes32 consolidationDataBufferId)
+        external
+        view
+        returns (ConsolidationObject memory consolidation);
+
+    /// @notice Returns the authorized writer address.
+    /// @return The authorized writer address
+    function getWriter() external view returns (address);
+
+    /// @notice Returns the admin address.
+    /// @return The admin address
+    function getAdmin() external view returns (address);
+}

--- a/contracts/src/state/attestationVerifier/ConsolidationCommitteeAttestationQuorum.sol
+++ b/contracts/src/state/attestationVerifier/ConsolidationCommitteeAttestationQuorum.sol
@@ -1,0 +1,23 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../libraries/LibUnstructuredStorage.sol";
+
+/// @title ConsolidationCommitteeAttestationQuorum
+/// @notice Library for storing the consolidation-committee attestation quorum.
+library ConsolidationCommitteeAttestationQuorum {
+    bytes32 internal constant CONSOLIDATION_COMMITTEE_ATTESTATION_QUORUM_SLOT =
+        bytes32(uint256(keccak256("attestationVerifier.state.consolidationCommitteeAttestationQuorum")) - 1);
+
+    /// @notice Retrieve the attestation quorum
+    /// @return The attestation quorum
+    function get() internal view returns (uint256) {
+        return LibUnstructuredStorage.getStorageUint256(CONSOLIDATION_COMMITTEE_ATTESTATION_QUORUM_SLOT);
+    }
+
+    /// @notice Set the attestation quorum
+    /// @param newValue The new attestation quorum
+    function set(uint256 newValue) internal {
+        LibUnstructuredStorage.setStorageUint256(CONSOLIDATION_COMMITTEE_ATTESTATION_QUORUM_SLOT, newValue);
+    }
+}

--- a/contracts/src/state/attestationVerifier/ConsolidationCommitteeAttesters.sol
+++ b/contracts/src/state/attestationVerifier/ConsolidationCommitteeAttesters.sol
@@ -1,0 +1,46 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../libraries/LibSanitize.sol";
+import "../../libraries/LibUnstructuredStorage.sol";
+
+/// @title ConsolidationCommitteeAttesters
+/// @notice Unstructured storage library for the consolidation-committee attester set and count.
+///         Membership uses a slot-based mapping:
+///         slot = keccak256(abi.encode(CONSOLIDATION_COMMITTEE_ATTESTER_MAPPING_BASE_SLOT, account))
+library ConsolidationCommitteeAttesters {
+    bytes32 internal constant CONSOLIDATION_COMMITTEE_ATTESTER_MAPPING_BASE_SLOT =
+        bytes32(uint256(keccak256("attestationVerifier.state.consolidationCommitteeAttesters.mapping")) - 1);
+
+    bytes32 internal constant CONSOLIDATION_COMMITTEE_ATTESTER_COUNT_SLOT =
+        bytes32(uint256(keccak256("attestationVerifier.state.consolidationCommitteeAttesters.count")) - 1);
+
+    /// @notice Check if an account is a consolidation-committee attester
+    /// @param account The account to check
+    /// @return True if the account is a consolidation-committee attester, false otherwise
+    function isConsolidationCommitteeAttester(address account) internal view returns (bool) {
+        bytes32 slot = keccak256(abi.encode(CONSOLIDATION_COMMITTEE_ATTESTER_MAPPING_BASE_SLOT, account));
+        return LibUnstructuredStorage.getStorageBool(slot);
+    }
+
+    /// @notice Set the consolidation-committee attester status for an account
+    /// @param account The account to set
+    /// @param value The new consolidation-committee attester status
+    function setConsolidationCommitteeAttester(address account, bool value) internal {
+        LibSanitize._notZeroAddress(account);
+        bytes32 slot = keccak256(abi.encode(CONSOLIDATION_COMMITTEE_ATTESTER_MAPPING_BASE_SLOT, account));
+        LibUnstructuredStorage.setStorageBool(slot, value);
+    }
+
+    /// @notice Retrieve the consolidation-committee attester count
+    /// @return The consolidation-committee attester count
+    function getCount() internal view returns (uint256) {
+        return LibUnstructuredStorage.getStorageUint256(CONSOLIDATION_COMMITTEE_ATTESTER_COUNT_SLOT);
+    }
+
+    /// @notice Set the consolidation-committee attester count
+    /// @param count The new consolidation-committee attester count
+    function setCount(uint256 count) internal {
+        LibUnstructuredStorage.setStorageUint256(CONSOLIDATION_COMMITTEE_ATTESTER_COUNT_SLOT, count);
+    }
+}

--- a/contracts/src/state/attestationVerifier/ConsolidationDataBufferAddress.sol
+++ b/contracts/src/state/attestationVerifier/ConsolidationDataBufferAddress.sol
@@ -1,0 +1,25 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../libraries/LibSanitize.sol";
+import "../../libraries/LibUnstructuredStorage.sol";
+
+/// @title ConsolidationDataBufferAddress
+/// @notice Library for storing the address of the ConsolidationDataBuffer contract.
+library ConsolidationDataBufferAddress {
+    bytes32 internal constant CONSOLIDATION_DATA_BUFFER_ADDRESS_SLOT =
+        bytes32(uint256(keccak256("attestationVerifier.state.consolidationDataBufferAddress")) - 1);
+
+    /// @notice Retrieve the address of the ConsolidationDataBuffer contract
+    /// @return The address of the ConsolidationDataBuffer contract
+    function get() internal view returns (address) {
+        return LibUnstructuredStorage.getStorageAddress(CONSOLIDATION_DATA_BUFFER_ADDRESS_SLOT);
+    }
+
+    /// @notice Set the address of the ConsolidationDataBuffer contract
+    /// @param newValue The new address of the ConsolidationDataBuffer contract
+    function set(address newValue) internal {
+        LibSanitize._notZeroAddress(newValue);
+        LibUnstructuredStorage.setStorageAddress(CONSOLIDATION_DATA_BUFFER_ADDRESS_SLOT, newValue);
+    }
+}

--- a/contracts/src/state/attestationVerifier/ConsolidationDomainSeparator.sol
+++ b/contracts/src/state/attestationVerifier/ConsolidationDomainSeparator.sol
@@ -1,0 +1,29 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../libraries/LibUnstructuredStorage.sol";
+
+/// @title Consolidation Domain Separator Storage
+/// @notice Stores the EIP-712 domain separator used for consolidation attestations,
+///         computed once at initialisation time.
+/// @dev    The cached separator binds `verifyingContract` to River's address (matching
+///         the deposit-flow anchor), with a distinct `name` field ("ConsolidationValidation")
+///         so attestor signatures cannot be replayed across the deposit and consolidation flows.
+///         Also bakes in `block.chainid` at `set()` time.
+library ConsolidationDomainSeparator {
+    /// @notice Storage slot of the consolidation domain separator
+    bytes32 internal constant CONSOLIDATION_DOMAIN_SEPARATOR_SLOT =
+        bytes32(uint256(keccak256("attestationVerifier.state.consolidationDomainSeparator")) - 1);
+
+    /// @notice Retrieve the cached domain separator
+    /// @return The cached domain separator
+    function get() internal view returns (bytes32) {
+        return LibUnstructuredStorage.getStorageBytes32(CONSOLIDATION_DOMAIN_SEPARATOR_SLOT);
+    }
+
+    /// @notice Cache the domain separator
+    /// @param newValue The new domain separator
+    function set(bytes32 newValue) internal {
+        LibUnstructuredStorage.setStorageBytes32(CONSOLIDATION_DOMAIN_SEPARATOR_SLOT, newValue);
+    }
+}

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -397,8 +397,17 @@ contract RiverV1Tests is RiverV1TestBase {
         _initDepositCommitteeAttesters[2] = depositCommitteeAttester3;
         attestationVerifier = new AttestationVerifierV1();
         LibImplementationUnbricker.unbrick(vm, address(attestationVerifier));
+        address[] memory _initConsolidationCommitteeAttesters = new address[](1);
+        _initConsolidationCommitteeAttesters[0] = makeAddr("consolidationCommitteeAttesterStub");
         attestationVerifier.initAttestationVerifierV1(
-            address(river), address(depositBuffer), _initDepositCommitteeAttesters, 2, bytes4(0)
+            address(river),
+            address(depositBuffer),
+            _initDepositCommitteeAttesters,
+            2,
+            bytes4(0),
+            makeAddr("consolidationDataBufferStub"),
+            _initConsolidationCommitteeAttesters,
+            1
         );
 
         // Wire validator address into River's storage (these tests skip initRiverV1_3
@@ -1344,8 +1353,17 @@ contract RiverV1TestsReport_HEAVY_FUZZING is RiverV1TestBase {
         _initDepositCommitteeAttesters2[2] = depositCommitteeAttester3;
         attestationVerifier = new AttestationVerifierV1();
         LibImplementationUnbricker.unbrick(vm, address(attestationVerifier));
+        address[] memory _initConsolidationCommitteeAttesters2 = new address[](1);
+        _initConsolidationCommitteeAttesters2[0] = makeAddr("consolidationCommitteeAttesterStub");
         attestationVerifier.initAttestationVerifierV1(
-            address(river), address(depositBuffer), _initDepositCommitteeAttesters2, 2, bytes4(0)
+            address(river),
+            address(depositBuffer),
+            _initDepositCommitteeAttesters2,
+            2,
+            bytes4(0),
+            makeAddr("consolidationDataBufferStub"),
+            _initConsolidationCommitteeAttesters2,
+            1
         );
         vm.store(
             address(river),
@@ -2761,9 +2779,20 @@ contract RiverV1CoverageTests is RiverV1TestBase {
         address[] memory _depositCommitteeAttesters_ = new address[](2);
         _depositCommitteeAttesters_[0] = makeAddr("depositCommitteeAttester1");
         _depositCommitteeAttesters_[1] = makeAddr("depositCommitteeAttester2");
+        address[] memory _consolidationCommitteeAttesters_ = new address[](1);
+        _consolidationCommitteeAttesters_[0] = makeAddr("consolidationCommitteeAttesterStub");
         v = new AttestationVerifierV1();
         LibImplementationUnbricker.unbrick(vm, address(v));
-        v.initAttestationVerifierV1(_river, makeAddr("depositBuffer"), _depositCommitteeAttesters_, 1, bytes4(0));
+        v.initAttestationVerifierV1(
+            _river,
+            makeAddr("depositBuffer"),
+            _depositCommitteeAttesters_,
+            1,
+            bytes4(0),
+            makeAddr("consolidationDataBufferStub"),
+            _consolidationCommitteeAttesters_,
+            1
+        );
     }
 
     /// Asserts that initRiverV1_3 sets in-flight deposit when reported validator count is less than deposited count.
@@ -2828,11 +2857,20 @@ contract RiverV1CoverageTests is RiverV1TestBase {
     function testInitAttestationVerifierRevertsOnEmptyDepositCommitteeAttesters() public {
         _initRiverAndV1_2();
         address[] memory _depositCommitteeAttesters_ = new address[](0);
+        address[] memory _consolidationCommitteeAttesters_ = new address[](1);
+        _consolidationCommitteeAttesters_[0] = makeAddr("consolidationCommitteeAttesterStub");
         AttestationVerifierV1 v = new AttestationVerifierV1();
         LibImplementationUnbricker.unbrick(vm, address(v));
         vm.expectRevert(abi.encodeWithSignature("InvalidArgument()"));
         v.initAttestationVerifierV1(
-            address(river), makeAddr("depositBuffer"), _depositCommitteeAttesters_, 1, bytes4(0)
+            address(river),
+            makeAddr("depositBuffer"),
+            _depositCommitteeAttesters_,
+            1,
+            bytes4(0),
+            makeAddr("consolidationDataBufferStub"),
+            _consolidationCommitteeAttesters_,
+            1
         );
     }
 
@@ -2846,9 +2884,18 @@ contract RiverV1CoverageTests is RiverV1TestBase {
         for (uint256 i = 0; i < tooMany; i++) {
             _depositCommitteeAttesters_[i] = address(uint160(i + 1));
         }
+        address[] memory _consolidationCommitteeAttesters_ = new address[](1);
+        _consolidationCommitteeAttesters_[0] = makeAddr("consolidationCommitteeAttesterStub");
         vm.expectRevert(abi.encodeWithSignature("InvalidArgument()"));
         v.initAttestationVerifierV1(
-            address(river), makeAddr("depositBuffer"), _depositCommitteeAttesters_, 1, bytes4(0)
+            address(river),
+            makeAddr("depositBuffer"),
+            _depositCommitteeAttesters_,
+            1,
+            bytes4(0),
+            makeAddr("consolidationDataBufferStub"),
+            _consolidationCommitteeAttesters_,
+            1
         );
     }
 

--- a/contracts/test/accounting/AccountingHarnessBase.sol
+++ b/contracts/test/accounting/AccountingHarnessBase.sol
@@ -210,8 +210,17 @@ abstract contract AccountingHarnessBase is Test, BytesGenerator {
         // pinned to River's address inside the validator's domain separator.
         attestationVerifier = new AttestationVerifierV1();
         LibImplementationUnbricker.unbrick(vm, address(attestationVerifier));
+        address[] memory _initConsolidationCommitteeAttesters = new address[](1);
+        _initConsolidationCommitteeAttesters[0] = makeAddr("consolidationCommitteeAttesterStub");
         attestationVerifier.initAttestationVerifierV1(
-            address(river), address(depositBuffer), _initDepositCommitteeAttesters, 2, bytes4(0)
+            address(river),
+            address(depositBuffer),
+            _initDepositCommitteeAttesters,
+            2,
+            bytes4(0),
+            makeAddr("consolidationDataBufferStub"),
+            _initConsolidationCommitteeAttesters,
+            1
         );
 
         bytes32 _initWc = withdraw.getCredentials();

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -213,14 +213,27 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         // 2. Deploy and init the AttestationVerifier. The validator's EIP-712
         //    domain separator binds verifyingContract to the harness's address
         //    so deposit-committee attester signing tooling stays River-anchored.
+        //    Consolidation params are dummies here — this suite exercises the deposit flow only.
         address[] memory depositCommitteeAttesters = new address[](3);
         depositCommitteeAttesters[0] = depositCommitteeAttester1;
         depositCommitteeAttesters[1] = depositCommitteeAttester2;
         depositCommitteeAttesters[2] = depositCommitteeAttester3;
 
+        address[] memory consolidationCommitteeAttesters = new address[](1);
+        consolidationCommitteeAttesters[0] = makeAddr("consolidationCommitteeAttesterStub");
+
         validator = new AttestationVerifierV1();
         LibImplementationUnbricker.unbrick(vm, address(validator));
-        validator.initAttestationVerifierV1(address(dm), address(buffer), depositCommitteeAttesters, 2, bytes4(0));
+        validator.initAttestationVerifierV1(
+            address(dm),
+            address(buffer),
+            depositCommitteeAttesters,
+            2,
+            bytes4(0),
+            makeAddr("consolidationDataBufferStub"),
+            consolidationCommitteeAttesters,
+            1
+        );
 
         // 3. Wire the validator address into the harness.
         dm.sudoSetAttestationVerifier(address(validator));

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -1,0 +1,944 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+
+import "../../src/AttestationVerifier.1.sol";
+import "../../src/interfaces/IAttestationVerifier.1.sol";
+import "../../src/interfaces/IConsolidationDataBuffer.sol";
+import "../../src/interfaces/IDepositDataBuffer.sol";
+import "../../src/libraries/BLS12_381.sol";
+import "../../src/libraries/LibErrors.sol";
+import "../utils/LibImplementationUnbricker.sol";
+import "../mocks/DepositContractEnhancedMock.sol";
+
+// ---------------------------------------------------------------------------
+// Minimal River admin mock — exposes getAdmin() so AttestationVerifierV1's
+// `onlyRiverAdmin` cross-contract lookup resolves to a known admin EOA.
+// ---------------------------------------------------------------------------
+
+contract MockRiverAdmin {
+    address internal immutable _admin;
+
+    constructor(address admin_) {
+        _admin = admin_;
+    }
+
+    function getAdmin() external view returns (address) {
+        return _admin;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock DepositDataBuffer — copied from the deposit attestation tests because
+// no real implementation exists. We need it to satisfy the v1 init.
+// ---------------------------------------------------------------------------
+
+contract MockDepositDataBufferForConsolidation is IDepositDataBuffer {
+    mapping(bytes32 => DepositObject[]) internal _batches;
+    mapping(bytes32 => bool) internal _exists;
+
+    function submitDepositData(bytes32 depositDataBufferId, DepositObject[] calldata deposits) external {
+        if (_exists[depositDataBufferId]) revert DepositDataBufferIdAlreadyExists(depositDataBufferId);
+        _exists[depositDataBufferId] = true;
+        for (uint256 i = 0; i < deposits.length; i++) {
+            _batches[depositDataBufferId].push(deposits[i]);
+        }
+        emit DepositDataSubmitted(depositDataBufferId, deposits.length);
+    }
+
+    function getDepositData(bytes32 depositDataBufferId) external view returns (DepositObject[] memory) {
+        if (!_exists[depositDataBufferId]) revert DepositDataBufferIdNotFound(depositDataBufferId);
+        return _batches[depositDataBufferId];
+    }
+
+    function getWriter() external pure returns (address) {
+        return address(0);
+    }
+
+    function getAdmin() external pure returns (address) {
+        return address(0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock ConsolidationDataBuffer — stores ConsolidationObject by bufferId.
+//
+// Includes a `submitRaw(id, obj)` helper that bypasses the id-derivation rule
+// so tests can store data under a deliberately wrong id (covers the
+// ConsolidationBufferIdMismatch path).
+// ---------------------------------------------------------------------------
+
+contract MockConsolidationDataBuffer is IConsolidationDataBuffer {
+    mapping(bytes32 => ConsolidationObject) internal _data;
+    mapping(bytes32 => bool) internal _exists;
+
+    function submitConsolidationData(bytes32 id, ConsolidationObject calldata consolidation) external {
+        if (_exists[id]) revert ConsolidationDataBufferIdAlreadyExists(id);
+        if (consolidation.sourcePubkeys.length == 0) revert EmptyConsolidationData();
+        _exists[id] = true;
+        _storeMemory(id, consolidation.user, consolidation.totalAmount);
+        for (uint256 i = 0; i < consolidation.sourcePubkeys.length; i++) {
+            _data[id].sourcePubkeys.push(consolidation.sourcePubkeys[i]);
+        }
+        for (uint256 i = 0; i < consolidation.targetPubkeys.length; i++) {
+            _data[id].targetPubkeys.push(consolidation.targetPubkeys[i]);
+        }
+        for (uint256 i = 0; i < consolidation.signatures.length; i++) {
+            _data[id].signatures.push(consolidation.signatures[i]);
+        }
+        emit ConsolidationDataSubmitted(id, consolidation.user, consolidation.sourcePubkeys.length);
+    }
+
+    /// @dev Test-only escape hatch: store a ConsolidationObject under an arbitrary id
+    ///      (not necessarily derived from its content). Used to exercise the verifier's
+    ///      bufferId-binding check.
+    function submitRaw(bytes32 id, ConsolidationObject memory consolidation) external {
+        _exists[id] = true;
+        _data[id].user = consolidation.user;
+        _data[id].totalAmount = consolidation.totalAmount;
+        for (uint256 i = 0; i < consolidation.sourcePubkeys.length; i++) {
+            _data[id].sourcePubkeys.push(consolidation.sourcePubkeys[i]);
+        }
+        for (uint256 i = 0; i < consolidation.targetPubkeys.length; i++) {
+            _data[id].targetPubkeys.push(consolidation.targetPubkeys[i]);
+        }
+        for (uint256 i = 0; i < consolidation.signatures.length; i++) {
+            _data[id].signatures.push(consolidation.signatures[i]);
+        }
+    }
+
+    function _storeMemory(bytes32 id, address user, uint256 totalAmount) internal {
+        _data[id].user = user;
+        _data[id].totalAmount = totalAmount;
+    }
+
+    function getConsolidationData(bytes32 id) external view returns (ConsolidationObject memory) {
+        if (!_exists[id]) revert ConsolidationDataBufferIdNotFound(id);
+        return _data[id];
+    }
+
+    function getWriter() external pure returns (address) {
+        return address(0);
+    }
+
+    function getAdmin() external pure returns (address) {
+        return address(0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ConsolidationAttestationTest — exercises the consolidation half of
+// AttestationVerifierV1.
+//
+// Setup runs both inits (deposit-side init(0) is required because consolidation
+// init(1) depends on Version having advanced). Tests focus on:
+//   - happy paths
+//   - structural validation (lengths, zero fields, pubkey lengths)
+//   - bufferId binding (signatures excluded from hash)
+//   - signature verification (quorum, duplicates, non-committee, malformed)
+//   - admin setters
+//   - isolation from the deposit flow
+// ---------------------------------------------------------------------------
+
+contract ConsolidationAttestationTest is Test {
+    AttestationVerifierV1 internal validator;
+    MockConsolidationDataBuffer internal cBuffer;
+    MockDepositDataBufferForConsolidation internal dBuffer;
+    DepositContractEnhancedMock internal depositContract;
+    MockRiverAdmin internal river;
+
+    address internal admin = address(0xAD);
+
+    uint256 internal pk1 = 0xC1;
+    uint256 internal pk2 = 0xC2;
+    uint256 internal pk3 = 0xC3;
+    address internal attester1;
+    address internal attester2;
+    address internal attester3;
+
+    address internal depositAttester = address(0xD1);
+
+    // EIP-712 constants (must match AttestationVerifierV1)
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant CONSOLIDATION_NAME_HASH = keccak256("ConsolidationValidation");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    bytes32 internal constant ATTEST_CONSOLIDATION_TYPEHASH =
+        keccak256("AttestConsolidation(bytes32 consolidationDataBufferId)");
+
+    // Storage slots (must match contracts/src/state/attestationVerifier/*)
+    bytes32 internal constant CONSOLIDATION_DOMAIN_SEPARATOR_SLOT =
+        bytes32(uint256(keccak256("attestationVerifier.state.consolidationDomainSeparator")) - 1);
+    bytes32 internal constant DEPOSIT_DOMAIN_SEPARATOR_SLOT =
+        bytes32(uint256(keccak256("attestationVerifier.state.domainSeparator")) - 1);
+
+    function setUp() public {
+        attester1 = vm.addr(pk1);
+        attester2 = vm.addr(pk2);
+        attester3 = vm.addr(pk3);
+
+        river = new MockRiverAdmin(admin);
+        depositContract = new DepositContractEnhancedMock();
+        dBuffer = new MockDepositDataBufferForConsolidation();
+        cBuffer = new MockConsolidationDataBuffer();
+
+        validator = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(validator));
+
+        // init(0) — deposit side. Throwaway committee just to advance Version.
+        address[] memory depCommittee = new address[](1);
+        depCommittee[0] = depositAttester;
+        validator.initAttestationVerifierV1(address(river), address(dBuffer), depCommittee, 1, bytes4(0));
+
+        // init(1) — consolidation side.
+        address[] memory cCommittee = new address[](3);
+        cCommittee[0] = attester1;
+        cCommittee[1] = attester2;
+        cCommittee[2] = attester3;
+        validator.initAttestationVerifierV1_1(address(cBuffer), cCommittee, 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// @dev 48-byte deterministic pubkey.
+    function _pubkey(uint256 seed) internal pure returns (bytes memory) {
+        return abi.encodePacked(sha256(abi.encode("pubkey", seed)), bytes16(0));
+    }
+
+    /// @dev Wrong-length pubkey for negative tests.
+    function _pubkeyOfLength(uint256 seed, uint256 len) internal pure returns (bytes memory out) {
+        out = new bytes(len);
+        bytes32 src = sha256(abi.encode("pubkey", seed));
+        for (uint256 i = 0; i < len; i++) {
+            out[i] = src[i % 32];
+        }
+    }
+
+    /// @dev Compute the bufferId following the verifier's encoding rule.
+    function _bufferId(address user, bytes[] memory sources, bytes[] memory targets, uint256 totalAmount)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(user, sources, targets, totalAmount));
+    }
+
+    /// @dev Sign an EIP-712 consolidation attestation digest with the given private key.
+    function _sign(uint256 pk, bytes32 bufferId) internal view returns (bytes memory) {
+        bytes32 domainSep = keccak256(
+            abi.encode(EIP712_DOMAIN_TYPEHASH, CONSOLIDATION_NAME_HASH, VERSION_HASH, block.chainid, address(river))
+        );
+        bytes32 structHash = keccak256(abi.encode(ATTEST_CONSOLIDATION_TYPEHASH, bufferId));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSep, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Build a single-pair consolidation object with two valid signatures (attester1 + attester2).
+    function _validConsolidation(address user, uint256 seed)
+        internal
+        view
+        returns (IConsolidationDataBuffer.ConsolidationObject memory consolidation, bytes32 bufferId)
+    {
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(seed);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(seed + 1000);
+        uint256 totalAmount = 32 ether;
+
+        bufferId = _bufferId(user, sources, targets, totalAmount);
+
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _sign(pk1, bufferId);
+        sigs[1] = _sign(pk2, bufferId);
+
+        consolidation = IConsolidationDataBuffer.ConsolidationObject({
+            user: user,
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: totalAmount,
+            signatures: sigs
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy-path tests
+    // -----------------------------------------------------------------------
+
+    function testValidateConsolidation_singlePair_quorumMet() public {
+        address user = address(0xBEEF);
+        (IConsolidationDataBuffer.ConsolidationObject memory c, bytes32 id) = _validConsolidation(user, 1);
+        cBuffer.submitConsolidationData(id, c);
+
+        (IConsolidationDataBuffer.ConsolidationObject memory returned, uint256 totalAmount) =
+            validator.validateConsolidation(id);
+        assertEq(returned.user, user);
+        assertEq(returned.totalAmount, 32 ether);
+        assertEq(totalAmount, 32 ether);
+        assertEq(returned.sourcePubkeys.length, 1);
+        assertEq(returned.targetPubkeys.length, 1);
+        assertEq(returned.signatures.length, 2);
+    }
+
+    function testValidateConsolidation_multiplePairs_succeeds() public {
+        address user = address(0xCAFE);
+        bytes[] memory sources = new bytes[](3);
+        bytes[] memory targets = new bytes[](3);
+        for (uint256 i = 0; i < 3; i++) {
+            sources[i] = _pubkey(100 + i);
+            targets[i] = _pubkey(200 + i);
+        }
+        uint256 totalAmount = 96 ether;
+        bytes32 id = _bufferId(user, sources, targets, totalAmount);
+
+        bytes[] memory sigs = new bytes[](3);
+        sigs[0] = _sign(pk1, id);
+        sigs[1] = _sign(pk2, id);
+        sigs[2] = _sign(pk3, id);
+
+        cBuffer.submitConsolidationData(
+            id,
+            IConsolidationDataBuffer.ConsolidationObject({
+                user: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: sigs
+            })
+        );
+
+        (IConsolidationDataBuffer.ConsolidationObject memory returned, uint256 amount) =
+            validator.validateConsolidation(id);
+        assertEq(amount, totalAmount);
+        assertEq(returned.sourcePubkeys.length, 3);
+        assertEq(returned.targetPubkeys.length, 3);
+    }
+
+    function testValidateConsolidation_exactlyQuorumSignatures() public {
+        // Quorum is 2; supplying exactly 2 valid signatures should pass.
+        address user = address(0x11);
+        (IConsolidationDataBuffer.ConsolidationObject memory c, bytes32 id) = _validConsolidation(user, 7);
+        cBuffer.submitConsolidationData(id, c);
+
+        (, uint256 amount) = validator.validateConsolidation(id);
+        assertEq(amount, 32 ether);
+    }
+
+    // -----------------------------------------------------------------------
+    // Init / config tests
+    // -----------------------------------------------------------------------
+
+    function testInit_revertEmptyAttesterArray() public {
+        AttestationVerifierV1 fresh = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(fresh));
+        address[] memory dep = new address[](1);
+        dep[0] = depositAttester;
+        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
+
+        address[] memory empty = new address[](0);
+        vm.expectRevert(LibErrors.InvalidArgument.selector);
+        fresh.initAttestationVerifierV1_1(address(cBuffer), empty, 1);
+    }
+
+    function testInit_revertTooManyAttesters() public {
+        AttestationVerifierV1 fresh = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(fresh));
+        address[] memory dep = new address[](1);
+        dep[0] = depositAttester;
+        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
+
+        address[] memory many = new address[](33);
+        for (uint256 i = 0; i < 33; i++) {
+            many[i] = address(uint160(0x1000 + i));
+        }
+        vm.expectRevert(LibErrors.InvalidArgument.selector);
+        fresh.initAttestationVerifierV1_1(address(cBuffer), many, 1);
+    }
+
+    function testInit_revertZeroQuorum() public {
+        AttestationVerifierV1 fresh = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(fresh));
+        address[] memory dep = new address[](1);
+        dep[0] = depositAttester;
+        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
+
+        address[] memory cc = new address[](1);
+        cc[0] = attester1;
+        vm.expectRevert(IAttestationVerifierV1.ZeroQuorum.selector);
+        fresh.initAttestationVerifierV1_1(address(cBuffer), cc, 0);
+    }
+
+    function testInit_revertQuorumExceedsMaxSignatures() public {
+        AttestationVerifierV1 fresh = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(fresh));
+        address[] memory dep = new address[](1);
+        dep[0] = depositAttester;
+        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
+
+        address[] memory cc = new address[](32);
+        for (uint256 i = 0; i < 32; i++) {
+            cc[i] = address(uint160(0x2000 + i));
+        }
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.QuorumExceedsMaxSignatures.selector, 21, fresh.MAX_SIGNATURES())
+        );
+        fresh.initAttestationVerifierV1_1(address(cBuffer), cc, 21);
+    }
+
+    function testInit_revertQuorumExceedsAttesterCount() public {
+        AttestationVerifierV1 fresh = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(fresh));
+        address[] memory dep = new address[](1);
+        dep[0] = depositAttester;
+        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
+
+        address[] memory cc = new address[](2);
+        cc[0] = attester1;
+        cc[1] = attester2;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAttestationVerifierV1.QuorumExceedsConsolidationCommitteeAttesterCount.selector, 3, 2
+            )
+        );
+        fresh.initAttestationVerifierV1_1(address(cBuffer), cc, 3);
+    }
+
+    function testInit_revertZeroBuffer() public {
+        AttestationVerifierV1 fresh = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(fresh));
+        address[] memory dep = new address[](1);
+        dep[0] = depositAttester;
+        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
+
+        address[] memory cc = new address[](1);
+        cc[0] = attester1;
+        vm.expectRevert(LibErrors.InvalidZeroAddress.selector);
+        fresh.initAttestationVerifierV1_1(address(0), cc, 1);
+    }
+
+    function testInit_revertAlreadyInitialized() public {
+        // setUp already called init(1) — calling it again must revert.
+        address[] memory cc = new address[](1);
+        cc[0] = attester1;
+        vm.expectRevert();
+        validator.initAttestationVerifierV1_1(address(cBuffer), cc, 1);
+    }
+
+    function testInit_consolidationDomainSeparatorDiffersFromDeposit() public {
+        bytes32 depositDS = validator.getDomainSeparator();
+        bytes32 consolidationDS = validator.getConsolidationDomainSeparator();
+        assertTrue(depositDS != consolidationDS, "consolidation domain separator must differ from deposit's");
+        assertTrue(consolidationDS != bytes32(0), "consolidation domain separator must be set");
+    }
+
+    function testInit_setsAttesterCount() public {
+        assertEq(validator.getConsolidationCommitteeAttesterCount(), 3);
+        assertTrue(validator.isConsolidationCommitteeAttester(attester1));
+        assertTrue(validator.isConsolidationCommitteeAttester(attester2));
+        assertTrue(validator.isConsolidationCommitteeAttester(attester3));
+        assertEq(validator.getConsolidationCommitteeAttestationQuorum(), 2);
+        assertEq(validator.getConsolidationDataBuffer(), address(cBuffer));
+    }
+
+    // -----------------------------------------------------------------------
+    // Structural validation tests
+    // -----------------------------------------------------------------------
+
+    function testRevert_emptySourcePubkeys() public {
+        // Build a consolidation with empty arrays so submit lets it through via submitRaw.
+        bytes[] memory empty = new bytes[](0);
+        bytes[] memory sigs = new bytes[](0);
+        IConsolidationDataBuffer.ConsolidationObject memory c = IConsolidationDataBuffer.ConsolidationObject({
+            user: address(0xAA),
+            sourcePubkeys: empty,
+            targetPubkeys: empty,
+            totalAmount: 1 ether,
+            signatures: sigs
+        });
+        bytes32 id = _bufferId(c.user, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
+        cBuffer.submitRaw(id, c);
+
+        vm.expectRevert(IAttestationVerifierV1.NoConsolidations.selector);
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_sourceTargetLengthMismatch() public {
+        bytes[] memory sources = new bytes[](2);
+        sources[0] = _pubkey(1);
+        sources[1] = _pubkey(2);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(3);
+
+        IConsolidationDataBuffer.ConsolidationObject memory c = IConsolidationDataBuffer.ConsolidationObject({
+            user: address(0xAA),
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: 32 ether,
+            signatures: new bytes[](0)
+        });
+        bytes32 id = _bufferId(c.user, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
+        cBuffer.submitRaw(id, c);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationArrayLengthMismatch.selector, 2, 1)
+        );
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_zeroTotalAmount() public {
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+
+        IConsolidationDataBuffer.ConsolidationObject memory c = IConsolidationDataBuffer.ConsolidationObject({
+            user: address(0xAA),
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: 0,
+            signatures: new bytes[](0)
+        });
+        bytes32 id = _bufferId(c.user, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
+        cBuffer.submitRaw(id, c);
+
+        vm.expectRevert(IAttestationVerifierV1.ZeroConsolidationTotalAmount.selector);
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_zeroUser() public {
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+
+        IConsolidationDataBuffer.ConsolidationObject memory c = IConsolidationDataBuffer.ConsolidationObject({
+            user: address(0),
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: 32 ether,
+            signatures: new bytes[](0)
+        });
+        bytes32 id = _bufferId(c.user, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
+        cBuffer.submitRaw(id, c);
+
+        vm.expectRevert(IAttestationVerifierV1.ZeroConsolidationUser.selector);
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_sourcePubkeyWrongLength() public {
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkeyOfLength(1, 47);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+
+        IConsolidationDataBuffer.ConsolidationObject memory c = IConsolidationDataBuffer.ConsolidationObject({
+            user: address(0xAA),
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: 32 ether,
+            signatures: new bytes[](0)
+        });
+        bytes32 id = _bufferId(c.user, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
+        cBuffer.submitRaw(id, c);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InvalidConsolidationPubkeyLength.selector, 0, 47, true)
+        );
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_targetPubkeyWrongLength() public {
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkeyOfLength(2, 49);
+
+        IConsolidationDataBuffer.ConsolidationObject memory c = IConsolidationDataBuffer.ConsolidationObject({
+            user: address(0xAA),
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: 32 ether,
+            signatures: new bytes[](0)
+        });
+        bytes32 id = _bufferId(c.user, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
+        cBuffer.submitRaw(id, c);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InvalidConsolidationPubkeyLength.selector, 0, 49, false)
+        );
+        validator.validateConsolidation(id);
+    }
+
+    // -----------------------------------------------------------------------
+    // Buffer integrity tests
+    // -----------------------------------------------------------------------
+
+    function testRevert_bufferIdMismatch() public {
+        // Sign and "commit" to id1, but stash a DIFFERENT object under id1.
+        address user = address(0xBEEF);
+        (IConsolidationDataBuffer.ConsolidationObject memory cSigned, bytes32 idSigned) =
+            _validConsolidation(user, 1);
+
+        // Different content (different seed → different pubkey → different content-hash).
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(99); // different source
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(100);
+        IConsolidationDataBuffer.ConsolidationObject memory cMalicious = IConsolidationDataBuffer.ConsolidationObject({
+            user: user,
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: cSigned.totalAmount,
+            signatures: cSigned.signatures
+        });
+        bytes32 idActual = _bufferId(cMalicious.user, cMalicious.sourcePubkeys, cMalicious.targetPubkeys, cMalicious.totalAmount);
+        assertTrue(idSigned != idActual);
+
+        cBuffer.submitRaw(idSigned, cMalicious);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationBufferIdMismatch.selector, idSigned, idActual)
+        );
+        validator.validateConsolidation(idSigned);
+    }
+
+    function testSignaturesExcludedFromBufferId() public {
+        // Two consolidations identical except for signatures must hash to the same bufferId.
+        address user = address(0xBEEF);
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+        uint256 totalAmount = 32 ether;
+
+        bytes32 id1 = _bufferId(user, sources, targets, totalAmount);
+
+        // Mutate signatures (different content, even garbage) — bufferId must be unchanged.
+        bytes32 id2 = _bufferId(user, sources, targets, totalAmount);
+        assertEq(id1, id2, "bufferId must be invariant under signature mutation");
+    }
+
+    // -----------------------------------------------------------------------
+    // Signature verification tests
+    // -----------------------------------------------------------------------
+
+    function testRevert_insufficientSignatures() public {
+        address user = address(0x11);
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+        uint256 totalAmount = 32 ether;
+        bytes32 id = _bufferId(user, sources, targets, totalAmount);
+
+        bytes[] memory sigs = new bytes[](1);
+        sigs[0] = _sign(pk1, id);
+
+        cBuffer.submitConsolidationData(
+            id,
+            IConsolidationDataBuffer.ConsolidationObject({
+                user: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: sigs
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 1, 2)
+        );
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_tooManySignatures() public {
+        address user = address(0x11);
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+        uint256 totalAmount = 32 ether;
+        bytes32 id = _bufferId(user, sources, targets, totalAmount);
+
+        bytes[] memory sigs = new bytes[](21);
+        for (uint256 i = 0; i < 21; i++) {
+            sigs[i] = _sign(pk1, id); // garbage content; just need 21 entries
+        }
+
+        cBuffer.submitConsolidationData(
+            id,
+            IConsolidationDataBuffer.ConsolidationObject({
+                user: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: sigs
+            })
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.TooManySignatures.selector, 21, 20));
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_duplicateSignerCountsOnce() public {
+        address user = address(0x11);
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+        uint256 totalAmount = 32 ether;
+        bytes32 id = _bufferId(user, sources, targets, totalAmount);
+
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _sign(pk1, id);
+        sigs[1] = _sign(pk1, id); // same signer
+
+        cBuffer.submitConsolidationData(
+            id,
+            IConsolidationDataBuffer.ConsolidationObject({
+                user: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: sigs
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 1, 2)
+        );
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_nonCommitteeSigner() public {
+        address user = address(0x11);
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+        uint256 totalAmount = 32 ether;
+        bytes32 id = _bufferId(user, sources, targets, totalAmount);
+
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _sign(pk1, id);
+        sigs[1] = _sign(0xDEAD, id); // not on the consolidation committee
+
+        cBuffer.submitConsolidationData(
+            id,
+            IConsolidationDataBuffer.ConsolidationObject({
+                user: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: sigs
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 1, 2)
+        );
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_malformedSignatureShort() public {
+        address user = address(0x11);
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+        uint256 totalAmount = 32 ether;
+        bytes32 id = _bufferId(user, sources, targets, totalAmount);
+
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _sign(pk1, id);
+        sigs[1] = new bytes(64); // wrong length
+
+        cBuffer.submitConsolidationData(
+            id,
+            IConsolidationDataBuffer.ConsolidationObject({
+                user: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: sigs
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 1, 2)
+        );
+        validator.validateConsolidation(id);
+    }
+
+    function testRevert_zeroDomainSeparator() public {
+        // Wipe the consolidation domain separator via vm.store.
+        vm.store(address(validator), CONSOLIDATION_DOMAIN_SEPARATOR_SLOT, bytes32(0));
+
+        address user = address(0x11);
+        (IConsolidationDataBuffer.ConsolidationObject memory c, bytes32 id) = _validConsolidation(user, 1);
+        cBuffer.submitConsolidationData(id, c);
+
+        vm.expectRevert(IAttestationVerifierV1.ZeroConsolidationDomainSeparator.selector);
+        validator.validateConsolidation(id);
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin setter tests
+    // -----------------------------------------------------------------------
+
+    function testSetConsolidationCommitteeAttester_addSucceeds() public {
+        address newAttester = address(0xABCD);
+        vm.prank(admin);
+        validator.setConsolidationCommitteeAttester(newAttester, true);
+        assertTrue(validator.isConsolidationCommitteeAttester(newAttester));
+        assertEq(validator.getConsolidationCommitteeAttesterCount(), 4);
+    }
+
+    function testSetConsolidationCommitteeAttester_removeSucceeds() public {
+        vm.prank(admin);
+        validator.setConsolidationCommitteeAttester(attester3, false);
+        assertFalse(validator.isConsolidationCommitteeAttester(attester3));
+        assertEq(validator.getConsolidationCommitteeAttesterCount(), 2);
+    }
+
+    function testSetConsolidationCommitteeAttester_revertStatusUnchanged() public {
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAttestationVerifierV1.ConsolidationCommitteeAttesterStatusUnchanged.selector, attester1, true
+            )
+        );
+        validator.setConsolidationCommitteeAttester(attester1, true);
+
+        address stranger = address(0xC0FFEE);
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAttestationVerifierV1.ConsolidationCommitteeAttesterStatusUnchanged.selector, stranger, false
+            )
+        );
+        validator.setConsolidationCommitteeAttester(stranger, false);
+    }
+
+    function testSetConsolidationCommitteeAttester_revertTooMany() public {
+        // Add up to 32 attesters (3 already registered → add 29).
+        for (uint256 i = 0; i < 29; i++) {
+            vm.prank(admin);
+            validator.setConsolidationCommitteeAttester(address(uint160(0x9000 + i)), true);
+        }
+        assertEq(validator.getConsolidationCommitteeAttesterCount(), 32);
+
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.TooManyConsolidationCommitteeAttesters.selector, 33, 32)
+        );
+        validator.setConsolidationCommitteeAttester(address(0x9999), true);
+    }
+
+    function testSetConsolidationCommitteeAttester_revertRemovingBreaksQuorum() public {
+        // We start with 3 attesters and quorum 2. Removing two would leave count=1 < quorum=2.
+        vm.prank(admin);
+        validator.setConsolidationCommitteeAttester(attester3, false); // 3 → 2
+
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAttestationVerifierV1.QuorumExceedsConsolidationCommitteeAttesterCount.selector, 2, 1
+            )
+        );
+        validator.setConsolidationCommitteeAttester(attester2, false); // would go 2 → 1
+    }
+
+    function testSetConsolidationCommitteeAttester_onlyRiverAdmin() public {
+        vm.expectRevert(abi.encodeWithSelector(LibErrors.Unauthorized.selector, address(this)));
+        validator.setConsolidationCommitteeAttester(address(0xABCD), true);
+    }
+
+    function testSetConsolidationCommitteeAttestationQuorum_succeeds() public {
+        vm.prank(admin);
+        validator.setConsolidationCommitteeAttestationQuorum(3);
+        assertEq(validator.getConsolidationCommitteeAttestationQuorum(), 3);
+    }
+
+    function testSetConsolidationCommitteeAttestationQuorum_revertZero() public {
+        vm.prank(admin);
+        vm.expectRevert(IAttestationVerifierV1.ZeroQuorum.selector);
+        validator.setConsolidationCommitteeAttestationQuorum(0);
+    }
+
+    function testSetConsolidationCommitteeAttestationQuorum_revertExceedsAttesters() public {
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAttestationVerifierV1.QuorumExceedsConsolidationCommitteeAttesterCount.selector, 4, 3
+            )
+        );
+        validator.setConsolidationCommitteeAttestationQuorum(4);
+    }
+
+    function testSetConsolidationCommitteeAttestationQuorum_revertExceedsMaxSignatures() public {
+        // Push attester count above MAX_SIGNATURES so the count check doesn't fire first.
+        for (uint256 i = 0; i < 18; i++) {
+            vm.prank(admin);
+            validator.setConsolidationCommitteeAttester(address(uint160(0xA000 + i)), true);
+        }
+        assertEq(validator.getConsolidationCommitteeAttesterCount(), 21);
+
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.QuorumExceedsMaxSignatures.selector, 21, 20)
+        );
+        validator.setConsolidationCommitteeAttestationQuorum(21);
+    }
+
+    function testSetConsolidationCommitteeAttestationQuorum_onlyRiverAdmin() public {
+        vm.expectRevert(abi.encodeWithSelector(LibErrors.Unauthorized.selector, address(this)));
+        validator.setConsolidationCommitteeAttestationQuorum(3);
+    }
+
+    function testSetConsolidationDataBuffer_succeeds() public {
+        address newBuffer = address(0xDDDD);
+        vm.prank(admin);
+        validator.setConsolidationDataBuffer(newBuffer);
+        assertEq(validator.getConsolidationDataBuffer(), newBuffer);
+    }
+
+    function testSetConsolidationDataBuffer_revertZeroAddress() public {
+        vm.prank(admin);
+        vm.expectRevert(LibErrors.InvalidZeroAddress.selector);
+        validator.setConsolidationDataBuffer(address(0));
+    }
+
+    function testSetConsolidationDataBuffer_onlyRiverAdmin() public {
+        vm.expectRevert(abi.encodeWithSelector(LibErrors.Unauthorized.selector, address(this)));
+        validator.setConsolidationDataBuffer(address(0xDDDD));
+    }
+
+    // -----------------------------------------------------------------------
+    // Isolation from deposit flow
+    // -----------------------------------------------------------------------
+
+    function testIsolation_consolidationAttesterNotADepositAttester() public {
+        vm.prank(admin);
+        validator.setConsolidationCommitteeAttester(address(0xBABE), true);
+        assertFalse(validator.isDepositCommitteeAttester(address(0xBABE)));
+        assertTrue(validator.isConsolidationCommitteeAttester(address(0xBABE)));
+    }
+
+    function testIsolation_quorumsAreSeparate() public {
+        // setUp configured consolidation quorum=2 and deposit quorum=1 — they must read independently.
+        assertEq(validator.getDepositCommitteeAttestationQuorum(), 1);
+        assertEq(validator.getConsolidationCommitteeAttestationQuorum(), 2);
+    }
+
+    function testIsolation_changingConsolidationQuorumDoesNotAffectDeposit() public {
+        uint256 depositQuorumBefore = validator.getDepositCommitteeAttestationQuorum();
+        vm.prank(admin);
+        validator.setConsolidationCommitteeAttestationQuorum(3);
+        assertEq(validator.getDepositCommitteeAttestationQuorum(), depositQuorumBefore);
+        assertEq(validator.getConsolidationCommitteeAttestationQuorum(), 3);
+    }
+}

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -186,17 +186,44 @@ contract ConsolidationAttestationTest is Test {
         validator = new AttestationVerifierV1();
         LibImplementationUnbricker.unbrick(vm, address(validator));
 
-        // init(0) — deposit side. Throwaway committee just to advance Version.
         address[] memory depCommittee = new address[](1);
         depCommittee[0] = depositAttester;
-        validator.initAttestationVerifierV1(address(river), address(dBuffer), depCommittee, 1, bytes4(0));
-
-        // init(1) — consolidation side.
         address[] memory cCommittee = new address[](3);
         cCommittee[0] = attester1;
         cCommittee[1] = attester2;
         cCommittee[2] = attester3;
-        validator.initAttestationVerifierV1_1(address(cBuffer), cCommittee, 2);
+        validator.initAttestationVerifierV1(
+            address(river), address(dBuffer), depCommittee, 1, bytes4(0), address(cBuffer), cCommittee, 2
+        );
+    }
+
+    /// @dev Deploy + unbrick a fresh validator.
+    function _deployFreshValidator() internal returns (AttestationVerifierV1 fresh) {
+        fresh = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(fresh));
+    }
+
+    /// @dev Init a fresh validator with the provided consolidation params, reusing a valid
+    ///      1-attester deposit committee. Internal so `vm.expectRevert` pierces through to
+    ///      the init external call.
+    function _initFreshWithConsolidationParams(
+        AttestationVerifierV1 fresh,
+        address consolidationBuffer,
+        address[] memory consolidationCommittee,
+        uint256 consolidationQuorum
+    ) internal {
+        address[] memory dep = new address[](1);
+        dep[0] = depositAttester;
+        fresh.initAttestationVerifierV1(
+            address(river),
+            address(dBuffer),
+            dep,
+            1,
+            bytes4(0),
+            consolidationBuffer,
+            consolidationCommittee,
+            consolidationQuorum
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -332,69 +359,46 @@ contract ConsolidationAttestationTest is Test {
     // -----------------------------------------------------------------------
 
     function testInit_revertEmptyAttesterArray() public {
-        AttestationVerifierV1 fresh = new AttestationVerifierV1();
-        LibImplementationUnbricker.unbrick(vm, address(fresh));
-        address[] memory dep = new address[](1);
-        dep[0] = depositAttester;
-        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
-
+        AttestationVerifierV1 fresh = _deployFreshValidator();
         address[] memory empty = new address[](0);
         vm.expectRevert(LibErrors.InvalidArgument.selector);
-        fresh.initAttestationVerifierV1_1(address(cBuffer), empty, 1);
+        _initFreshWithConsolidationParams(fresh, address(cBuffer), empty, 1);
     }
 
     function testInit_revertTooManyAttesters() public {
-        AttestationVerifierV1 fresh = new AttestationVerifierV1();
-        LibImplementationUnbricker.unbrick(vm, address(fresh));
-        address[] memory dep = new address[](1);
-        dep[0] = depositAttester;
-        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
-
+        AttestationVerifierV1 fresh = _deployFreshValidator();
         address[] memory many = new address[](33);
         for (uint256 i = 0; i < 33; i++) {
             many[i] = address(uint160(0x1000 + i));
         }
         vm.expectRevert(LibErrors.InvalidArgument.selector);
-        fresh.initAttestationVerifierV1_1(address(cBuffer), many, 1);
+        _initFreshWithConsolidationParams(fresh, address(cBuffer), many, 1);
     }
 
     function testInit_revertZeroQuorum() public {
-        AttestationVerifierV1 fresh = new AttestationVerifierV1();
-        LibImplementationUnbricker.unbrick(vm, address(fresh));
-        address[] memory dep = new address[](1);
-        dep[0] = depositAttester;
-        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
-
+        AttestationVerifierV1 fresh = _deployFreshValidator();
         address[] memory cc = new address[](1);
         cc[0] = attester1;
         vm.expectRevert(IAttestationVerifierV1.ZeroQuorum.selector);
-        fresh.initAttestationVerifierV1_1(address(cBuffer), cc, 0);
+        _initFreshWithConsolidationParams(fresh, address(cBuffer), cc, 0);
     }
 
     function testInit_revertQuorumExceedsMaxSignatures() public {
-        AttestationVerifierV1 fresh = new AttestationVerifierV1();
-        LibImplementationUnbricker.unbrick(vm, address(fresh));
-        address[] memory dep = new address[](1);
-        dep[0] = depositAttester;
-        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
-
+        AttestationVerifierV1 fresh = _deployFreshValidator();
         address[] memory cc = new address[](32);
         for (uint256 i = 0; i < 32; i++) {
             cc[i] = address(uint160(0x2000 + i));
         }
         vm.expectRevert(
-            abi.encodeWithSelector(IAttestationVerifierV1.QuorumExceedsMaxSignatures.selector, 21, fresh.MAX_SIGNATURES())
+            abi.encodeWithSelector(
+                IAttestationVerifierV1.QuorumExceedsMaxSignatures.selector, 21, validator.MAX_SIGNATURES()
+            )
         );
-        fresh.initAttestationVerifierV1_1(address(cBuffer), cc, 21);
+        _initFreshWithConsolidationParams(fresh, address(cBuffer), cc, 21);
     }
 
     function testInit_revertQuorumExceedsAttesterCount() public {
-        AttestationVerifierV1 fresh = new AttestationVerifierV1();
-        LibImplementationUnbricker.unbrick(vm, address(fresh));
-        address[] memory dep = new address[](1);
-        dep[0] = depositAttester;
-        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
-
+        AttestationVerifierV1 fresh = _deployFreshValidator();
         address[] memory cc = new address[](2);
         cc[0] = attester1;
         cc[1] = attester2;
@@ -403,28 +407,27 @@ contract ConsolidationAttestationTest is Test {
                 IAttestationVerifierV1.QuorumExceedsConsolidationCommitteeAttesterCount.selector, 3, 2
             )
         );
-        fresh.initAttestationVerifierV1_1(address(cBuffer), cc, 3);
+        _initFreshWithConsolidationParams(fresh, address(cBuffer), cc, 3);
     }
 
     function testInit_revertZeroBuffer() public {
-        AttestationVerifierV1 fresh = new AttestationVerifierV1();
-        LibImplementationUnbricker.unbrick(vm, address(fresh));
-        address[] memory dep = new address[](1);
-        dep[0] = depositAttester;
-        fresh.initAttestationVerifierV1(address(river), address(dBuffer), dep, 1, bytes4(0));
-
+        AttestationVerifierV1 fresh = _deployFreshValidator();
         address[] memory cc = new address[](1);
         cc[0] = attester1;
         vm.expectRevert(LibErrors.InvalidZeroAddress.selector);
-        fresh.initAttestationVerifierV1_1(address(0), cc, 1);
+        _initFreshWithConsolidationParams(fresh, address(0), cc, 1);
     }
 
     function testInit_revertAlreadyInitialized() public {
-        // setUp already called init(1) — calling it again must revert.
+        // setUp already called init — calling it again must revert.
+        address[] memory dep = new address[](1);
+        dep[0] = depositAttester;
         address[] memory cc = new address[](1);
         cc[0] = attester1;
         vm.expectRevert();
-        validator.initAttestationVerifierV1_1(address(cBuffer), cc, 1);
+        validator.initAttestationVerifierV1(
+            address(river), address(dBuffer), dep, 1, bytes4(0), address(cBuffer), cc, 1
+        );
     }
 
     function testInit_consolidationDomainSeparatorDiffersFromDeposit() public {


### PR DESCRIPTION
## Description

Extends `AttestationVerifierV1` with a parallel attestation flow for EIP-7251 consolidation requests. The deposit attestation flow is left untouched — every new piece of state, storage, and code is additive.

A new `ConsolidationDataBuffer` interface is introduced. The buffer is expected to hold `ConsolidationObject` records with:

1. `address user` — initiator (and eventual recipient of LsETH in a later PR)
2. `bytes[] sourcePubkeys` — 48 bytes each
3. `bytes[] targetPubkeys` — 48 bytes each, paired by index with sources
4. `uint256 totalAmount` — total ETH being consolidated, in wei
5. `bytes[] signatures` — committee EIP-712 ECDSA signatures, 65 bytes each

Two deliberate departures from the deposit pattern:
- **Signatures live in the buffer**, not in calldata. `validateConsolidation` reads them on-chain. The `bufferId` hash excludes signatures (`keccak256(abi.encode(user, sourcePubkeys, targetPubkeys, totalAmount))`) so signers can sign the bufferId without a circular dependency.
- **No BLS verification** and **no `depositRootHash` co-sign** — consolidations don't carry BLS deposit messages and have no front-runnable shared on-chain root.

Integration with `mintLsETHForConsolidation` (currently on `feat/pectra/consolidation-minting`) is intentionally out of scope. This PR is the trust layer only.

### What's added

- `contracts/src/interfaces/IConsolidationDataBuffer.sol` — `ConsolidationObject` struct + `getConsolidationData` getter + admin/writer views.
- `contracts/src/state/attestationVerifier/ConsolidationCommitteeAttesters.sol` — attester mapping + count.
- `contracts/src/state/attestationVerifier/ConsolidationCommitteeAttestationQuorum.sol` — `uint256` quorum.
- `contracts/src/state/attestationVerifier/ConsolidationDataBufferAddress.sol` — buffer address.
- `contracts/src/state/attestationVerifier/ConsolidationDomainSeparator.sol` — EIP-712 domain separator (NAME_HASH = `"ConsolidationValidation"`, anchored to River).
- `contracts/test/components/ConsolidationAttestation.t.sol` — 43 unit tests + `MockConsolidationDataBuffer` + `MockRiverAdmin`.

### What's extended

- `contracts/src/AttestationVerifier.1.sol`:
  - `initAttestationVerifierV1_1` with `init(1)` so existing deployments can be upgraded forward. Reuses `RiverAddress` set in `init(0)`.
  - `validateConsolidation(bytes32) view` — structural validation → bufferId recomputation → ECDSA quorum verification → returns the struct and totalAmount.
  - `_verifyConsolidationAttestationQuorum` — mirrors `_verifyAttestationQuorum` but with a single-field typehash, the consolidation domain separator, and the consolidation committee set.
  - `_recoverMemory` — `bytes memory` sibling of `_recover` (signatures arrive via a memory struct from the buffer). The calldata-optimized `_recover` used by the deposit hot path is untouched.
  - Three admin setters (`setConsolidationDataBuffer`, `setConsolidationCommitteeAttester`, `setConsolidationCommitteeAttestationQuorum`) gated by `onlyRiverAdmin`.
  - Five views (`isConsolidationCommitteeAttester`, count, quorum, buffer, domain separator).
- `contracts/src/interfaces/IAttestationVerifier.1.sol` — parallel events, errors, function signatures.

### Cross-flow replay protection

Defense-in-depth at two levels:
1. Distinct EIP-712 domain separator (different `NAME_HASH`).
2. Distinct typehash (`AttestConsolidation(bytes32 consolidationDataBufferId)` vs `Attest(bytes32 depositDataBufferId,bytes32 depositRootHash)`).

Storage slots use the `attestationVerifier.state.consolidation*` prefix to ensure no collision with the deposit-side slots.

### Verification

- `forge build --sizes`: `AttestationVerifierV1` runtime size = **13,108 bytes** (11,468-byte EIP-170 margin).
- 43/43 new consolidation tests pass: `forge test --match-contract ConsolidationAttestationTest`.
- Deposit regression: 14/14 deposit attestation tests still pass.
- Full suite: 679/680 pass — the 1 failure is `TlcMigrationTest` failing at `setUp()` for missing `MAINNET_FORK_RPC_URL`, unrelated to this change.

## Notice

- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [x] Have you added sufficient documentation in your code?
- [x] Have you added relevant tests to the official test suite?

## Pull Request Type

- [x] 💫 New Feature (Non-breaking Change)

## Breaking changes (if applicable)

None. All additions are strictly additive: new state libraries on disjoint slots, a new initializer at `init(1)`, new external functions on the verifier, and a new interface. The deposit attestation path (existing `validate`, deposit committee state, EIP-712 `Attest` typehash, deposit domain separator) is unchanged.

## Testing

- [x] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

N/A — this PR is the trust layer only. End-to-end integration (`mintLsETHForConsolidation`) is the subject of a follow-up PR.