### PR TITLE
fix/broken tests operator

### DIFF
--- a/contracts/src/Withdraw.1.sol
+++ b/contracts/src/Withdraw.1.sol
@@ -17,7 +17,10 @@ import "./state/withdraw/PectraConsolidationContractAddress.sol";
 
 /// @title Withdraw (v1)
 /// @author Alluvial Finance Inc.
-/// @notice This contract is in charge of holding the exit and skimming funds and allow river to pull these funds
+/// @notice This contract is the withdrawal address for all LC validators.
+/// @notice It is in charge of holding the exited and skimmed funds and allows river to pull these funds.
+/// @notice Furthermore, it enables consolidation of LC validators.
+/// @notice LC validators (0x02) can be EL-exited using partial or full EL withdrawals via the withdraw function.
 contract WithdrawV1 is IWithdrawV1, Initializable, ReentrancyGuard, IProtocolVersion {
     modifier onlyRiver() {
         if (msg.sender != RiverAddress.get()) {

--- a/contracts/src/interfaces/IRiver.1.sol
+++ b/contracts/src/interfaces/IRiver.1.sol
@@ -131,7 +131,7 @@ interface IRiverV1 is IConsensusLayerDepositManagerV1, IUserDepositManagerV1, IS
 
     /// @notice Emitted when balance commitment to deposit is skipped because slashing containment mode is active
     event SkippedCommitToDepositDueToSlashingContainment();
-    
+
     /// @notice Emitted when River forwards a Pectra consolidation request to the Withdraw contract
     /// @param requests Consolidation requests
     /// @param maxFeePerConsolidation Maximum fee per consolidation

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -1769,6 +1769,7 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         vm.prank(admin);
         reg.addOperator("Op0", makeAddr("op0"));
         uint256[] memory empty = new uint256[](0);
+        vm.prank(river);
         vm.expectRevert(abi.encodeWithSignature("InvalidEmptyArray()"));
         reg.reportCLETH(empty);
     }
@@ -1778,6 +1779,7 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         vm.prank(admin);
         reg.addOperator("Op0", makeAddr("op0"));
         uint256[] memory tooLong = new uint256[](2);
+        vm.prank(river);
         vm.expectRevert(abi.encodeWithSignature("InvalidActiveCLETHArrayLength()"));
         reg.reportCLETH(tooLong);
     }
@@ -1791,6 +1793,7 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         uint256[] memory values = new uint256[](2);
         values[0] = 100 ether;
         values[1] = 200 ether;
+        vm.prank(river);
         reg.reportCLETH(values);
         assertEq(reg.getOperator(0).activeCLETH, 100 ether);
         assertEq(reg.getOperator(1).activeCLETH, 200 ether);
@@ -1807,6 +1810,7 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         values[1] = 70 ether;
         vm.expectEmit(false, false, false, true, address(reg));
         emit IOperatorsRegistryV1.UpdatedActiveCLETH(values);
+        vm.prank(river);
         reg.reportCLETH(values);
     }
 
@@ -1816,6 +1820,7 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         reg.initOperatorsRegistryV1(admin, river);
         vm.prank(admin);
         reg.addOperator("Op0", makeAddr("op0"));
+        vm.prank(river);
         reg.demandETHExits(100 ether, 60 ether);
         assertEq(reg.getCurrentETHExitsDemand(), 60 ether);
     }
@@ -1824,8 +1829,10 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         reg.initOperatorsRegistryV1(admin, river);
         vm.prank(admin);
         reg.addOperator("Op0", makeAddr("op0"));
+        vm.prank(river);
         reg.demandETHExits(50 ether, 50 ether);
         assertEq(reg.getCurrentETHExitsDemand(), 50 ether);
+        vm.prank(river);
         reg.demandETHExits(10 ether, 50 ether);
         assertEq(reg.getCurrentETHExitsDemand(), 50 ether);
     }
@@ -1834,6 +1841,7 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         reg.initOperatorsRegistryV1(admin, river);
         vm.prank(admin);
         reg.addOperator("Op0", makeAddr("op0"));
+        vm.prank(river);
         reg.demandETHExits(100 ether, 0);
         assertEq(reg.getCurrentETHExitsDemand(), 0);
     }


### PR DESCRIPTION
## Description

This pull request updates several tests in `OperatorsRegistryV1CoverageTests` to ensure that calls to sensitive functions such as `reportCLETH` and `demandETHExits` are properly performed as the `river` address. This change improves the accuracy of the tests by correctly simulating the required caller context for these functions.

Test improvements for correct caller context:

* Added `vm.prank(river)` before calls to `reportCLETH` in tests for empty, too-long, and valid arrays to ensure the function is called as the `river` address. [[1]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R1772) [[2]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R1782) [[3]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R1796) [[4]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R1813)
* Added `vm.prank(river)` before calls to `demandETHExits` in tests to verify correct behavior when called by the `river` address, including scenarios with different demand values. [[1]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R1823) [[2]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R1832-R1835) [[3]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R1844)

<!-- Please provide a detailed description of your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->