### PR TITLE
  fix(coverage): check allowlist before mutating balance in donate() …

### DIFF
--- a/contracts/src/ConsolidationCoverageFund.1.sol
+++ b/contracts/src/ConsolidationCoverageFund.1.sol
@@ -48,10 +48,14 @@ contract ConsolidationCoverageFundV1 is Initializable, IConsolidationCoverageFun
         if (msg.value == 0) {
             revert EmptyDonation();
         }
-        BalanceForConsolidationCoverage.set(BalanceForConsolidationCoverage.get() + msg.value);
 
+        // Checks before effects: run the allowlist check before mutating state so an unauthorized
+        // call reverts before touching storage (cheaper fail-fast, and no state is ever written ahead
+        // of access control should an interaction be inserted here in future).
         IAllowlistV1 allowlist = IAllowlistV1(IRiverV1(payable(RiverAddress.get())).getAllowlist());
         allowlist.onlyAllowed(msg.sender, LibAllowlistMasks.DONATE_CONSOLIDATION_MASK);
+
+        BalanceForConsolidationCoverage.set(BalanceForConsolidationCoverage.get() + msg.value);
 
         emit Donate(msg.sender, msg.value);
     }

--- a/contracts/src/ConsolidationCoverageFund.1.sol
+++ b/contracts/src/ConsolidationCoverageFund.1.sol
@@ -49,9 +49,6 @@ contract ConsolidationCoverageFundV1 is Initializable, IConsolidationCoverageFun
             revert EmptyDonation();
         }
 
-        // Checks before effects: run the allowlist check before mutating BalanceForConsolidationCoverage so an
-        // unauthorized call fails before the balance SLOAD/SSTORE (cheaper fail-fast, and prevents
-        // state being written ahead of access control if an interaction is inserted here in future).
         IAllowlistV1 allowlist = IAllowlistV1(IRiverV1(payable(RiverAddress.get())).getAllowlist());
         allowlist.onlyAllowed(msg.sender, LibAllowlistMasks.DONATE_CONSOLIDATION_MASK);
 

--- a/contracts/src/ConsolidationCoverageFund.1.sol
+++ b/contracts/src/ConsolidationCoverageFund.1.sol
@@ -49,9 +49,9 @@ contract ConsolidationCoverageFundV1 is Initializable, IConsolidationCoverageFun
             revert EmptyDonation();
         }
 
-        // Checks before effects: run the allowlist check before mutating state so an unauthorized
-        // call reverts before touching storage (cheaper fail-fast, and no state is ever written ahead
-        // of access control should an interaction be inserted here in future).
+        // Checks before effects: run the allowlist check before mutating BalanceForConsolidationCoverage so an
+        // unauthorized call fails before the balance SLOAD/SSTORE (cheaper fail-fast, and prevents
+        // state being written ahead of access control if an interaction is inserted here in future).
         IAllowlistV1 allowlist = IAllowlistV1(IRiverV1(payable(RiverAddress.get())).getAllowlist());
         allowlist.onlyAllowed(msg.sender, LibAllowlistMasks.DONATE_CONSOLIDATION_MASK);
 

--- a/contracts/src/CoverageFund.1.sol
+++ b/contracts/src/CoverageFund.1.sol
@@ -56,9 +56,9 @@ contract CoverageFundV1 is Initializable, ICoverageFundV1, IProtocolVersion {
             revert EmptyDonation();
         }
 
-        // Checks before effects: run the allowlist check before mutating state so an unauthorized
-        // call reverts before touching storage (cheaper fail-fast, and no state is ever written ahead
-        // of access control should an interaction be inserted here in future).
+        // Checks before effects: run the allowlist check before mutating BalanceForCoverage so an
+        // unauthorized call fails before the balance SLOAD/SSTORE (cheaper fail-fast, and prevents
+        // state being written ahead of access control if an interaction is inserted here in future).
         IAllowlistV1 allowlist = IAllowlistV1(IRiverV1(payable(RiverAddress.get())).getAllowlist());
         allowlist.onlyAllowed(msg.sender, LibAllowlistMasks.DONATE_MASK);
 

--- a/contracts/src/CoverageFund.1.sol
+++ b/contracts/src/CoverageFund.1.sol
@@ -56,9 +56,6 @@ contract CoverageFundV1 is Initializable, ICoverageFundV1, IProtocolVersion {
             revert EmptyDonation();
         }
 
-        // Checks before effects: run the allowlist check before mutating BalanceForCoverage so an
-        // unauthorized call fails before the balance SLOAD/SSTORE (cheaper fail-fast, and prevents
-        // state being written ahead of access control if an interaction is inserted here in future).
         IAllowlistV1 allowlist = IAllowlistV1(IRiverV1(payable(RiverAddress.get())).getAllowlist());
         allowlist.onlyAllowed(msg.sender, LibAllowlistMasks.DONATE_MASK);
 

--- a/contracts/src/CoverageFund.1.sol
+++ b/contracts/src/CoverageFund.1.sol
@@ -55,10 +55,14 @@ contract CoverageFundV1 is Initializable, ICoverageFundV1, IProtocolVersion {
         if (msg.value == 0) {
             revert EmptyDonation();
         }
-        BalanceForCoverage.set(BalanceForCoverage.get() + msg.value);
 
+        // Checks before effects: run the allowlist check before mutating state so an unauthorized
+        // call reverts before touching storage (cheaper fail-fast, and no state is ever written ahead
+        // of access control should an interaction be inserted here in future).
         IAllowlistV1 allowlist = IAllowlistV1(IRiverV1(payable(RiverAddress.get())).getAllowlist());
         allowlist.onlyAllowed(msg.sender, LibAllowlistMasks.DONATE_MASK);
+
+        BalanceForCoverage.set(BalanceForCoverage.get() + msg.value);
 
         emit Donate(msg.sender, msg.value);
     }

--- a/contracts/test/ConsolidationCoverageFund.1.t.sol
+++ b/contracts/test/ConsolidationCoverageFund.1.t.sol
@@ -176,6 +176,77 @@ contract ConsolidationCoverageFundTestV1 is ConsolidationCoverageFundV1TestBase 
         vm.stopPrank();
     }
 
+    // ---- CEI-ordering regression guards --------------------------------------------------------
+    // donate() runs the allowlist check before writing BalanceForConsolidationCoverage. These assert
+    // that a donate() rejected by access control never mutates the stored balance — the guarantee that
+    // would break if the state write were ever (re)ordered ahead of the check, or the check were made
+    // non-reverting. We seed a prior authorized donation so "unchanged" is a non-trivial value.
+
+    bytes32 internal constant BALANCE_FOR_CONSOLIDATION_COVERAGE_SLOT =
+        bytes32(uint256(keccak256("river.state.balanceForConsolidationCoverage")) - 1);
+
+    function _storedConsolidationBalance() internal view returns (uint256) {
+        return uint256(vm.load(address(consolidationCoverageFund), BALANCE_FOR_CONSOLIDATION_COVERAGE_SLOT));
+    }
+
+    function _allow(address _account, uint256 _mask) internal {
+        address[] memory accounts = new address[](1);
+        accounts[0] = _account;
+        uint256[] memory permissions = new uint256[](1);
+        permissions[0] = _mask;
+        vm.prank(admin);
+        allowlist.setAllowPermissions(accounts, permissions);
+    }
+
+    function _deny(address _account) internal {
+        address[] memory accounts = new address[](1);
+        accounts[0] = _account;
+        uint256[] memory permissions = new uint256[](1);
+        permissions[0] = LibAllowlistMasks.DENY_MASK;
+        vm.prank(admin);
+        allowlist.setDenyPermissions(accounts, permissions);
+    }
+
+    function testDonateRejectedDoesNotMutateBalance(uint256 _seedSalt, uint256 _amount) external {
+        _amount = bound(_amount, 1, 1e24);
+
+        // Seed a prior authorized donation so the stored balance is non-zero.
+        address donor = uf._new(_seedSalt);
+        vm.deal(donor, _amount);
+        _allow(donor, LibAllowlistMasks.DONATE_CONSOLIDATION_MASK);
+        vm.prank(donor);
+        consolidationCoverageFund.donate{value: _amount}();
+        uint256 balanceBefore = _storedConsolidationBalance();
+        assertEq(balanceBefore, _amount, "seed donation should be stored");
+
+        // (a) Unknown caller (no permissions) -> Unauthorized; stored balance untouched.
+        address stranger = makeAddr("stranger");
+        vm.deal(stranger, _amount);
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", stranger));
+        consolidationCoverageFund.donate{value: _amount}();
+        assertEq(_storedConsolidationBalance(), balanceBefore, "unknown-caller revert must not mutate balance");
+
+        // (b) Known but lacks DONATE_CONSOLIDATION_MASK (allowlisted for coverage DONATE only)
+        //     -> Unauthorized; stored balance untouched.
+        address wrongMask = makeAddr("wrongMask");
+        vm.deal(wrongMask, _amount);
+        _allow(wrongMask, LibAllowlistMasks.DONATE_MASK);
+        vm.prank(wrongMask);
+        vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", wrongMask));
+        consolidationCoverageFund.donate{value: _amount}();
+        assertEq(_storedConsolidationBalance(), balanceBefore, "wrong-mask revert must not mutate balance");
+
+        // (c) Denylisted caller -> Denied; stored balance untouched.
+        address denied = makeAddr("denied");
+        vm.deal(denied, _amount);
+        _deny(denied);
+        vm.prank(denied);
+        vm.expectRevert(abi.encodeWithSignature("Denied(address)", denied));
+        consolidationCoverageFund.donate{value: _amount}();
+        assertEq(_storedConsolidationBalance(), balanceBefore, "denylisted revert must not mutate balance");
+    }
+
     function testDonateZero(uint256 _senderSalt) external {
         address sender = uf._new(_senderSalt);
 

--- a/contracts/test/CoverageFund.1.t.sol
+++ b/contracts/test/CoverageFund.1.t.sol
@@ -171,6 +171,76 @@ contract CoverageFundTestV1 is CoverageFundV1TestBase {
         vm.stopPrank();
     }
 
+    // ---- CEI-ordering regression guards --------------------------------------------------------
+    // donate() runs the allowlist check before writing BalanceForCoverage. These assert that a
+    // donate() rejected by access control never mutates the stored coverage balance — the guarantee
+    // that would break if the state write were ever (re)ordered ahead of the check, or the check were
+    // made non-reverting. We seed a prior authorized donation so "unchanged" is a non-trivial value.
+
+    bytes32 internal constant BALANCE_FOR_COVERAGE_SLOT =
+        bytes32(uint256(keccak256("river.state.balanceForCoverage")) - 1);
+
+    function _storedCoverageBalance() internal view returns (uint256) {
+        return uint256(vm.load(address(coverageFund), BALANCE_FOR_COVERAGE_SLOT));
+    }
+
+    function _allow(address _account, uint256 _mask) internal {
+        address[] memory accounts = new address[](1);
+        accounts[0] = _account;
+        uint256[] memory permissions = new uint256[](1);
+        permissions[0] = _mask;
+        vm.prank(admin);
+        allowlist.setAllowPermissions(accounts, permissions);
+    }
+
+    function _deny(address _account) internal {
+        address[] memory accounts = new address[](1);
+        accounts[0] = _account;
+        uint256[] memory permissions = new uint256[](1);
+        permissions[0] = LibAllowlistMasks.DENY_MASK;
+        vm.prank(admin);
+        allowlist.setDenyPermissions(accounts, permissions);
+    }
+
+    function testDonateRejectedDoesNotMutateBalance(uint256 _seedSalt, uint256 _amount) external {
+        _amount = bound(_amount, 1, 1e24);
+
+        // Seed a prior authorized donation so the stored balance is non-zero.
+        address donor = uf._new(_seedSalt);
+        vm.deal(donor, _amount);
+        _allow(donor, LibAllowlistMasks.DONATE_MASK);
+        vm.prank(donor);
+        coverageFund.donate{value: _amount}();
+        uint256 balanceBefore = _storedCoverageBalance();
+        assertEq(balanceBefore, _amount, "seed donation should be stored");
+
+        // (a) Unknown caller (no permissions) -> Unauthorized; stored balance untouched.
+        address stranger = makeAddr("stranger");
+        vm.deal(stranger, _amount);
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", stranger));
+        coverageFund.donate{value: _amount}();
+        assertEq(_storedCoverageBalance(), balanceBefore, "unknown-caller revert must not mutate balance");
+
+        // (b) Known but lacks DONATE_MASK (allowlisted for DEPOSIT only) -> Unauthorized; untouched.
+        address wrongMask = makeAddr("wrongMask");
+        vm.deal(wrongMask, _amount);
+        _allow(wrongMask, LibAllowlistMasks.DEPOSIT_MASK);
+        vm.prank(wrongMask);
+        vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", wrongMask));
+        coverageFund.donate{value: _amount}();
+        assertEq(_storedCoverageBalance(), balanceBefore, "wrong-mask revert must not mutate balance");
+
+        // (c) Denylisted caller -> Denied; stored balance untouched.
+        address denied = makeAddr("denied");
+        vm.deal(denied, _amount);
+        _deny(denied);
+        vm.prank(denied);
+        vm.expectRevert(abi.encodeWithSignature("Denied(address)", denied));
+        coverageFund.donate{value: _amount}();
+        assertEq(_storedCoverageBalance(), balanceBefore, "denylisted revert must not mutate balance");
+    }
+
     function testDonateZero(uint256 _senderSalt) external {
         address sender = uf._new(_senderSalt);
 


### PR DESCRIPTION
…(CEI)

  Both CoverageFundV1.donate() and ConsolidationCoverageFundV1.donate() wrote
  BalanceForCoverage / BalanceForConsolidationCoverage before running the
  allowlist check. Hoist the onlyAllowed() check above the state write
  (checks-before-effects), keeping the free msg.value == 0 input check first.

  Today the trailing revert rolls back the premature write, so there is no
  exploitable consequence — but the ordering is a latent foot-gun: the moment an
  interaction/hook is inserted between the write and the check, or the check is
  made non-reverting, a state-mutated-before-access-control bug appears. Checks
  first removes that class by construction, fails unauthorized callers before any
  SLOAD/SSTORE, and aligns donate() with every other restricted entry point.

  No storage-layout or interface changes.

  Tests: add testDonateRejectedDoesNotMutateBalance to both suites. It seeds a
  prior authorized donation, then asserts the stored balance (read via vm.load) is
  untouched when donate() is rejected for (a) an unknown caller, (b) a caller
  allowlisted for a different mask (the previously-untested "known but lacks the
  donate mask" branch), and (c) a denylisted caller. This guards the future
  regression the reorder protects against.

  Closes #502

## Description

This pull request improves the security and correctness of the `donate()` functions in both the `CoverageFundV1` and `ConsolidationCoverageFundV1` contracts by ensuring that access control checks are performed before any state mutation occurs. Additionally, it introduces comprehensive regression tests to guarantee that unauthorized or denied donation attempts do not alter the contract's internal balances.

Key changes include:

**Security and Access Control Improvements:**

* Reordered the `donate()` function logic in both `CoverageFundV1` and `ConsolidationCoverageFundV1` to perform the allowlist (access control) check before updating the balance, ensuring that unauthorized calls revert before any state is mutated. This adheres to the Checks-Effects-Interactions (CEI) pattern and prevents unauthorized state changes. [[1]](diffhunk://#diff-73042bddf7304820430d04439dfff83e5ae33d39982628238d855c0598d3c20aL58-R66) [[2]](diffhunk://#diff-f9671944967e8b63a10bb506e8229791a4924c928ba0dec59cae9494e62ba95dL51-R59)

**Testing and Regression Guards:**

* Added new regression tests to both `CoverageFundTestV1` and `ConsolidationCoverageFundTestV1` that assert the contract balance remains unchanged if a `donate()` call is rejected by access control (either due to lack of permissions or explicit denial). These tests cover various scenarios, including unknown callers, callers with incorrect permissions, and denylisted addresses. [[1]](diffhunk://#diff-427f142c0a74429278a3803b6a034118e3e225045b190f835bb7620a097c8980R174-R243) [[2]](diffhunk://#diff-a8323987c45510d752ea668e3eab18dea2ed9456274fb391d3af4a4bcaa33c18R179-R249)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization checks in donation operations now execute before state modifications, preventing unauthorized requests from altering contract balances.

* **Tests**
  * Regression tests added to verify that rejected donations—whether from unauthorized, allowlisted, or denied callers—do not mutate contract state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->