### PR TITLE
fix: Remove same-batch pubkey deduping (BS-4204)

### DIFF
--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -427,12 +427,11 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         bytes32 computedId = keccak256(abi.encode(batch));
         if (computedId != depositDataBufferId) revert BufferIdMismatch(depositDataBufferId, computedId);
 
-        // 4. Validate initial deposits: field lengths, amount bounds, pubkey-not-already-funded
-        //    and no in-batch duplicates. The cross-array "pubkey in both deposits and topUps"
-        //    case is implicitly forbidden: an initial deposit reverts PubkeyAlreadyFunded if
-        //    the pubkey is in the lookup, and a top-up reverts TopUpPubkeyNotFunded if it
-        //    isn't — so no pubkey can pass both branches in one batch.
-        bytes32[] memory pubkeyHashes = new bytes32[](depositCount);
+        // 4. Validate initial deposits: field lengths, amount bounds, and pubkey-not-already-funded.
+        //    Same-batch duplicate pubkeys are a Keeper input invariant, not deduplicated on-chain.
+        //    The cross-array "pubkey in both deposits and topUps" case is still implicitly forbidden:
+        //    an initial deposit reverts PubkeyAlreadyFunded if the pubkey is already in the lookup,
+        //    and a top-up reverts TopUpPubkeyNotFunded if it is not.
         for (uint256 i = 0; i < depositCount; i++) {
             IDepositDataBuffer.Deposit memory d = batch.deposits[i];
             if (d.pubkey.length != DEPOSIT_PUBKEY_LENGTH) {
@@ -451,21 +450,13 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             }
             totalAmount += d.amount;
 
-            bytes32 pkHash = keccak256(d.pubkey);
-            pubkeyHashes[i] = pkHash;
-
             if (PectraValidatorPubkeyLookup.isPubkeyFunded(d.pubkey)) {
                 revert PubkeyAlreadyFunded(d.pubkey);
-            }
-            for (uint256 j = 0; j < i; j++) {
-                if (pubkeyHashes[j] == pkHash) {
-                    revert PubkeyAlreadyFunded(d.pubkey);
-                }
             }
         }
 
         // 5. Validate top-ups: field length on pubkey, amount bounds, pubkey-must-be-funded.
-        //    Per-batch duplicate top-up pubkeys are allowed.
+        //    Same-batch duplicate pubkeys are a Keeper input invariant, not deduplicated on-chain.
         for (uint256 i = 0; i < topUpCount; i++) {
             IDepositDataBuffer.TopUp memory t = batch.topUps[i];
             if (t.pubkey.length != DEPOSIT_PUBKEY_LENGTH) {
@@ -491,11 +482,9 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     // -----------------------------------------------------------------------
 
     /// @inheritdoc IAttestationVerifierV1
-    /// @dev Assumes `pubkeys` is already deduplicated against the lookup and against itself —
-    ///      `fetchAndValidateDeposits()` enforces both invariants (initial-deposit branch at the top of
-    ///      `fetchAndValidateDeposits()`) and runs in the same transaction. Re-checking here would only fire
-    ///      on a `fetchAndValidateDeposits()` regression and would cost a cold SLOAD per pubkey for a
-    ///      condition that cannot occur in production.
+    /// @dev Assumes `pubkeys` was already checked against the lookup by `fetchAndValidateDeposits()`,
+    ///      which runs in the same transaction. Same-batch duplicate pubkeys are a Keeper input
+    ///      invariant, not deduplicated here.
     function recordNewlyFundedPubkeys(bytes[] calldata pubkeys) external onlyRiver {
         uint256 len = pubkeys.length;
         for (uint256 i = 0; i < len; ++i) {

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -256,7 +256,7 @@ interface IAttestationVerifierV1 {
     /// @param pubkey The offending 48-byte BLS pubkey
     error TopUpPubkeyNotFunded(bytes pubkey);
 
-    /// @notice recordNewlyFundedPubkeys was passed a pubkey already in the initial-deposit set.
+    /// @notice An initial deposit referenced a pubkey already in the initial-deposit set.
     /// @param pubkey The offending 48-byte BLS pubkey
     error PubkeyAlreadyFunded(bytes pubkey);
 
@@ -308,10 +308,11 @@ interface IAttestationVerifierV1 {
     ///         the validated batch + total amount for River to execute.
     /// @dev Per-deposit pubkey-state checks fire eagerly inside this call — top-ups must
     ///      reference a pubkey already in the initial-deposit lookup, and initial deposits
-    ///      must not duplicate any already-recorded or in-batch pubkey. The buffer's
-    ///      `operatorIdx` is NOT verified against any on-chain record (the lookup tracks
-    ///      membership only — see PectraValidatorPubkeyLookup natspec). A failure reverts here,
-    ///      before River runs any `_depositValidator`.
+    ///      must not duplicate any already-recorded pubkey. Same-batch duplicate pubkeys are
+    ///      not deduplicated on-chain; Keeper is trusted not to submit duplicate pubkeys within
+    ///      the same batch. The buffer's `operatorIdx` is NOT verified against any on-chain record
+    ///      (the lookup tracks membership only — see PectraValidatorPubkeyLookup natspec).
+    ///      A failure reverts here, before River runs any `_depositValidator`.
     /// @dev `depositContract` is supplied by the caller (River) rather than read from the
     ///      verifier's own storage so we avoid an additional cold SLOAD per call. The same
     ///      address is used both for the front-run-resistant `get_deposit_root()` check here
@@ -346,10 +347,11 @@ interface IAttestationVerifierV1 {
     /// @notice Record one or more pubkeys as initial-deposited. Only callable by River.
     /// @dev Called by River after the deposit-execution loop. The recorded set is consulted
     ///      by the top-up branch of `fetchAndValidateDeposits()` to require that top-ups reference a pubkey
-    ///      River has previously initial-deposited. Assumes `pubkeys` is already deduplicated
-    ///      against the lookup and against itself; `fetchAndValidateDeposits()` enforces both invariants
-    ///      earlier in the same transaction. Per-pubkey logging is emitted on the caller
-    ///      (ConsensusLayerDepositManager's `PubkeyFunded` event), not here.
+    ///      River has previously initial-deposited. Assumes `pubkeys` was already checked against
+    ///      the lookup by `fetchAndValidateDeposits()` earlier in the same transaction. Same-batch
+    ///      duplicate pubkeys are not deduplicated here; Keeper is trusted not to include them.
+    ///      Per-pubkey logging is emitted on the caller (ConsensusLayerDepositManager's
+    ///      `PubkeyFunded` event), not here.
     /// @param pubkeys The 48-byte BLS pubkeys to record
     function recordNewlyFundedPubkeys(bytes[] calldata pubkeys) external;
 

--- a/contracts/src/interfaces/components/IConsensusLayerDepositManager.1.sol
+++ b/contracts/src/interfaces/components/IConsensusLayerDepositManager.1.sol
@@ -110,6 +110,8 @@ interface IConsensusLayerDepositManagerV1 {
     ///      `IDepositDataBuffer.DepositObject` (`deposits[]` and `topUps[]`). Initial deposits
     ///      go through BLS verification; top-ups skip BLS and require their pubkey to already
     ///      be in `PectraValidatorPubkeyLookup`.
+    /// @dev Same-batch duplicate pubkeys are not deduplicated on-chain; Keeper is trusted not
+    ///      to submit duplicate pubkeys within the same batch.
     /// @param depositDataBufferId  Batch identifier in the DepositDataBuffer
     /// @param depositRootHash      Current deposit contract root hash co-signed by root attesters
     /// @param signatures           EIP-712 signatures from root attesters

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -1493,6 +1493,27 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         assertEq(depositContract.deposit_count(), depositCountBefore, "no deposit should reach the beacon contract");
     }
 
+    /// @dev Same-batch duplicate initial deposits are not caught by the lookup table because
+    ///      `fetchAndValidateDeposits()` only checks the pre-existing lookup state. The lookup
+    ///      is updated after both deposit-contract calls execute, so this regression test pins
+    ///      the intended Keeper-input-invariant behavior.
+    function testSameBatch_duplicateInitialDeposits_executesBoth() public {
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](2);
+        deposits[0] = _makeDeposit(0, 150);
+        deposits[1] = _makeDeposit(0, 150);
+
+        assertFalse(verifier.isPubkeyFunded(deposits[0].pubkey), "duplicate pubkey starts unfunded");
+
+        (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits);
+
+        uint256 depositCountBefore = depositContract.deposit_count();
+        vm.prank(keeper);
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+
+        assertEq(depositContract.deposit_count(), depositCountBefore + 2, "both duplicate initials should execute");
+        assertTrue(verifier.isPubkeyFunded(deposits[0].pubkey), "duplicate pubkey recorded after execution");
+    }
+
     /// @dev `recordNewlyFundedPubkeys` is gated by `onlyRiver` (msg.sender == RiverAddress.get()).
     ///      Any other caller must revert with LibErrors.Unauthorized.
     function testRevert_recordNewlyFundedPubkeys_notRiver() public {

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -1493,25 +1493,6 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         assertEq(depositContract.deposit_count(), depositCountBefore, "no deposit should reach the beacon contract");
     }
 
-    /// @dev Same-batch duplicate-initial (two entries with the same pubkey, both flagged as
-    ///      initials via non-zero depositY) must revert in `fetchAndValidateDeposits()` with PubkeyAlreadyFunded
-    ///      before any deposit is sent to the beacon contract. Catches the producer-bug class where
-    ///      the dup is intra-batch and not yet recorded on-chain — the on-chain lookup is empty for
-    ///      this pubkey at validate-time, so the inner per-batch scan is what fires.
-    function testRevert_sameBatch_duplicateInitial_failsBeforeDeposit() public {
-        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](2);
-        deposits[0] = _makeDeposit(0, 150);
-        deposits[1] = _makeDeposit(0, 150); // same operator + same seed → same pubkey, both initials
-
-        (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits);
-
-        uint256 depositCountBefore = depositContract.deposit_count();
-        vm.prank(keeper);
-        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.PubkeyAlreadyFunded.selector, deposits[1].pubkey));
-        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
-        assertEq(depositContract.deposit_count(), depositCountBefore, "no deposit should reach the beacon contract");
-    }
-
     /// @dev `recordNewlyFundedPubkeys` is gated by `onlyRiver` (msg.sender == RiverAddress.get()).
     ///      Any other caller must revert with LibErrors.Unauthorized.
     function testRevert_recordNewlyFundedPubkeys_notRiver() public {
@@ -1752,8 +1733,8 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
     }
 
     /// @dev Two top-ups for the same pubkey within one batch are Pectra-legal under 0x02
-    ///      compounding withdrawal credentials. Both entries must succeed because the
-    ///      in-batch duplicate scan only applies to initial deposits — top-ups are exempt.
+    ///      compounding withdrawal credentials. Both entries must succeed because validation
+    ///      does not deduplicate same-batch pubkeys.
     function testTopUp_sameBatch_twoTopUpsForSamePubkey_succeeds() public {
         IDepositDataBuffer.TopUp[] memory topUps = new IDepositDataBuffer.TopUp[](2);
         topUps[0] = _makeTopUpDeposit(0, 300);


### PR DESCRIPTION
## Description

closes #572 

This pull request updates the attestation verification logic and documentation to clarify how same-batch duplicate pubkeys are handled for deposits and top-ups. The main change is to make explicit that deduplication of pubkeys within the same batch is now the responsibility of the Keeper, not enforced on-chain. As a result, related in-batch duplicate checks and tests are removed, and comments and NatSpec documentation are updated for clarity.

**Attestation verification and deduplication logic:**

* Removed on-chain deduplication of same-batch duplicate pubkeys for both initial deposits and top-ups in `AttestationVerifierV1`; this is now a Keeper input invariant. [[1]](diffhunk://#diff-2cbbaf82cf40abbadf2169784f860b0a4a2fc2bf356e6e03305e081c2a69b90aL430-R434) [[2]](diffhunk://#diff-2cbbaf82cf40abbadf2169784f860b0a4a2fc2bf356e6e03305e081c2a69b90aL454-R459)
* Updated function and error documentation (`IAttestationVerifierV1`, `IConsensusLayerDepositManagerV1`) to clarify that same-batch duplicate pubkeys are not deduplicated on-chain, and that the Keeper is trusted not to submit duplicates. [[1]](diffhunk://#diff-2cca6fbd0887dba17a65589a8f86c7d3a2a32849fd684cfcbe38c2103be3d779L311-R315) [[2]](diffhunk://#diff-2cca6fbd0887dba17a65589a8f86c7d3a2a32849fd684cfcbe38c2103be3d779L349-R354) [[3]](diffhunk://#diff-41dd0c8d6419746e57796a886349069300908652825ec3ed37aceeb08c057d3fR113-R114)
* Adjusted error message for `PubkeyAlreadyFunded` to clarify it refers to an initial deposit referencing a pubkey already in the initial-deposit set.

**Testing:**

* Removed the test that checked for reversion on same-batch duplicate initial deposits, since this is no longer enforced on-chain.
* Updated top-up test to clarify that same-batch duplicate pubkeys are allowed and not deduplicated in validation.

These changes shift responsibility for duplicate pubkey validation within a batch from on-chain logic to the Keeper, simplifying contract logic and making the invariants explicit in documentation and tests.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed on-chain validation for duplicate public keys within the same batch; this validation is now delegated to external keepers.

* **Documentation**
  * Updated contract documentation for deposit and public key validation flows to clarify revised validation boundaries and assumptions.

* **Tests**
  * Removed test for same-batch duplicate initial deposit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->