### PR TITLE
fix(operators): guard incrementFundedETH against over-length delta ar…

### DIFF
--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -194,6 +194,12 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
         }
 
         uint256 operatorCount = OperatorsV3.getCount();
+        // indices are strictly ascending and bounded by operatorCount, so there can be at
+        // most one delta per operator.
+        if (len > operatorCount) {
+            revert FundedETHArrayLengthExceedsOperatorCount();
+        }
+
         uint256 lastIndex;
         for (uint256 i = 0; i < len; ++i) {
             OperatorFundingDelta calldata delta = _deltas[i];

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -170,7 +170,10 @@ interface IOperatorsRegistryV1 {
     error ExitedETHArrayLengthExceedsOperatorCount();
 
     /// @notice Thrown when the funding-delta array is longer than the operator count, which is
-    ///         impossible for a well-formed input (one delta per operator, strictly ascending)
+    ///         impossible for a well-formed input: operator indices are unique and strictly ascending,
+    ///         so there is at most one delta per operator. The array is sparse — operators with no
+    ///         deposits or top-ups in the batch are omitted — so its length can never exceed the
+    ///         operator count.
     error FundedETHArrayLengthExceedsOperatorCount();
 
     /// @notice Thrown when no exit requests can be performed

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -169,6 +169,10 @@ interface IOperatorsRegistryV1 {
     /// @notice Thrown when the number of exited ETH is too high compared to operator count
     error ExitedETHArrayLengthExceedsOperatorCount();
 
+    /// @notice Thrown when the funding-delta array is longer than the operator count, which is
+    ///         impossible for a well-formed input (one delta per operator, strictly ascending)
+    error FundedETHArrayLengthExceedsOperatorCount();
+
     /// @notice Thrown when no exit requests can be performed
     error NoExitRequestsToPerform();
 

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -1576,6 +1576,25 @@ contract OperatorsRegistryV1FlattenAndAllocationTests is OperatorAllocationTestB
         assertEq(operatorsRegistry.getOperator(9).funded, 0, "op9 untouched");
     }
 
+    /// @notice Asserts incrementFundedETH fails fast with FundedETHArrayLengthExceedsOperatorCount when
+    ///         the delta array is longer than the operator count (issue #411). The guard fires before
+    ///         the per-element loop: with 3 deltas against 2 operators it reverts on length, not on the
+    ///         out-of-range index 2 (which would otherwise be the first per-element failure).
+    function testIncrementFundedRevertsArrayLengthExceedsOperatorCount() external {
+        _setupOperators(2, 10);
+
+        IOperatorsRegistryV1.OperatorFundingDelta[] memory deltas = new IOperatorsRegistryV1.OperatorFundingDelta[](3);
+        for (uint256 i = 0; i < 3; i++) {
+            deltas[i].operatorIndex = i; // strictly ascending, so only the length is malformed
+            deltas[i].fundedETH = 32 ether;
+            deltas[i].depositPubkeys = new bytes[](1);
+            deltas[i].depositAmounts = new uint256[](1);
+        }
+        vm.prank(river);
+        vm.expectRevert(IOperatorsRegistryV1.FundedETHArrayLengthExceedsOperatorCount.selector);
+        operatorsRegistry.incrementFundedETH(deltas);
+    }
+
     /// @notice Asserts incrementFundedETH reverts InvalidOperatorIndex when a delta references an
     ///         operator beyond the registered range.
     function testIncrementFundedRevertsInvalidOperatorIndex() external {


### PR DESCRIPTION
…ray (#411)

  incrementFundedETH validated each delta's operatorIndex but had no upfront
  check on the array length itself. A malformed input longer than the operator
  count would still revert (via InvalidOperatorIndex or
  OperatorIndicesUnsortedOrDuplicate, since indices are bounded and strictly
  ascending), but only after allocating and looping — wasting gas and giving a
  less obvious error.

  Add a fail-fast guard `if (len > operatorCount) revert
  FundedETHArrayLengthExceedsOperatorCount()` at the top of incrementFundedETH,
  mirroring the equivalent length guards already in reportCLETH and
  _setExitedETH. Add the matching error to IOperatorsRegistryV1, named in
  parallel with ExitedETHArrayLengthExceedsOperatorCount.

  Add testIncrementFundedRevertsArrayLengthExceedsOperatorCount: 3 deltas
  against 2 operators, with strictly-ascending indices so the new guard reverts
  on length before the per-element InvalidOperatorIndex would fire — proving the
  fail-fast ordering.

  Closes #411

## Description

<!-- Please provide a detailed description of your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation to ensure funding delta arrays do not exceed the registered operator count, preventing invalid operations and improving system robustness.
  * Enhanced error handling with specific error messages for validation failures.

* **Tests**
  * Added test cases to verify proper validation and error handling in operator funding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->