### PR TITLE
  fix(attestation): enforce 32 ETH minimum on initial deposits (#441)

### DIFF
--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -93,6 +93,13 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     uint256 internal constant DEPOSIT_PUBKEY_LENGTH = 48;
     uint256 internal constant DEPOSIT_SIGNATURE_LENGTH = 96;
 
+    /// @notice Minimum amount for an initial validator deposit. A brand-new validator requires the
+    ///         full 32 ETH to activate on the consensus layer; a smaller initial deposit would never
+    ///         activate yet would still be counted in InFlightDeposit / TotalDepositedETH, permanently
+    ///         inflating River's `_assetBalance()` (issue #441/#309). Top-ups are intentionally exempt —
+    ///         they credit already-activated validators and may be below this amount.
+    uint256 internal constant MIN_INITIAL_DEPOSIT_AMOUNT = 32 ether;
+
     /// @dev Expected length for BLS pubkeys in a ConsolidationObject (source or target).
     uint256 internal constant CONSOLIDATION_PUBKEY_LENGTH = 48;
 
@@ -401,8 +408,12 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             if (d.signature.length != DEPOSIT_SIGNATURE_LENGTH) {
                 revert InvalidSignatureLength(i, d.signature.length);
             }
-            // Mirrors the bound check inside `_depositValidator` so we fail early
-            if (d.amount < 1 ether || d.amount > 2048 ether || d.amount % 1 gwei != 0) {
+            // Initial deposits must be >= 32 ETH so the validator actually activates on the CL.
+            // A sub-32-ETH initial deposit would never activate yet would still inflate
+            // InFlightDeposit / _assetBalance() (issue #441/#309). The upper bound and gwei-alignment
+            // mirror `_depositValidator`; the 32-ETH floor is stricter here because this loop only
+            // covers initial deposits (top-ups are validated separately below and stay >= 1 ETH).
+            if (d.amount < MIN_INITIAL_DEPOSIT_AMOUNT || d.amount > 2048 ether || d.amount % 1 gwei != 0) {
                 revert InvalidDepositAmount(i, d.amount);
             }
             totalAmount += d.amount;

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -142,15 +142,22 @@ interface IAttestationVerifierV1 {
     error InvalidSignatureLength(uint256 index, uint256 length);
 
     /// @notice An initial deposit's `amount` is outside the protocol-accepted range
-    ///         [1 ether, 2048 ether] or is not gwei-aligned. Enforced here in
-    ///         `fetchAndValidateDeposits()` so producer bugs fail before the heavy BLS path runs;
-    ///         downstream `_depositValidator` trusts this check.
+    ///         [MIN_INITIAL_DEPOSIT_AMOUNT (32 ether), 2048 ether] or is not gwei-aligned. Initial
+    ///         deposits require the full 32 ether so the validator actually activates on the consensus
+    ///         layer; a smaller amount would never activate yet would still inflate InFlightDeposit /
+    ///         `_assetBalance()` (see #441). This 32 ether floor is intentionally distinct from the
+    ///         top-up range, which allows down to 1 ether (see `InvalidTopUpAmount`) because top-ups
+    ///         credit already-activated validators. Enforced here in `fetchAndValidateDeposits()` so
+    ///         producer bugs fail before the heavy BLS path runs; downstream `_depositValidator`
+    ///         trusts this check.
     /// @param index Index into `batch.deposits`
     /// @param amount The offending amount in wei
     error InvalidDepositAmount(uint256 index, uint256 amount);
 
     /// @notice A top-up's `amount` is outside the protocol-accepted range
-    ///         [1 ether, 2048 ether] or is not gwei-aligned. Enforced here in
+    ///         [1 ether, 2048 ether] or is not gwei-aligned. Top-ups credit already-activated
+    ///         validators, so the lower bound is 1 ether — intentionally below the 32 ether floor
+    ///         that initial deposits require (see `InvalidDepositAmount`). Enforced here in
     ///         `fetchAndValidateDeposits()` so producer bugs fail before the heavy BLS path runs;
     ///         downstream `_depositValidator` trusts this check.
     /// @param index Index into `batch.topUps`

--- a/contracts/test/accounting/invariant/AccountingHandler.sol
+++ b/contracts/test/accounting/invariant/AccountingHandler.sol
@@ -25,7 +25,7 @@ interface IAccountingActions {
 /// @notice Foundry invariant-test handler that bounds fuzzed inputs and delegates to sim_* step functions
 ///         on the test contract. Each public function is a target for Foundry's stateful fuzzer.
 contract AccountingHandler is StdUtils {
-    uint256 private constant MIN_DEPOSIT = 1 ether;
+    uint256 private constant MIN_DEPOSIT = 32 ether;
     uint256 private constant MAX_DEPOSIT = 2048 ether;
 
     IAccountingActions private _test;
@@ -59,11 +59,11 @@ contract AccountingHandler is StdUtils {
     // ─── bounded handler functions ──────────────────────────────────────────────
 
     /// @notice Fuzzer entry point: deposits 1–4 validators for a pseudo-randomly selected operator,
-    ///         each with a fuzzed amount in [1, 2048] ETH.
+    ///         each with a fuzzed amount in [32, 2048] ETH.
     ///         Updates `ghost_depositCount` so that `oracleReport` knows at least one deposit exists.
     /// @param opSeed     Seed used to select the target operator (even → operator one, odd → operator two).
     /// @param nSeed      Seed used to derive the number of validators to deposit, bounded to [1, 4].
-    /// @param amountSeed Seed used to derive the per-validator deposit amount, bounded to [1, 2048] ETH.
+    /// @param amountSeed Seed used to derive the per-validator deposit amount, bounded to [32, 2048] ETH.
     function deposit(uint256 opSeed, uint256 nSeed, uint256 amountSeed) external {
         // Step 1: Select operator and bound the validator count and deposit amount to safe ranges.
         uint256 opIdx = (opSeed % 2 == 0) ? _opOne : _opTwo;

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -1682,6 +1682,33 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
     }
 
+    /// @dev An initial deposit below 32 ETH must revert with InvalidDepositAmount (issue #441/#309):
+    ///      a brand-new validator needs the full 32 ETH to activate on the CL, and a smaller initial
+    ///      deposit would never activate yet would permanently inflate InFlightDeposit / _assetBalance().
+    ///      Amounts in [1 ether, 32 ether) are gwei-aligned and within the legacy [1, 2048] range, so
+    ///      they passed before this guard — they must now revert. Top-ups below 32 ETH stay valid and
+    ///      are exercised by the separate top-up tests.
+    function testRevert_validate_initialDepositBelowMinimum() public {
+        // 1 ETH: smallest legacy-valid amount, must now revert.
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](1);
+        deposits[0] = _makeDeposit(0, 410);
+        deposits[0].amount = 1 ether;
+        (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits);
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.InvalidDepositAmount.selector, 0, 1 ether));
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+
+        // Just below the floor (32 ETH - 1 gwei, gwei-aligned), must revert.
+        deposits[0] = _makeDeposit(0, 411);
+        deposits[0].amount = 32 ether - 1 gwei;
+        (bufferId, rootHash, sigs) = _prepareDeposit(deposits);
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InvalidDepositAmount.selector, 0, 32 ether - 1 gwei)
+        );
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+    }
+
     /// @dev Two top-ups for the same pubkey within one batch are Pectra-legal under 0x02
     ///      compounding withdrawal credentials. Both entries must succeed because the
     ///      in-batch duplicate scan only applies to initial deposits — top-ups are exempt.

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -1651,10 +1651,10 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
     }
 
     /// @dev `fetchAndValidateDeposits()` must fail-fast on out-of-range or mis-aligned `amount` rather than
-    ///      deferring to the per-deposit check inside `_depositValidator`. Tests all three
-    ///      branches: below minimum (1 ether), above maximum (2048 ether), and non-gwei-aligned.
+    ///      deferring to the per-deposit check inside `_depositValidator`. Tests three branches:
+    ///      zero (absolute lower bound), above maximum (2048 ether), and non-gwei-aligned.
     function testRevert_validate_invalidDepositAmount() public {
-        // Below minimum (0 wei).
+        // Zero — always invalid (below the 32 ETH minimum).
         IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](1);
         deposits[0] = _makeDeposit(0, 400);
         deposits[0].amount = 0;
@@ -1706,6 +1706,48 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(IAttestationVerifierV1.InvalidDepositAmount.selector, 0, 32 ether - 1 gwei)
         );
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+    }
+
+    /// @dev The 32-ETH floor is the exact passing boundary: a single initial deposit at exactly
+    ///      32 ETH must succeed. This pins the minimum against future drift of MIN_INITIAL_DEPOSIT_AMOUNT.
+    function testDeposit_exactMinimum_32ETH_succeeds() public {
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](1);
+        deposits[0] = _makeDeposit(0, 412); // _makeDeposit already sets amount = 32 ether
+        (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits);
+        vm.prank(keeper);
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs); // must not revert
+    }
+
+    /// @dev When a batch has two initial deposits and the second is below 32 ETH, validation must
+    ///      revert with the correct index (1) and amount. Ensures the loop applies the floor to
+    ///      every element, not just index 0.
+    function testRevert_validate_initialDepositBelowMinimum_atNonZeroIndex() public {
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](2);
+        deposits[0] = _makeDeposit(0, 413); // 32 ETH — valid
+        deposits[1] = _makeDeposit(0, 414);
+        deposits[1].amount = 16 ether; // sub-32 ETH at index 1
+        (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits);
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.InvalidDepositAmount.selector, 1, 16 ether));
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+    }
+
+    /// @dev A batch with a sub-32-ETH initial deposit and a valid top-up must still revert on the
+    ///      initial deposit before the top-up loop runs. Confirms that validation ordering means
+    ///      the top-up never reaches execution when the deposit is invalid.
+    function testRevert_validate_initialDepositBelowMinimum_withTopUp() public {
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](1);
+        deposits[0] = _makeDeposit(0, 415);
+        deposits[0].amount = 16 ether; // sub-32 ETH — invalid initial deposit
+
+        IDepositDataBuffer.TopUp[] memory topUps = new IDepositDataBuffer.TopUp[](1);
+        topUps[0] = _makeTopUpDeposit(0, 416);
+        _seedFundedPubkey(topUps[0].pubkey); // top-up is itself valid
+
+        (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits, topUps);
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.InvalidDepositAmount.selector, 0, 16 ether));
         dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
     }
 
@@ -2364,6 +2406,16 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         (bufferId, rootHash, sigs) = _prepareTopUps(topUps);
         vm.prank(keeper);
         vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.InvalidTopUpAmount.selector, 0, 32 ether + 1));
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+
+        // Above maximum (2048 ether + 1 gwei).
+        topUps[0] = _makeTopUpDeposit(0, 713);
+        topUps[0].amount = 2048 ether + 1 gwei;
+        (bufferId, rootHash, sigs) = _prepareTopUps(topUps);
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InvalidTopUpAmount.selector, 0, 2048 ether + 1 gwei)
+        );
         dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
     }
 


### PR DESCRIPTION
  validate()'s initial-deposit loop accepted any gwei-aligned amount in
  [1, 2048] ETH. A sub-32-ETH initial deposit creates a validator that can
  never activate on the consensus layer, yet the ETH is still counted in
  InFlightDeposit / TotalDepositedETH and so permanently inflates River's
  _assetBalance() (and the LsETH share price). Reported as #441, matching the
  earlier (empty) #309.

  Tighten the initial-deposit lower bound to a new MIN_INITIAL_DEPOSIT_AMOUNT
  (32 ETH) in AttestationVerifierV1.validate(). The 2048 ETH upper bound and
  gwei-alignment are unchanged. Top-ups are intentionally left at >= 1 ETH:
  they credit already-activated validators and may legitimately be smaller.
  validate() is the sole validation entry point, so it is the only layer that
  both knows a deposit is an initial deposit and rejects it before any balance
  inflation; _depositValidator's shared [1, 2048] bound is left as-is.

  Add testRevert_validate_initialDepositBelowMinimum covering 1 ETH and
  32 ETH - 1 gwei (both previously accepted) now reverting with
  InvalidDepositAmount; existing top-up tests confirm sub-32-ETH top-ups
  still pass.

  Closes #441
  Closes #309

## Description

<!-- Please provide a detailed description of your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minimum initial deposit requirement increased from 1 ETH to 32 ETH. Top-up deposits are validated separately and remain exempt from this threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->