### PR TITLE
This fixes the issue flagged where the bool wasn't actually used or

### DIFF
--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -631,7 +631,6 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     function validateConsolidation(IAttestationVerifierV1.ConsolidationObject calldata consolidation)
         external
         onlyRiver
-        returns (bool)
     {
         // 1. Structural checks (cheapest first — fail fast)
         uint256 sourceLen = consolidation.sourcePubkeys.length;
@@ -682,8 +681,6 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         // 6. Mark as processed and emit
         ProcessedConsolidations.markProcessed(structHash);
         emit ConsolidationProcessed(structHash);
-
-        return true;
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -383,8 +383,8 @@ interface IAttestationVerifierV1 {
     ///           - Financial caps (e.g. against committed/in-flight balances)
     /// @param consolidation The consolidation request to validate (withdrawal address,
     ///                      source/target pubkeys, totalAmount, signatures).
-    /// @return Always `true` if the call returns; reverts otherwise.
-    function validateConsolidation(ConsolidationObject calldata consolidation) external returns (bool);
+    /// @dev Reverts on any validation failure; returns normally on success.
+    function validateConsolidation(ConsolidationObject calldata consolidation) external;
 
     // -----------------------------------------------------------------------
     // Admin setters

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -371,9 +371,6 @@ interface IAttestationVerifierV1 {
     ///         `ConsolidationAlreadyProcessed`. Note that this makes the function
     ///         state-mutating (not `view`) and callable only by River.
     ///
-    ///         The function reverts on any validation failure and returns `true` on success.
-    ///         The boolean is a positive signal for off-chain `eth_call` style invocations.
-    ///
     ///         Trust boundary: this function only validates structural shape and the attestation
     ///         quorum. The following are intentionally NOT checked here and are delegated to the
     ///         caller (off-chain pipeline / consolidation committee) or to the eventual River

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -196,12 +196,9 @@ contract ConsolidationAttestationTest is Test {
         });
     }
 
-    function _validateConsolidationAsRiver(IAttestationVerifierV1.ConsolidationObject memory consolidation)
-        internal
-        returns (bool)
-    {
+    function _validateConsolidationAsRiver(IAttestationVerifierV1.ConsolidationObject memory consolidation) internal {
         vm.prank(address(river));
-        return verifier.validateConsolidation(consolidation);
+        verifier.validateConsolidation(consolidation);
     }
 
     // -----------------------------------------------------------------------
@@ -211,7 +208,7 @@ contract ConsolidationAttestationTest is Test {
     function testValidateConsolidation_singlePair_quorumMet() public {
         address user = address(0xBEEF);
         IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(user, 1);
-        assertTrue(_validateConsolidationAsRiver(c));
+        _validateConsolidationAsRiver(c);
     }
 
     function testValidateConsolidation_multiplePairs_succeeds() public {
@@ -237,14 +234,14 @@ contract ConsolidationAttestationTest is Test {
             totalAmount: totalAmount,
             signatures: sigs
         });
-        assertTrue(_validateConsolidationAsRiver(c));
+        _validateConsolidationAsRiver(c);
     }
 
     function testValidateConsolidation_exactlyQuorumSignatures() public {
         // Quorum is 2; supplying exactly 2 valid signatures should pass.
         address user = address(0x11);
         IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(user, 7);
-        assertTrue(_validateConsolidationAsRiver(c));
+        _validateConsolidationAsRiver(c);
     }
 
     function testRevert_validateConsolidation_onlyRiver() public {
@@ -511,16 +508,15 @@ contract ConsolidationAttestationTest is Test {
         bytes[] memory sigsA = new bytes[](2);
         sigsA[0] = _sign(pk1, expectedDigest);
         sigsA[1] = _sign(pk2, expectedDigest);
-        assertTrue(
-            _validateConsolidationAsRiver(
-                IAttestationVerifierV1.ConsolidationObject({
-                    withdrawalAddress: user,
-                    sourcePubkeys: sources,
-                    targetPubkeys: targets,
-                    totalAmount: totalAmount,
-                    signatures: sigsA
-                })
-            )
+        // Succeeds (does not revert): correct signatures over the same request fields.
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: sigsA
+            })
         );
     }
 
@@ -529,7 +525,7 @@ contract ConsolidationAttestationTest is Test {
         // call with the same payload (even with the same valid signatures) must revert.
         address user = address(0xBEEF);
         IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(user, 1);
-        assertTrue(_validateConsolidationAsRiver(c));
+        _validateConsolidationAsRiver(c);
 
         // The expected key is the EIP-712 structHash over the four request fields.
         bytes32 structHash = keccak256(


### PR DESCRIPTION
## Description

This fixes https://github.com/liquid-collective/liquid-collective-protocol/issues/555

This pull request refactors the `validateConsolidation` function in the attestation verifier contract and updates its interface and associated tests. The function no longer returns a boolean value; instead, it reverts on failure and returns normally on success. This change simplifies the interface and aligns the function's behavior with common Solidity patterns.

**Contract and Interface Refactoring:**

* The `validateConsolidation` function in `AttestationVerifierV1` was changed to no longer return a boolean; it now reverts on validation failure and returns normally otherwise, removing the need for callers to check a return value. [[1]](diffhunk://#diff-2cbbaf82cf40abbadf2169784f860b0a4a2fc2bf356e6e03305e081c2a69b90aL634) [[2]](diffhunk://#diff-2cbbaf82cf40abbadf2169784f860b0a4a2fc2bf356e6e03305e081c2a69b90aL685-L686)
* The interface `IAttestationVerifierV1` was updated to match the new function signature and documentation, clarifying that the function reverts on failure instead of returning a boolean.

**Test Updates:**

* Test helper `_validateConsolidationAsRiver` and all related test assertions were updated to remove checks for a boolean return value, now simply calling the function and relying on revert behavior for validation. [[1]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646L199-R201) [[2]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646L214-R211) [[3]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646L240-R244) [[4]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646L514-R511) [[5]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646L523) [[6]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646L532-R528)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified consolidation validation function signature: no longer returns a value. Callers must update integration code accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->