### PR TITLE
  docs(operators): document post-migration activeCLETH=0 exit deadloc…

### DIFF
--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -73,7 +73,7 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
                     // allocation reverts with ExitsRequestedExceedAvailableFundedAmount — even though
                     // CurrentETHExitsDemand / TotalETHExitsRequested are carried over non-zero from V2.
                     // A fresh oracle report MUST land immediately after initOperatorsRegistryV1_2, with
-                    // the redemption queue paused to cover the gap. See issue #443.
+                    // the redemption queue paused to cover the gap.
                     activeCLETH: 0
                 })
             );

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -67,7 +67,14 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
                     active: operatorV2.active,
                     name: operatorV2.name,
                     operator: operatorV2.operator,
-                    activeCLETH: 0 // This is ok to set 0 here because it will be updated via the oracle report before it gets used
+                    // activeCLETH starts at 0 and is only populated by the first post-upgrade oracle
+                    // report (OracleManager._reportCLETH). UNTIL that report lands, requestETHExits caps
+                    // each operator's allocation by activeCLETH, so `available == 0` and any non-zero exit
+                    // allocation reverts with ExitsRequestedExceedAvailableFundedAmount — even though
+                    // CurrentETHExitsDemand / TotalETHExitsRequested are carried over non-zero from V2.
+                    // A fresh oracle report MUST land immediately after initOperatorsRegistryV1_2, with
+                    // the redemption queue paused to cover the gap. See issue #443.
+                    activeCLETH: 0
                 })
             );
         }

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -283,7 +283,7 @@ interface IOperatorsRegistryV1 {
     ///         report — even though `CurrentETHExitsDemand` / `TotalETHExitsRequested` are already
     ///         non-zero (carried over from V2). OPERATIONAL REQUIREMENT: a fresh oracle report MUST
     ///         land immediately after this call, and the redemption queue MUST be paused over the
-    ///         gap. See issue #443.
+    ///         gap.
     /// @param _withdrawAddress The address of the Withdrawal contract
     function initOperatorsRegistryV1_2(address _withdrawAddress) external;
 

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -279,7 +279,7 @@ interface IOperatorsRegistryV1 {
     /// @notice Migrates operators from V2 to V3 storage, dropping key-management fields
     /// @dev    Migrated operators start with `activeCLETH == 0`, which is only populated by the first
     ///         post-upgrade oracle report. Since `requestETHExits` caps each operator's allocation by
-    ///         `activeCLETH`, NO validator exits can be requested between this call and that first
+    ///         `activeCLETH`, no validator exits can be requested between this call and that first
     ///         report — even though `CurrentETHExitsDemand` / `TotalETHExitsRequested` are already
     ///         non-zero (carried over from V2). OPERATIONAL REQUIREMENT: a fresh oracle report MUST
     ///         land immediately after this call, and the redemption queue MUST be paused over the

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -277,6 +277,13 @@ interface IOperatorsRegistryV1 {
     // function initOperatorsRegistryV1_1() external;
 
     /// @notice Migrates operators from V2 to V3 storage, dropping key-management fields
+    /// @dev    Migrated operators start with `activeCLETH == 0`, which is only populated by the first
+    ///         post-upgrade oracle report. Since `requestETHExits` caps each operator's allocation by
+    ///         `activeCLETH`, NO validator exits can be requested between this call and that first
+    ///         report — even though `CurrentETHExitsDemand` / `TotalETHExitsRequested` are already
+    ///         non-zero (carried over from V2). OPERATIONAL REQUIREMENT: a fresh oracle report MUST
+    ///         land immediately after this call, and the redemption queue MUST be paused over the
+    ///         gap. See issue #443.
     /// @param _withdrawAddress The address of the Withdrawal contract
     function initOperatorsRegistryV1_2(address _withdrawAddress) external;
 


### PR DESCRIPTION
…k (#443)

  _migrateOperators_V2_3 initializes migrated operators with activeCLETH = 0,
  which is only populated by the first post-upgrade oracle report. Because
  requestETHExits caps each operator's allocation by activeCLETH, no validator
  exits can be requested between initOperatorsRegistryV1_2 and that first report —
  even though CurrentETHExitsDemand / TotalETHExitsRequested are carried over
  non-zero from V2.

  Per the agreed remediation (#443, option 3) this is handled operationally rather
  than in code, so document the constraint where future readers will see it:

  - Expand the activeCLETH:0 inline comment (which previously understated the assumption) to spell out the deadlock and the required deploy sequencing.
  - Add a @dev warning to the IOperatorsRegistryV1.initOperatorsRegistryV1_2 NatSpec: a fresh oracle report MUST land immediately after the initializer, with the redemption queue paused over the gap.

  Docs-only; no behavioural or storage change. The runbook step (pause queue ->
  init -> land report -> unpause) lives in the upgrade runbook.

  Closes #443

## Description

<!-- Please provide a detailed description of your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->