### PR TITLE
Adds in a reentrancyguard 

### DIFF
--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -11,6 +11,8 @@ import "./libraries/LibUint256.sol";
 import "./Initializable.sol";
 import "./Administrable.sol";
 
+import "openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
+
 import "./state/operatorsRegistry/Operators.2.sol";
 import "./state/operatorsRegistry/Operators.3.sol";
 import "./state/operatorsRegistry/ValidatorKeys.sol";
@@ -27,7 +29,7 @@ import "./state/shared/RiverAddress.sol";
 /// @dev Operator index is the position in the operators array. Operators are only
 /// @dev added, never removed, so the operator at index i is always the one at
 /// @dev array position i and indices are stable over time.
-contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrable, IProtocolVersion {
+contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrable, ReentrancyGuard, IProtocolVersion {
     uint256 private constant DEPOSIT_SIZE = 32 ether;
 
     uint256 private constant MIN_ETH_AMOUNT = 1 ether;
@@ -317,7 +319,7 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
         ExitETHAllocation[] calldata _allocations,
         ELExitETHAllocation[] calldata _elAllocations,
         uint256 _maxFeePerWithdrawal
-    ) external payable {
+    ) external payable nonReentrant {
         if (msg.sender != IConsensusLayerDepositManagerV1(RiverAddress.get()).getKeeper()) {
             revert IConsensusLayerDepositManagerV1.OnlyKeeper();
         }

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -70,7 +70,7 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
                     // activeCLETH starts at 0 and is only populated by the first post-upgrade oracle
                     // report (OracleManager._reportCLETH). UNTIL that report lands, requestETHExits caps
                     // each operator's allocation by activeCLETH, so `available == 0` and any non-zero exit
-                    // allocation reverts with ExitsRequestedExceedAvailableFundedAmount — even though
+                    // allocation reverts with ExitsRequestedExceedAvailableActiveCLAmount — even though
                     // CurrentETHExitsDemand / TotalETHExitsRequested are carried over non-zero from V2.
                     // A fresh oracle report MUST land immediately after initOperatorsRegistryV1_2, with
                     // the redemption queue paused to cover the gap.
@@ -457,9 +457,9 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
         uint256 available = _getOperatorAvailableExitETH(_operator, _operatorIndex);
         if (_amount > available) {
             if (_isEL) {
-                revert ELExitsRequestedExceedAvailableFundedAmount(_operatorIndex, _amount, available);
+                revert ELExitsRequestedExceedAvailableActiveCLAmount(_operatorIndex, _amount, available);
             }
-            revert ExitsRequestedExceedAvailableFundedAmount(_operatorIndex, _amount, available);
+            revert ExitsRequestedExceedAvailableActiveCLAmount(_operatorIndex, _amount, available);
         }
         _operator.requestedExits += _amount;
     }

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -185,17 +185,17 @@ interface IOperatorsRegistryV1 {
     /// @notice Thrown when the exited ETH for an operator has decreased compared to the previous report
     error ExitedETHPerOperatorDecreased();
 
-    /// @notice The provided exit requests exceed the available funded ETH amount of the operator
+    /// @notice The provided exit requests exceed the operator's available active CL ETH (active CL ETH minus pending exits)
     /// @param operatorIndex The operator index
     /// @param requested The requested ETH(wei) amount
     /// @param available The available ETH(wei) amount
-    error ExitsRequestedExceedAvailableFundedAmount(uint256 operatorIndex, uint256 requested, uint256 available);
+    error ExitsRequestedExceedAvailableActiveCLAmount(uint256 operatorIndex, uint256 requested, uint256 available);
 
-    /// @notice The provided exit requests exceed the available funded ETH amount of the operator
+    /// @notice The provided EL exit requests exceed the operator's available active CL ETH (active CL ETH minus pending exits)
     /// @param operatorIndex The operator index
     /// @param requested The requested ETH(wei) amount
     /// @param available The available ETH(wei) amount
-    error ELExitsRequestedExceedAvailableFundedAmount(uint256 operatorIndex, uint256 requested, uint256 available);
+    error ELExitsRequestedExceedAvailableActiveCLAmount(uint256 operatorIndex, uint256 requested, uint256 available);
 
     /// @notice The provided exit requests exceed the current exit request demand
     /// @param requestedETHAmount The requested ETH(wei) amount
@@ -388,13 +388,13 @@ interface IOperatorsRegistryV1 {
     /// @notice Process explicit per-operator exit allocations and update operator requestedExits
     /// @dev Only callable by the keeper address returned by the River contract's getKeeper()
     /// @dev The allocations must be sorted by operator index in strictly ascending order with no duplicates
-    /// @dev Each allocation's ethAmount must be non-zero and not exceed the operator's available funded-but-not-yet-exited ETH amount
+    /// @dev Each allocation's ethAmount must be non-zero and not exceed the operator's available active CL ETH (active CL ETH minus pending exits)
     /// @dev The total requested exits across all allocations must not exceed the current ETH exit demand
     /// @dev Reverts with InvalidEmptyArray if _allocations is empty
     /// @dev Reverts with AllocationWithIncorrectAmount if any allocation has an ETH amount less than 1 ether
     /// @dev Reverts with UnorderedOperatorList if operator indexes are not strictly ascending
     /// @dev Reverts with InactiveOperator if a referenced operator is inactive
-    /// @dev Reverts with ExitsRequestedExceedAvailableFundedAmount if count exceeds funded minus requestedExits for an operator
+    /// @dev Reverts with ExitsRequestedExceedAvailableActiveCLAmount if an allocation's ETH amount exceeds the operator's active CL ETH minus pending exits (requestedExits - exitedETH)
     /// @dev Reverts with ExitsRequestedExceedExitDemand if total exits requested exceed the current demand
     /// @dev Reverts with NoExitRequestsToPerform if there is no pending exit demand
     /// @param _allocations The proposed per-operator exit ETH allocations, sorted by operator index

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -1980,7 +1980,7 @@ contract OperatorsRegistryV1CoverageTests is OperatorsRegistryV1TestBase, Operat
         vm.prank(keeper);
         vm.expectRevert(
             abi.encodeWithSignature(
-                "ExitsRequestedExceedAvailableFundedAmount(uint256,uint256,uint256)", 0, 2 * 32 ether, 1 * 32 ether
+                "ExitsRequestedExceedAvailableActiveCLAmount(uint256,uint256,uint256)", 0, 2 * 32 ether, 1 * 32 ether
             )
         );
         reg.requestETHExits(
@@ -2347,7 +2347,7 @@ contract OperatorsRegistryV1ELExitTests is Test {
         vm.prank(keeper);
         vm.expectRevert(
             abi.encodeWithSignature(
-                "ELExitsRequestedExceedAvailableFundedAmount(uint256,uint256,uint256)", 0, 16 ether, 8 ether
+                "ELExitsRequestedExceedAvailableActiveCLAmount(uint256,uint256,uint256)", 0, 16 ether, 8 ether
             )
         );
         reg.requestETHExits(empty, allocs, 0);

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -7,6 +7,7 @@ import "forge-std/Test.sol";
 import "./OperatorAllocationTestBase.sol";
 import "../src/libraries/LibBytes.sol";
 import "./mocks/RejectEtherMock.sol";
+import "./mocks/ReentrancyExitAttackMock.sol";
 import "./utils/UserFactory.sol";
 import "./utils/BytesGenerator.sol";
 import "./utils/LibImplementationUnbricker.sol";
@@ -1459,6 +1460,45 @@ contract OperatorsRegistryV1ExitCorrectnessTests is OperatorAllocationTestBase {
     //         assertEq(operatorsRegistry.getTotalValidatorExitsRequested(), 5, "Total exits = unsolicited 5");
     //         assertEq(operatorsRegistry.getCurrentValidatorExitsDemand(), 5, "Demand reduced by unsolicited 5");
     //     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Reentrancy protection on requestETHExits
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// @notice requestETHExits refunds any excess msg.value to the keeper via a raw call.
+    ///         A malicious keeper contract can use that callback to re-enter the function.
+    ///         This test registers such a contract as the keeper, drives a CL exit with
+    ///         excess ETH attached (so the refund fires mid-execution), and asserts the
+    ///         re-entrant call is rejected.
+    ///         Without nonReentrant: the re-entrant call succeeds (reentrancySucceeded = true).
+    ///         With nonReentrant:    the re-entrant call is blocked  (reentrancySucceeded = false).
+    function testRequestETHExitsBlocksReentrancy() external {
+        _fundAllOperators();
+
+        vm.prank(river);
+        operatorsRegistry.demandETHExits(100 * 32 ether, 250 * 32 ether);
+
+        // Deploy the attacker and register it as the keeper (the address that receives refunds).
+        ReentrancyExitAttackMock attacker = new ReentrancyExitAttackMock(address(operatorsRegistry));
+        RiverMock(river).setKeeper(address(attacker));
+
+        // Single CL exit of 1 validator (32 ETH) from operator 0; re-used by the re-entrant call.
+        uint256[] memory ops = new uint256[](1);
+        ops[0] = 0;
+        uint32[] memory counts = new uint32[](1);
+        counts[0] = 1;
+        attacker.setAttackAllocation(_createExitAllocation(ops, counts));
+
+        // Attach excess ETH: a CL-only exit pays no withdrawal fee, so the whole amount is
+        // refunded to the keeper, invoking its receive() and the re-entrant requestETHExits.
+        vm.deal(address(this), 1 ether);
+        attacker.attack{value: 1 ether}();
+
+        assertFalse(attacker.reentrancySucceeded(), "re-entrant call to requestETHExits must be blocked");
+        // The outer (legitimate) call must still settle normally despite the blocked re-entry.
+        assertEq(operatorsRegistry.getOperator(0).requestedExits, 32 ether, "outer CL exit must still settle");
+        assertEq(operatorsRegistry.getCurrentETHExitsDemand(), 100 * 32 ether - 32 ether, "demand decremented once");
+    }
 }
 
 // ══════════════════════════════════════════════════════════════════════════

--- a/contracts/test/mocks/ReentrancyExitAttackMock.sol
+++ b/contracts/test/mocks/ReentrancyExitAttackMock.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../../src/interfaces/IOperatorRegistry.1.sol";
+
+/// @notice Attacker contract: registered as the keeper, it re-enters requestETHExits
+/// from its receive() (triggered by the excess-fee refund the function sends back to
+/// msg.sender) to prove the nonReentrant guard is enforced.
+contract ReentrancyExitAttackMock {
+    IOperatorsRegistryV1 public immutable target;
+    bool public reentrancySucceeded;
+    bool internal _armed;
+
+    IOperatorsRegistryV1.ExitETHAllocation[] internal _allocations;
+
+    constructor(address _target) {
+        target = IOperatorsRegistryV1(_target);
+    }
+
+    /// @notice Primes the CL exit allocation re-used for both the outer and the re-entrant call.
+    function setAttackAllocation(IOperatorsRegistryV1.ExitETHAllocation[] calldata allocations) external {
+        delete _allocations;
+        for (uint256 i = 0; i < allocations.length; ++i) {
+            _allocations.push(allocations[i]);
+        }
+    }
+
+    /// @notice Outer entrypoint. Attaches excess ETH so requestETHExits refunds it to this
+    /// contract mid-execution, invoking receive() before the function has returned.
+    function attack() external payable {
+        _armed = true;
+        target.requestETHExits{value: msg.value}(_allocations, new IOperatorsRegistryV1.ELExitETHAllocation[](0), 0);
+    }
+
+    receive() external payable {
+        if (!_armed) {
+            return;
+        }
+        _armed = false; // single re-entry attempt; avoids an infinite refund loop
+        try target.requestETHExits(_allocations, new IOperatorsRegistryV1.ELExitETHAllocation[](0), 0) {
+            reentrancySucceeded = true;
+        } catch {}
+    }
+}


### PR DESCRIPTION
## Description

This fixes this issue https://github.com/liquid-collective/liquid-collective-protocol/issues/535  and https://github.com/liquid-collective/liquid-collective-protocol/issues/547

## Notice

This pull request updates the `OperatorsRegistryV1` contract to improve exit request handling and security. The main changes include renaming error types and revert messages to clarify that exit requests are limited by "available active CL ETH" (active consensus layer ETH minus pending exits), and adding reentrancy protection to critical functions.

**Error handling and messaging improvements:**

* Renamed errors and revert messages from `ExitsRequestedExceedAvailableFundedAmount` and `ELExitsRequestedExceedAvailableFundedAmount` to `ExitsRequestedExceedAvailableActiveCLAmount` and `ELExitsRequestedExceedAvailableActiveCLAmount` for clarity, and updated all related comments and documentation to match the new terminology. [[1]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabL73-R75) [[2]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabL460-R464) [[3]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L188-R198) [[4]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L391-R397)
* Updated test assertions to expect the new error names and signatures. [[1]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L1983-R1983) [[2]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2350-R2350)

**Security enhancements:**

* Added OpenZeppelin's `ReentrancyGuard` to the contract and marked the `requestETHExits` function as `nonReentrant` to prevent reentrancy attacks. [[1]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabR14-R15) [[2]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabL30-R32) [[3]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabL320-R322)

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security of exit request functionality with reentrancy protection
  * Updated exit allocation calculation to use active CL ETH metric

<!-- end of auto-generated comment: release notes by coderabbit.ai -->