### PR TITLE
chore: this updates the .github ci machines to be more on the heavy ci jobs

### DIFF
--- a/.github/workflows/Coverage.yaml
+++ b/.github/workflows/Coverage.yaml
@@ -22,7 +22,9 @@ on:
 
 jobs:
   run-coverage:
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: eth-protocol-runners
+      labels: ubuntu-24.04-8core
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/HeavyTests.yaml
+++ b/.github/workflows/HeavyTests.yaml
@@ -19,7 +19,9 @@ on:
 
 jobs:
   run-heavy-tests:
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: eth-protocol-runners
+      labels: ubuntu-24.04-8core
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -19,7 +19,9 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: eth-protocol-runners
+      labels: ubuntu-24.04-8core
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/foundry-gas-diff.yml
+++ b/.github/workflows/foundry-gas-diff.yml
@@ -19,7 +19,9 @@ on:
 
 jobs:
   compare_gas_reports:
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: eth-protocol-runners
+      labels: ubuntu-24.04-8core
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Description

This pull request updates the runner configuration for several GitHub Actions workflows to use a specific runner group and label, ensuring jobs run on dedicated hardware with the required specs. This change helps standardize and control the execution environment for CI jobs.

**GitHub Actions runner configuration:**

* Updated the `runs-on` field in the following workflows to use the `eth-protocol-runners` group with the `ubuntu-24.04-8core` label:
  - `.github/workflows/Coverage.yaml`
  - `.github/workflows/HeavyTests.yaml`
  - `.github/workflows/Tests.yaml`
  - `.github/workflows/foundry-gas-diff.yml`
  
  
 Which jobs are actually slow

  The slow ones are all forge/fuzz-test jobs — they're CPU-bound and Foundry parallelizes test execution across cores, so more cores ≈
  proportionally faster:

  ```┌──────────────────────┬─────────────────────┬──────────────────────────────────────────────────────┬────────────────────────────────┐
  │       Workflow       │         Job         │                       Why slow                       │      Bigger runner helps?      │
  ├──────────────────────┼─────────────────────┼──────────────────────────────────────────────────────┼────────────────────────────────┤
  │ Coverage.yaml        │ run-coverage        │ forge coverage, 1500 fuzz runs — your failing run    │ ✅ Big win (3.6× CPU already   │
  │                      │                     │ took 465s wall / 1696s CPU                           │ wants more cores)              │
  ├──────────────────────┼─────────────────────┼──────────────────────────────────────────────────────┼────────────────────────────────┤
  │ Tests.yaml           │ run-tests           │ make test, 1500 fuzz runs                            │ ✅                             │
  ├──────────────────────┼─────────────────────┼──────────────────────────────────────────────────────┼────────────────────────────────┤
  │ HeavyTests.yaml      │ run-heavy-tests     │ --match-contract HEAVY_FUZZING, 1000 runs            │ ✅                             │
  ├──────────────────────┼─────────────────────┼──────────────────────────────────────────────────────┼────────────────────────────────┤
  │ foundry-gas-diff.yml │ compare_gas_reports │ forge test --gas-report (full suite)                 │ ✅                             │
  └──────────────────────┴─────────────────────┴──────────────────────────────────────────────────────┴────────────────────────────────┘
```

  The rest don't benefit (or already scale differently):
  - Mythril.yaml & Certora.yaml — already fan out via a matrix (per-contract / per-conf), and Certora runs the heavy work on a remote
  prover. Each shard is light locally.
  - Lint.yaml, Format.yaml, Deploy.yaml — I/O- or network-bound (yarn install, anvil fork), not CPU-bound.


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->