### PR TITLE
 fix(attestation): validate genesisForkVersion + add deposit-domain r…

### DIFF
--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -166,9 +166,11 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         DepositDataBufferAddress.set(_depositDataBuffer);
         emit SetDepositDataBuffer(_depositDataBuffer);
 
-        bytes32 depositDomain = BLS12_381.computeDepositDomain(_genesisForkVersion);
-        DepositDomainValue.set(depositDomain);
-        emit SetDepositDomain(depositDomain);
+        // Validate + store the BLS deposit domain. On a known chain (mainnet/hoodi) the supplied fork
+        // version must match the canonical value, so a misconfigured domain — which would silently
+        // brick the attestation deposit path — reverts at deploy. On unknown chains (e.g. local/test)
+        // the value is accepted as-is. Shared with the admin recovery setter. See #498.
+        _setDepositDomainFromForkVersion(_genesisForkVersion);
 
         for (uint256 i = 0; i < _rootAttesters.length; i++) {
             if (!RootAttesters.isRootAttester(_rootAttesters[i])) {
@@ -232,6 +234,37 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     function setDepositDataBuffer(address _depositDataBuffer) external onlyRiverAdmin {
         DepositDataBufferAddress.set(_depositDataBuffer);
         emit SetDepositDataBuffer(_depositDataBuffer);
+    }
+
+    /// @inheritdoc IAttestationVerifierV1
+    function setDepositDomainFromForkVersion(bytes4 genesisForkVersion) external onlyRiverAdmin {
+        _setDepositDomainFromForkVersion(genesisForkVersion);
+    }
+
+    /// @notice The canonical beacon-chain GENESIS_FORK_VERSION for the chain this contract runs on.
+    /// @dev Only mainnet and hoodi are known. On any other chain `known` is false and the supplied
+    ///      fork version is accepted as-is (no canonical value to validate against).
+    /// @return known True if the current chain has a known fork version
+    /// @return expected The expected GENESIS_FORK_VERSION for the current chain (zero if unknown)
+    function _expectedForkVersion() internal view returns (bool known, bytes4 expected) {
+        if (block.chainid == 1) return (true, 0x00000000); // mainnet
+        if (block.chainid == 560048) return (true, 0x10000910); // hoodi
+        return (false, bytes4(0));
+    }
+
+    /// @notice Validate `genesisForkVersion` against the chain's canonical value (where known),
+    ///         compute the BLS deposit domain from it, and store it. On unknown chains the value is
+    ///         accepted as-is. Shared by `initAttestationVerifierV1` and the admin recovery setter.
+    /// @dev Reverts `InvalidGenesisForkVersion` only on a known chain (mainnet/hoodi) when the value
+    ///      does not match; on any other chain it passes through.
+    function _setDepositDomainFromForkVersion(bytes4 genesisForkVersion) internal {
+        (bool known, bytes4 expected) = _expectedForkVersion();
+        if (known && genesisForkVersion != expected) {
+            revert InvalidGenesisForkVersion(genesisForkVersion);
+        }
+        bytes32 depositDomain = BLS12_381.computeDepositDomain(genesisForkVersion);
+        DepositDomainValue.set(depositDomain);
+        emit SetDepositDomain(depositDomain);
     }
 
     /// @inheritdoc IAttestationVerifierV1

--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -169,7 +169,7 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         // Validate + store the BLS deposit domain. On a known chain (mainnet/hoodi) the supplied fork
         // version must match the canonical value, so a misconfigured domain — which would silently
         // brick the attestation deposit path — reverts at deploy. On unknown chains (e.g. local/test)
-        // the value is accepted as-is. Shared with the admin recovery setter. See #498.
+        // the value is accepted as-is. Shared with the admin recovery setter.
         _setDepositDomainFromForkVersion(_genesisForkVersion);
 
         for (uint256 i = 0; i < _rootAttesters.length; i++) {

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -186,6 +186,10 @@ interface IAttestationVerifierV1 {
     /// @param max The MAX_SIGNATURES bound
     error QuorumExceedsMaxSignatures(uint256 quorum, uint256 max);
 
+    /// @notice The provided genesis fork version does not match the expected value for this chain.
+    /// @param provided The supplied genesis fork version
+    error InvalidGenesisForkVersion(bytes4 provided);
+
     /// @notice Adding a root attester would exceed MAX_ROOT_ATTESTERS
     /// @param count The would-be root attester count
     /// @param max The MAX_ROOT_ATTESTERS bound
@@ -398,6 +402,16 @@ interface IAttestationVerifierV1 {
     /// @notice Update the DepositDataBuffer address. Only callable by River's admin.
     /// @param _depositDataBuffer The new buffer address
     function setDepositDataBuffer(address _depositDataBuffer) external;
+
+    /// @notice Recompute and store the BLS deposit domain from a genesis fork version. Admin recovery
+    ///         path for a misconfigured deposit domain (e.g. a wrong fork version at init), which would
+    ///         otherwise brick the attestation deposit path until a full redeploy. Only callable by
+    ///         River's admin.
+    /// @dev On a known chain (mainnet or hoodi) reverts `InvalidGenesisForkVersion` unless
+    ///      `genesisForkVersion` exactly matches that chain's canonical value; on any other chain the
+    ///      value is accepted as-is (no canonical value to validate against). Same validation as init.
+    /// @param genesisForkVersion The beacon-chain GENESIS_FORK_VERSION for the current chain
+    function setDepositDomainFromForkVersion(bytes4 genesisForkVersion) external;
 
     /// @notice Add or remove a consolidation-committee attester. Only callable by River's admin.
     /// @param consolidationCommitteeAttester The consolidation-committee attester address to update

--- a/contracts/test/accounting/AccountingInvariants.sol
+++ b/contracts/test/accounting/AccountingInvariants.sol
@@ -229,9 +229,7 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
         uint256 inFlight = river.getInFlightDeposit();
         uint256 activated = river.getLastConsensusLayerReport().totalDepositedActivatedETH;
         uint256 totalDeposited = river.getTotalDepositedETH();
-        assertEq(
-            inFlight + activated, totalDeposited, "I7: InFlightDeposit + activatedETH != TotalDepositedETH"
-        );
+        assertEq(inFlight + activated, totalDeposited, "I7: InFlightDeposit + activatedETH != TotalDepositedETH");
     }
 
     /// @notice I8: Per-operator requestedExits >= exited (both fields in ETH/wei, not exit counts).

--- a/contracts/test/accounting/scenarios/ExitDemand.t.sol
+++ b/contracts/test/accounting/scenarios/ExitDemand.t.sol
@@ -63,8 +63,7 @@ contract ExitDemandTest is AccountingInvariants {
 
         sim_oracleReport();
         uint256 demandAfterSecond = operatorsRegistry.getCurrentETHExitsDemand();
-        (uint256 totalExitedETH, uint256 totalRequestedETHExits) =
-            operatorsRegistry.getExitedAndRequestedETHExits();
+        (uint256 totalExitedETH, uint256 totalRequestedETHExits) = operatorsRegistry.getExitedAndRequestedETHExits();
 
         assertGt(totalRequestedETHExits, totalExitedETH, "preExitingBalance should be non-zero");
         assertEq(demandAfterSecond, demandAfterRequest, "preExiting should prevent new demand");

--- a/contracts/test/components/SetDepositDomainFromForkVersion.t.sol
+++ b/contracts/test/components/SetDepositDomainFromForkVersion.t.sol
@@ -149,12 +149,19 @@ contract SetDepositDomainFromForkVersionTest is Test {
         assertEq(fresh.DEPOSIT_DOMAIN(), BLS12_381.computeDepositDomain(MAINNET_FORK_VERSION), "mainnet init domain");
     }
 
-    /// @dev init passes through on an unknown chain (the setUp verifier was init'd on 31337 with
-    ///      bytes4(0)); assert it stored that value rather than reverting.
+    /// @dev init passes through on an unknown chain: a fresh verifier on a not-mainnet/not-hoodi
+    ///      chain accepts an arbitrary (non-canonical) fork version and stores its domain rather than
+    ///      reverting. Self-contained — does not rely on setUp's chain/init state.
     function testInit_acceptsAnyForkVersion_unknownChain() public {
+        vm.chainId(11155111); // sepolia — not in the known table
+        bytes4 arbitrary = 0x12345678;
+        AttestationVerifierV1 fresh = _freshVerifier();
+
+        _init(fresh, arbitrary);
+
         assertEq(
-            verifier.DEPOSIT_DOMAIN(),
-            BLS12_381.computeDepositDomain(bytes4(0)),
+            fresh.DEPOSIT_DOMAIN(),
+            BLS12_381.computeDepositDomain(arbitrary),
             "unknown-chain init should store the supplied value"
         );
     }

--- a/contracts/test/components/SetDepositDomainFromForkVersion.t.sol
+++ b/contracts/test/components/SetDepositDomainFromForkVersion.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "forge-std/Test.sol";
+
+import "../../src/AttestationVerifier.1.sol";
+import "../../src/interfaces/IAttestationVerifier.1.sol";
+import "../../src/libraries/BLS12_381.sol";
+import "../../src/libraries/LibErrors.sol";
+import "../utils/LibImplementationUnbricker.sol";
+
+contract SetDepositDomainFromForkVersionTest is Test {
+    AttestationVerifierV1 internal verifier;
+
+    address internal admin = makeAddr("admin");
+    address internal river = makeAddr("river");
+
+    // Beacon-chain GENESIS_FORK_VERSION constants. Mainnet is the value that ships;
+    // hoodi is the supported staking testnet. Both confirmed against the beacon /eth/v1/beacon/genesis
+    // endpoints. Sepolia is intentionally NOT supported here (app/EVM testnet, not used for staking).
+    bytes4 internal constant MAINNET_FORK_VERSION = 0x00000000;
+    bytes4 internal constant HOODI_FORK_VERSION = 0x10000910;
+
+    function setUp() public {
+        verifier = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(verifier));
+
+        // onlyRiverAdmin resolves via IAdministrable(RiverAddress.get()).getAdmin()
+        vm.mockCall(river, abi.encodeWithSignature("getAdmin()"), abi.encode(admin));
+
+        address[] memory rootAttesters = new address[](1);
+        rootAttesters[0] = makeAddr("rootAttester");
+        address[] memory consolidationAttesters = new address[](1);
+        consolidationAttesters[0] = makeAddr("consolidationAttester");
+
+        // init with bytes4(0) — accepted here because the default Foundry chain (31337) is unknown,
+        // so init is permissive; the strict admin setter below is what enforces correctness.
+        verifier.initAttestationVerifierV1(
+            river, makeAddr("buffer"), rootAttesters, 1, bytes4(0), consolidationAttesters, 1
+        );
+    }
+
+    /// @dev Happy path on mainnet — the value that ships.
+    function testSetDepositDomain_mainnet() public {
+        vm.chainId(1);
+        bytes32 expected = BLS12_381.computeDepositDomain(MAINNET_FORK_VERSION);
+
+        vm.prank(admin);
+        verifier.setDepositDomainFromForkVersion(MAINNET_FORK_VERSION);
+
+        assertEq(verifier.DEPOSIT_DOMAIN(), expected, "domain not set to mainnet value");
+    }
+
+    /// @dev Hoodi is also accepted.
+    function testSetDepositDomain_hoodi() public {
+        vm.chainId(560048);
+        bytes32 expected = BLS12_381.computeDepositDomain(HOODI_FORK_VERSION);
+
+        vm.prank(admin);
+        verifier.setDepositDomainFromForkVersion(HOODI_FORK_VERSION);
+
+        assertEq(verifier.DEPOSIT_DOMAIN(), expected, "domain not set to hoodi value");
+    }
+
+    /// @dev Wrong value for the chain reverts. Note bytes4(0) is mainnet's *valid* value, so the
+    ///      all-zero foot-gun is exercised on hoodi (where the expected value is non-zero); a
+    ///      non-zero wrong value (hoodi's, incl. its reversed-byte cousins) is exercised on mainnet.
+    function testRevert_wrongForkVersionForChain() public {
+        // On mainnet, a non-zero wrong value reverts (bytes4(0) is mainnet's correct value).
+        vm.chainId(1);
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InvalidGenesisForkVersion.selector, HOODI_FORK_VERSION)
+        );
+        verifier.setDepositDomainFromForkVersion(HOODI_FORK_VERSION); // hoodi's value, wrong on mainnet
+
+        // On hoodi, the all-zero value reverts (hoodi's expected value is non-zero).
+        vm.chainId(560048);
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.InvalidGenesisForkVersion.selector, bytes4(0)));
+        verifier.setDepositDomainFromForkVersion(bytes4(0));
+    }
+
+    /// @dev On an unknown chain there is no canonical value to validate against, so any fork version
+    ///      is accepted as-is (same pass-through behaviour as init).
+    function testSetDepositDomain_unknownChainAccepts() public {
+        vm.chainId(11155111); // sepolia — not in the known table
+        bytes4 arbitrary = 0x12345678;
+        bytes32 expected = BLS12_381.computeDepositDomain(arbitrary);
+
+        vm.prank(admin);
+        verifier.setDepositDomainFromForkVersion(arbitrary);
+
+        assertEq(verifier.DEPOSIT_DOMAIN(), expected, "unknown chain should accept the supplied value");
+    }
+
+    /// @dev Only River's admin may call.
+    function testRevert_notAdmin() public {
+        vm.chainId(1);
+        address stranger = makeAddr("stranger");
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(LibErrors.Unauthorized.selector, stranger));
+        verifier.setDepositDomainFromForkVersion(MAINNET_FORK_VERSION);
+    }
+
+    // -----------------------------------------------------------------------
+    // initAttestationVerifierV1 path — the deploy-time M-03 prevention. These exercise the same
+    // shared validation reached through init (not just the recovery setter), so a future refactor
+    // that stopped routing init through the check would fail here.
+    // -----------------------------------------------------------------------
+
+    /// @dev Deploy a fresh, uninitialized verifier (the setUp one is already init'd; init is one-shot).
+    function _freshVerifier() internal returns (AttestationVerifierV1 fresh) {
+        fresh = new AttestationVerifierV1();
+        LibImplementationUnbricker.unbrick(vm, address(fresh));
+    }
+
+    function _init(AttestationVerifierV1 v, bytes4 forkVersion) internal {
+        address[] memory rootAttesters = new address[](1);
+        rootAttesters[0] = makeAddr("rootAttester");
+        address[] memory consolidationAttesters = new address[](1);
+        consolidationAttesters[0] = makeAddr("consolidationAttester");
+        v.initAttestationVerifierV1(river, makeAddr("buffer"), rootAttesters, 1, forkVersion, consolidationAttesters, 1);
+    }
+
+    /// @dev init reverts at deploy on a known chain when the fork version is wrong — the core M-03 fix.
+    function testInit_revertsOnWrongForkVersion_knownChain() public {
+        vm.chainId(1); // mainnet — canonical is 0x00000000
+        AttestationVerifierV1 fresh = _freshVerifier();
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InvalidGenesisForkVersion.selector, HOODI_FORK_VERSION)
+        );
+        _init(fresh, HOODI_FORK_VERSION); // non-zero wrong value on mainnet
+    }
+
+    /// @dev init reverts on hoodi for the all-zero foot-gun (hoodi's canonical value is non-zero).
+    function testInit_revertsOnZeroForkVersion_hoodi() public {
+        vm.chainId(560048); // hoodi — canonical is 0x10000910
+        AttestationVerifierV1 fresh = _freshVerifier();
+        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.InvalidGenesisForkVersion.selector, bytes4(0)));
+        _init(fresh, bytes4(0));
+    }
+
+    /// @dev init stores the correct domain when given the canonical value on a known chain.
+    function testInit_acceptsCanonicalForkVersion_mainnet() public {
+        vm.chainId(1);
+        AttestationVerifierV1 fresh = _freshVerifier();
+        _init(fresh, MAINNET_FORK_VERSION);
+        assertEq(fresh.DEPOSIT_DOMAIN(), BLS12_381.computeDepositDomain(MAINNET_FORK_VERSION), "mainnet init domain");
+    }
+
+    /// @dev init passes through on an unknown chain (the setUp verifier was init'd on 31337 with
+    ///      bytes4(0)); assert it stored that value rather than reverting.
+    function testInit_acceptsAnyForkVersion_unknownChain() public {
+        assertEq(
+            verifier.DEPOSIT_DOMAIN(),
+            BLS12_381.computeDepositDomain(bytes4(0)),
+            "unknown-chain init should store the supplied value"
+        );
+    }
+}

--- a/contracts/test/components/SetDepositDomainFromForkVersion.t.sol
+++ b/contracts/test/components/SetDepositDomainFromForkVersion.t.sol
@@ -104,7 +104,7 @@ contract SetDepositDomainFromForkVersionTest is Test {
     }
 
     // -----------------------------------------------------------------------
-    // initAttestationVerifierV1 path — the deploy-time M-03 prevention. These exercise the same
+    // initAttestationVerifierV1 path — the deploy-time prevention. These exercise the same
     // shared validation reached through init (not just the recovery setter), so a future refactor
     // that stopped routing init through the check would fail here.
     // -----------------------------------------------------------------------

--- a/contracts/test/components/SetDepositDomainFromForkVersion.t.sol
+++ b/contracts/test/components/SetDepositDomainFromForkVersion.t.sol
@@ -123,7 +123,7 @@ contract SetDepositDomainFromForkVersionTest is Test {
         v.initAttestationVerifierV1(river, makeAddr("buffer"), rootAttesters, 1, forkVersion, consolidationAttesters, 1);
     }
 
-    /// @dev init reverts at deploy on a known chain when the fork version is wrong — the core M-03 fix.
+    /// @dev init reverts at deploy on a known chain when the fork version is wrong.
     function testInit_revertsOnWrongForkVersion_knownChain() public {
         vm.chainId(1); // mainnet — canonical is 0x00000000
         AttestationVerifierV1 fresh = _freshVerifier();


### PR DESCRIPTION
…ecovery setter (#498)

  initAttestationVerifierV1 computed the BLS deposit domain from an unvalidated
  _genesisForkVersion. Because computeDepositDomain ORs in DOMAIN_DEPOSIT_TYPE, even
  bytes4(0) yields a non-zero domain, so the existing ZeroDepositDomain guard never
  catches a wrong fork version — a typo silently bricks the attestation deposit path
  until a full redeploy (ToB M-03).

  - Validate _genesisForkVersion against the chain's canonical GENESIS_FORK_VERSION where known (mainnet 0x00000000, hoodi 0x10000910); revert InvalidGenesisForkVersion on mismatch. Unknown chains (local/test/future) pass through as-is.
  - Add admin setDepositDomainFromForkVersion(bytes4) recovery path sharing the exact same validation, so a misconfigured domain is fixable without a redeploy.
  - Tests: mainnet/hoodi happy paths, wrong-value-for-chain, unknown-chain pass-through, admin-only.

  Fork versions confirmed against beacon /eth/v1/beacon/genesis for mainnet and hoodi.

    Closes #498

## Description

This pull request improves the safety and flexibility of the deposit domain configuration in the `AttestationVerifierV1` contract. It introduces stricter validation of the beacon-chain `GENESIS_FORK_VERSION` on known chains (mainnet and hoodi), preventing misconfiguration at deployment or during admin recovery. The changes also add a new admin-only recovery function and comprehensive tests to ensure correct behavior across different network environments.

**Deposit domain validation and recovery:**

* Replaces direct storage of the deposit domain in `AttestationVerifierV1` with a new internal `_setDepositDomainFromForkVersion` method, which validates the supplied fork version against known values for mainnet and hoodi, reverting if mismatched. On unknown chains, any value is accepted. This logic is used both at initialization and in the new admin setter.
* Adds a new public admin-only method `setDepositDomainFromForkVersion` to allow recovery from a misconfigured deposit domain without redeploying the contract.
* Introduces the `InvalidGenesisForkVersion` custom error, emitted when an incorrect fork version is supplied on a known chain.
* Updates the `IAttestationVerifierV1` interface to include the new admin setter and custom error, with detailed documentation of its behavior.

**Testing:**

* Adds a comprehensive Foundry test suite (`SetDepositDomainFromForkVersion.t.sol`) covering correct domain setting on mainnet and hoodi, rejection of invalid values, permissive behavior on unknown chains, admin access control, and validation at both initialization and via the new admin recovery path.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new admin function to update BLS deposit domain configuration from genesis fork version
  * Introduced validation for genesis fork version with chain-specific behavior

* **Tests**
  * Added comprehensive test coverage for deposit domain configuration updates and chain-specific validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->