### PR TITLE
test(pectra): strengthen attestation post-state & revert assertions

### DIFF
--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -949,6 +949,11 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
 
         assertEq(dm.lastFundedETH(0), 64 ether, "both initial and top-up bump fundedETH");
         assertEq(depositContract.deposit_count(), 2);
+
+        // mixed initial + top-up batch balance bookkeeping
+        assertEq(dm.getCommittedBalance(), 64 ether, "committed balance after batch");
+        assertEq(dm.getTotalDepositedETH(), 64 ether, "total deposited after batch");
+        assertEq(address(dm).balance, 64 ether, "contract ETH balance after batch");
     }
 
     // Issue #543: a top-ups-only batch must NOT emit Deposits (which would inflate
@@ -1717,6 +1722,10 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits);
         vm.prank(keeper);
         dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs); // must not revert
+
+        // deposit must be recorded, not just non-reverting
+        assertEq(depositContract.deposit_count(), 1, "exact-minimum deposit must reach the deposit contract");
+        assertEq(dm.getTotalDepositedETH(), 32 ether, "total deposited must reflect the 32 ETH deposit");
     }
 
     /// @dev When a batch has two initial deposits and the second is below 32 ETH, validation must

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -954,7 +954,6 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         assertEq(dm.lastFundedETH(0), 64 ether, "both initial and top-up bump fundedETH");
         assertEq(depositContract.deposit_count(), 2);
 
-        // assert the change from the batch, not fixture-seeded absolute values
         assertEq(committedBefore - dm.getCommittedBalance(), 64 ether, "committed balance should decrease by 64 ETH");
         assertEq(balanceBefore - address(dm).balance, 64 ether, "contract ETH balance should decrease by 64 ETH");
         assertEq(
@@ -1729,7 +1728,6 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         vm.prank(keeper);
         dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs); // must not revert
 
-        // deposit must be recorded, not just non-reverting
         assertEq(depositContract.deposit_count(), 1, "exact-minimum deposit must reach the deposit contract");
         assertEq(dm.getTotalDepositedETH(), 32 ether, "total deposited must reflect the 32 ETH deposit");
     }

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -944,16 +944,22 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         vm.expectEmit(true, false, false, true);
         emit TopUps(0, topUpKeys, topUpAmounts);
 
+        uint256 committedBefore = dm.getCommittedBalance();
+        uint256 balanceBefore = address(dm).balance;
+        uint256 totalDepositedBefore = dm.getTotalDepositedETH();
+
         vm.prank(keeper);
         dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
 
         assertEq(dm.lastFundedETH(0), 64 ether, "both initial and top-up bump fundedETH");
         assertEq(depositContract.deposit_count(), 2);
 
-        // mixed initial + top-up batch balance bookkeeping
-        assertEq(dm.getCommittedBalance(), 64 ether, "committed balance after batch");
-        assertEq(dm.getTotalDepositedETH(), 64 ether, "total deposited after batch");
-        assertEq(address(dm).balance, 64 ether, "contract ETH balance after batch");
+        // assert the change from the batch, not fixture-seeded absolute values
+        assertEq(committedBefore - dm.getCommittedBalance(), 64 ether, "committed balance should decrease by 64 ETH");
+        assertEq(balanceBefore - address(dm).balance, 64 ether, "contract ETH balance should decrease by 64 ETH");
+        assertEq(
+            dm.getTotalDepositedETH() - totalDepositedBefore, 64 ether, "total deposited should increase by 64 ETH"
+        );
     }
 
     // Issue #543: a top-ups-only batch must NOT emit Deposits (which would inflate

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -312,7 +312,6 @@ contract ConsolidationAttestationTest is Test {
         dep[0] = depositAttester;
         address[] memory cc = new address[](1);
         cc[0] = attester1;
-        // pin the exact revert selector
         vm.expectRevert(abi.encodeWithSignature("InvalidInitialization(uint256,uint256)", 0, 1));
         verifier.initAttestationVerifierV1(address(river), depositBufferStub, dep, 1, bytes4(0), cc, 1);
     }

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -312,7 +312,8 @@ contract ConsolidationAttestationTest is Test {
         dep[0] = depositAttester;
         address[] memory cc = new address[](1);
         cc[0] = attester1;
-        vm.expectRevert();
+        // pin the exact revert selector
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization(uint256,uint256)", 0, 1));
         verifier.initAttestationVerifierV1(address(river), depositBufferStub, dep, 1, bytes4(0), cc, 1);
     }
 


### PR DESCRIPTION
## What

Strengthens three Pectra attestation tests where line coverage was green but the assertions verified little. Surfaced by a test-adequacy audit of the attestation components (analyze + adversarial-verify pass).

## Changes

- **`testTopUp_fundingDeltas_emitsTopUpsEventNotDeposits`** — this is the only test exercising a single-call **mixed batch** (1 initial + 1 top-up). It now asserts the full balance bookkeeping (`getCommittedBalance`, `getTotalDepositedETH`, contract ETH balance — 64 ETH each). Previously the mixed-path accounting was unverified; a regression that mishandled the top-up amount would have passed.
- **`testDeposit_exactMinimum_32ETH_succeeds`** — asserts `deposit_count == 1` and `getTotalDepositedETH == 32 ETH` so a silently-dropped boundary deposit can't pass on a bare "didn't revert".
- **`testInit_revertAlreadyInitialized`** — pins `InvalidInitialization(0, 1)` instead of a bare `vm.expectRevert()` that would accept any revert (matches the existing pattern in sibling tests).

## Testing

- The three affected tests pass.
- Full suite: 990 passed; the 1 failure is the pre-existing `TLC_globalUnlockScheduleMigration` mainnet-fork test that needs `MAINNET_FORK_RPC_URL` (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added stronger post-deposit checks to verify balance and total-deposit accounting after mixed and minimum-amount deposits.
  * Improved initialization test coverage by asserting the exact revert details when initialization is attempted more than once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->