### PR TITLE
fix: natspec description of `preExitingBalance` (BS-4190)

### DIFF
--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -728,9 +728,9 @@ contract RiverV1 is
 
                 (uint256 totalExitedETH, uint256 totalRequestedETHExits) = or.getExitedAndRequestedETHExits();
 
-                // what we are calling pre-exiting balance is the amount of eth the protocol has committed to exit                                                                                                                                                                         
-                // but not yet received — covering both dispatched exit requests and demand not yet sent to operators                                                                                                                                                                        
-                // we take them into account to not over-request exits across oracle cycles     
+                // what we are calling pre-exiting balance is the amount of ETH (wei) the protocol has committed to exit
+                // but not yet received — covering both dispatched exit requests and demand not yet sent to operators
+                // we take them into account to not over-request exits across oracle cycles
                 uint256 preExitingBalance =
                     totalRequestedETHExits > totalExitedETH ? (totalRequestedETHExits - totalExitedETH) : 0;
 

--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -728,9 +728,9 @@ contract RiverV1 is
 
                 (uint256 totalExitedETH, uint256 totalRequestedETHExits) = or.getExitedAndRequestedETHExits();
 
-                // what we are calling pre-exiting balance is the amount of eth that should soon enter the exiting balance
-                // because exit requests have been made and operators might have a lag to process them
-                // we take them into account to not exit too many validators
+                // what we are calling pre-exiting balance is the amount of eth the protocol has committed to exit                                                                                                                                                                         
+                // but not yet received — covering both dispatched exit requests and demand not yet sent to operators                                                                                                                                                                        
+                // we take them into account to not over-request exits across oracle cycles     
                 uint256 preExitingBalance =
                     totalRequestedETHExits > totalExitedETH ? (totalRequestedETHExits - totalExitedETH) : 0;
 


### PR DESCRIPTION
closes #602 

## Description

This pull request updates the comments in the `RiverV1` contract to clarify the definition of "pre-exiting balance" in the exit request logic. The new comment more accurately describes the protocol's handling of ETH committed to exit but not yet received, including both dispatched exit requests and pending demand.

Clarification of exit request logic:

* Updated the comment describing `preExitingBalance` to clarify that it covers both ETH committed via dispatched exit requests and demand not yet sent to operators, helping prevent over-requesting exits across oracle cycles.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->