### PR TITLE
chore: added comments to specify the value present in the validatorExitedBalance

### DIFF
--- a/contracts/src/interfaces/components/IOracleManager.1.sol
+++ b/contracts/src/interfaces/components/IOracleManager.1.sol
@@ -141,9 +141,9 @@ interface IOracleManagerV1 {
         // these values can be found in the execution layer block bodies under the withdrawals field
         // a withdrawal is considered exit if
         // - the epoch at which it happened is >= validator.withdrawableEpoch and in that case we only account for what would be <= 32 eth as exit
-        // this value cannot decrease over reports
         // a withdrawal is considered to be a partial exit if
         // - the the validator was present in the pending_partial_withdrawals list at slot - 1
+        // this value cannot decrease over reports
         uint256 validatorsExitedBalance;
         // the sum of all the exiting balance, which is all the validators on their way to get sweeped and exited
         // this includes voluntary exits and slashings

--- a/contracts/src/interfaces/components/IOracleManager.1.sol
+++ b/contracts/src/interfaces/components/IOracleManager.1.sol
@@ -137,11 +137,13 @@ interface IOracleManagerV1 {
         // - the epoch at which it happened is >= validator.withdrawableEpoch and in that case we only account for what would be above 32 eth as skimming
         // this value cannot decrease over reports
         uint256 validatorsSkimmedBalance;
-        // the sum of all the exits performed on the validators
+        // the sum of all the exits performed on the validators, includes full and partial exits
         // these values can be found in the execution layer block bodies under the withdrawals field
         // a withdrawal is considered exit if
         // - the epoch at which it happened is >= validator.withdrawableEpoch and in that case we only account for what would be <= 32 eth as exit
         // this value cannot decrease over reports
+        // a withdrawal is considered to be a partial exit if
+        // - the the validator was present in the pending_partial_withdrawals list at slot - 1
         uint256 validatorsExitedBalance;
         // the sum of all the exiting balance, which is all the validators on their way to get sweeped and exited
         // this includes voluntary exits and slashings

--- a/contracts/src/interfaces/components/IOracleManager.1.sol
+++ b/contracts/src/interfaces/components/IOracleManager.1.sol
@@ -139,10 +139,10 @@ interface IOracleManagerV1 {
         uint256 validatorsSkimmedBalance;
         // the sum of all the exits performed on the validators, includes full and partial exits
         // these values can be found in the execution layer block bodies under the withdrawals field
-        // a withdrawal is considered exit if
+        // a withdrawal is considered an exit if
         // - the epoch at which it happened is >= validator.withdrawableEpoch and in that case we only account for what would be <= 32 eth as exit
-        // a withdrawal is considered to be a partial exit if
-        // - the the validator was present in the pending_partial_withdrawals list at slot - 1
+        // a withdrawal is considered a partial exit if
+        // - the validator was present in the pending_partial_withdrawals list at the previous slot (slot - 1)
         // this value cannot decrease over reports
         uint256 validatorsExitedBalance;
         // the sum of all the exiting balance, which is all the validators on their way to get sweeped and exited


### PR DESCRIPTION

## Description

This pull request updates the documentation comments in the `IOracleManagerV1` interface to clarify the definition of validator exits, specifically distinguishing between full and partial exits and how partial exits are determined.

Documentation improvements:

* Clarified that `validatorsExitedBalance` includes both full and partial exits, and added an explanation that a withdrawal is considered a partial exit if the validator was present in the `pending_partial_withdrawals` list at the previous slot.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?