### PR TITLE
test(pectra): strengthen crypto-primitive test assertions

### DIFF
--- a/contracts/test/libraries/BLS12_381_SSZ.t.sol
+++ b/contracts/test/libraries/BLS12_381_SSZ.t.sol
@@ -132,7 +132,6 @@ contract BLS12_381_SSZTest is Test {
         uint256 amount = 32 ether;
         uint256 amountGwei = amount / 1 gwei;
 
-        // expected pubkey root via sha256 builtin, independent of the library
         bytes32 pubkeyRoot = sha256(abi.encodePacked(pubkey, bytes16(0)));
         bytes32 amountChunk = bytes32(LibUint256.toLittleEndian64(amountGwei));
         bytes32 specDepositMessageRoot = sha256(

--- a/contracts/test/libraries/BLS12_381_SSZ.t.sol
+++ b/contracts/test/libraries/BLS12_381_SSZ.t.sol
@@ -111,4 +111,45 @@ contract BLS12_381_SSZTest is Test {
         bytes32 actualSigningRoot = harness.computeSigningRoot(pubkey, amount, wc, domain);
         assertEq(actualSigningRoot, expectedSigningRoot, "signing root does not match spec for 1 ETH deposit");
     }
+
+    // Verifies depositMessageSigningRoot reverts with InvalidDepositAmount when the
+    // deposit amount is not a whole number of gwei (BLS12_381.sol:584). Uses
+    // 1 gwei + 1 wei; the aligned-amount happy path is covered by the tests above.
+    function test_computeSigningRoot_revertsOnNonGweiAlignedAmount() public {
+        bytes memory pubkey = new bytes(48);
+        bytes32 wc = bytes32(uint256(1));
+        bytes32 domain = bytes32(uint256(0xdeadbeef));
+        uint256 amount = 1 gwei + 1;
+
+        vm.expectRevert(BLS12_381.InvalidDepositAmount.selector);
+        harness.computeSigningRoot(pubkey, amount, wc, domain);
+    }
+
+    // Verifies the signing root for a fully non-zero 48-byte pubkey (bytes 0x01..0x30).
+    // The other tests use pubkeys that are zero in bytes 1..47, so this is the only test
+    // that exercises pubkeyRoot's assembly copy/zero-padding across the whole pubkey; the
+    // expected pubkey leaf is computed independently via the sha256 builtin.
+    function test_computeSigningRoot_fullNonZeroPubkey() public {
+        bytes memory pubkey = new bytes(48);
+        for (uint256 i = 0; i < 48; i++) {
+            pubkey[i] = bytes1(uint8(i + 1));
+        }
+        bytes32 wc = keccak256("full_pubkey_wc");
+        bytes32 domain = keccak256("full_pubkey_domain");
+        uint256 amount = 32 ether;
+        uint256 amountGwei = amount / 1 gwei;
+
+        // expected pubkey root via sha256 builtin, independent of the library
+        bytes32 pubkeyRoot = sha256(abi.encodePacked(pubkey, bytes16(0)));
+        bytes32 amountChunk = bytes32(LibUint256.toLittleEndian64(amountGwei));
+        bytes32 specDepositMessageRoot = sha256(
+            abi.encodePacked(
+                sha256(abi.encodePacked(pubkeyRoot, wc)), sha256(abi.encodePacked(amountChunk, bytes32(0)))
+            )
+        );
+        bytes32 expectedSigningRoot = sha256(abi.encodePacked(specDepositMessageRoot, domain));
+
+        bytes32 actualSigningRoot = harness.computeSigningRoot(pubkey, amount, wc, domain);
+        assertEq(actualSigningRoot, expectedSigningRoot, "signing root mismatch for full non-zero pubkey");
+    }
 }

--- a/contracts/test/libraries/BLS12_381_SSZ.t.sol
+++ b/contracts/test/libraries/BLS12_381_SSZ.t.sol
@@ -112,9 +112,6 @@ contract BLS12_381_SSZTest is Test {
         assertEq(actualSigningRoot, expectedSigningRoot, "signing root does not match spec for 1 ETH deposit");
     }
 
-    // Verifies depositMessageSigningRoot reverts with InvalidDepositAmount when the
-    // deposit amount is not a whole number of gwei (BLS12_381.sol:584). Uses
-    // 1 gwei + 1 wei; the aligned-amount happy path is covered by the tests above.
     function test_computeSigningRoot_revertsOnNonGweiAlignedAmount() public {
         bytes memory pubkey = new bytes(48);
         bytes32 wc = bytes32(uint256(1));
@@ -125,10 +122,6 @@ contract BLS12_381_SSZTest is Test {
         harness.computeSigningRoot(pubkey, amount, wc, domain);
     }
 
-    // Verifies the signing root for a fully non-zero 48-byte pubkey (bytes 0x01..0x30).
-    // The other tests use pubkeys that are zero in bytes 1..47, so this is the only test
-    // that exercises pubkeyRoot's assembly copy/zero-padding across the whole pubkey; the
-    // expected pubkey leaf is computed independently via the sha256 builtin.
     function test_computeSigningRoot_fullNonZeroPubkey() public {
         bytes memory pubkey = new bytes(48);
         for (uint256 i = 0; i < 48; i++) {

--- a/contracts/test/libraries/BLS12_381_SSZ.t.sol
+++ b/contracts/test/libraries/BLS12_381_SSZ.t.sol
@@ -58,20 +58,6 @@ contract BLS12_381_SSZTest is Test {
         assertEq(actualDomain, expectedDomain, "computeDepositDomain holesky does not match spec");
     }
 
-    // Anchors computeDepositDomain to an external published value rather than to a
-    // re-derivation in this test. For mainnet (genesis fork version 0x00000000 and a
-    // zero genesis_validators_root), the ForkData root is the canonical SSZ zero hash
-    // z1 = sha256(64 zero bytes) = f5a5fd42...2759fb4b, so the deposit domain is
-    // DOMAIN_DEPOSIT (0x03000000) followed by z1's first 28 bytes.
-    function test_computeDepositDomain_mainnetVector() public {
-        bytes32 expectedMainnetDomain = 0x03000000f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a9;
-        assertEq(
-            harness.computeDepositDomain(0x00000000),
-            expectedMainnetDomain,
-            "computeDepositDomain(mainnet) does not match the published deposit domain"
-        );
-    }
-
     // -----------------------------------------------------------------------
     // _computeSigningRoot amount node must hash 64 bytes.
     //

--- a/contracts/test/libraries/BLS12_381_SSZ.t.sol
+++ b/contracts/test/libraries/BLS12_381_SSZ.t.sol
@@ -58,6 +58,20 @@ contract BLS12_381_SSZTest is Test {
         assertEq(actualDomain, expectedDomain, "computeDepositDomain holesky does not match spec");
     }
 
+    // Anchors computeDepositDomain to an external published value rather than to a
+    // re-derivation in this test. For mainnet (genesis fork version 0x00000000 and a
+    // zero genesis_validators_root), the ForkData root is the canonical SSZ zero hash
+    // z1 = sha256(64 zero bytes) = f5a5fd42...2759fb4b, so the deposit domain is
+    // DOMAIN_DEPOSIT (0x03000000) followed by z1's first 28 bytes.
+    function test_computeDepositDomain_mainnetVector() public {
+        bytes32 expectedMainnetDomain = 0x03000000f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a9;
+        assertEq(
+            harness.computeDepositDomain(0x00000000),
+            expectedMainnetDomain,
+            "computeDepositDomain(mainnet) does not match the published deposit domain"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // _computeSigningRoot amount node must hash 64 bytes.
     //

--- a/contracts/test/state/attestationVerifier/PrePectraValidatorPubkeyLookup.t.sol
+++ b/contracts/test/state/attestationVerifier/PrePectraValidatorPubkeyLookup.t.sol
@@ -63,7 +63,6 @@ contract PrePectraValidatorPubkeyLookupTest is Test {
         inputs.add(pk);
         assertTrue(inputs.isPubkeyFunded(pk));
 
-        // one remove must fully clear it
         bytes[] memory pubkeys = new bytes[](1);
         pubkeys[0] = pk;
         inputs.remove(pubkeys);

--- a/contracts/test/state/attestationVerifier/PrePectraValidatorPubkeyLookup.t.sol
+++ b/contracts/test/state/attestationVerifier/PrePectraValidatorPubkeyLookup.t.sol
@@ -57,11 +57,18 @@ contract PrePectraValidatorPubkeyLookupTest is Test {
         assertFalse(inputs.isPubkeyFunded(pkB));
     }
 
+    // add is idempotent: adding a pubkey twice then removing once leaves it unfunded.
     function testAddIsIdempotent() public {
         bytes memory pk = _pubkey(keccak256("pre-pectra-pubkey-C"));
         inputs.add(pk);
         inputs.add(pk);
         assertTrue(inputs.isPubkeyFunded(pk));
+
+        // one remove must fully clear it
+        bytes[] memory pubkeys = new bytes[](1);
+        pubkeys[0] = pk;
+        inputs.remove(pubkeys);
+        assertFalse(inputs.isPubkeyFunded(pk));
     }
 
     function testRemoveClearsOnlyRequestedKeys() public {

--- a/contracts/test/state/attestationVerifier/PrePectraValidatorPubkeyLookup.t.sol
+++ b/contracts/test/state/attestationVerifier/PrePectraValidatorPubkeyLookup.t.sol
@@ -57,7 +57,6 @@ contract PrePectraValidatorPubkeyLookupTest is Test {
         assertFalse(inputs.isPubkeyFunded(pkB));
     }
 
-    // add is idempotent: adding a pubkey twice then removing once leaves it unfunded.
     function testAddIsIdempotent() public {
         bytes memory pk = _pubkey(keccak256("pre-pectra-pubkey-C"));
         inputs.add(pk);


### PR DESCRIPTION
Strengthens assertions in three Pectra crypto-primitive test files that had full coverage but verified little: a tautological amount-leaf check, a missing gwei-alignment revert, an unexercised pubkey leaf, and a hollow idempotence test. Also anchors the deposit domain to the published mainnet constant. Test-only (no src/ changes); all tests pass under via_ir.

Resubmitted on the main repo; supersedes the earlier fork-based PR #616.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened BLS12_381 SSZ validation test coverage with new deposit domain and signing-root tests
  * Added edge case tests for non-gwei-aligned amounts and non-zero pubkeys
  * Enhanced test documentation and clarity in pubkey lookup validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->