### PR TITLE
This implements Option B as discussed ... no behaviour change,

### DIFF
--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -444,8 +444,8 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
                 revert InvalidELExitETHAllocationAmount(operatorIndex, withdrawalAmount, reservedExitAmount);
             }
             // A non-zero wire amount denotes a partial exit, which must withdraw exactly what it reserves.
-            // A zero wire amount denotes a full exit, whose reserved value is the projected balance.
-            if (withdrawalAmount != 0 && withdrawalAmount != reservedExitAmount) {
+            // A zero wire amount denotes a full exit. In that case the reserved value is keeper-supplied
+            // accounting data (typically the projected balance) and is not validated on-chain.
                 revert ELExitReservedWithdrawalMismatch(operatorIndex, withdrawalAmount, reservedExitAmount);
             }
             elExitAmount += uint256(reservedExitAmount) * 1 gwei;

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -424,7 +424,7 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
     /// @notice Validates a single operator's EL exit allocation, reserves it, triggers the withdrawal and emits.
     /// @return elExitAmount The total reserved exit amount (wei) for this operator
     /// @return feePaid The withdrawal fee paid for this operator
-    function _requestSingleELETHExit(
+    function _requestELETHExits(
         IWithdrawV1 _withdraw,
         ELExitETHAllocation calldata _operatorAllocation,
         uint256 _maxFeePerWithdrawal

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -397,58 +397,72 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
         IWithdrawV1 withdraw = IWithdrawV1(WithdrawAddress.get());
 
         for (uint256 i = 0; i < _elAllocations.length; ++i) {
-            uint256 operatorIndex = _elAllocations[i].operatorIndex;
-
-            if (i > 0 && operatorIndex <= _elAllocations[i - 1].operatorIndex) {
+            if (i > 0 && _elAllocations[i].operatorIndex <= _elAllocations[i - 1].operatorIndex) {
                 revert UnorderedOperatorList();
             }
 
-            if (
-                _elAllocations[i].pubkeys.length != _elAllocations[i].withdrawalAmounts.length
-                    || _elAllocations[i].pubkeys.length != _elAllocations[i].reservedExitAmounts.length
-            ) {
-                revert InvalidELExitETHAllocationLength();
-            }
-
-            OperatorsV3.Operator storage operator = OperatorsV3.get(operatorIndex);
-            if (!operator.active) {
-                revert InactiveOperator(operatorIndex);
-            }
-
-            uint256 elExitAmount;
-            for (uint256 j = 0; j < _elAllocations[i].reservedExitAmounts.length; ++j) {
-                uint64 withdrawalAmount = _elAllocations[i].withdrawalAmounts[j];
-                uint64 reservedExitAmount = _elAllocations[i].reservedExitAmounts[j];
-                // The reserved amount feeds the per-operator headroom cap, so it must always be a positive
-                // value within the allowed bound — for both partial and full exits.
-                if (reservedExitAmount == 0 || reservedExitAmount > MAX_EL_EXIT_AMOUNT_GWEI) {
-                    revert InvalidELExitETHAllocationAmount(operatorIndex, withdrawalAmount, reservedExitAmount);
-                }
-                // A non-zero wire amount denotes a partial exit, which must withdraw exactly what it reserves.
-                // A zero wire amount denotes a full exit, whose reserved value is the projected balance.
-                if (withdrawalAmount != 0 && withdrawalAmount != reservedExitAmount) {
-                    revert ELExitReservedWithdrawalMismatch(operatorIndex, withdrawalAmount, reservedExitAmount);
-                }
-                elExitAmount += uint256(reservedExitAmount) * 1 gwei;
-            }
-
-            _reserveOperatorExit(operator, operatorIndex, elExitAmount, true);
+            (uint256 elExitAmount, uint256 feePaid) =
+                _requestSingleELETHExit(withdraw, _elAllocations[i], _maxFeePerWithdrawal);
             requestedETHAmount += elExitAmount;
-
-            withdraw.withdraw{value: _maxFeePerWithdrawal * _elAllocations[i].pubkeys.length}(
-                _elAllocations[i].pubkeys, _elAllocations[i].withdrawalAmounts, _maxFeePerWithdrawal, msg.sender
-            );
-            totalFeePaid += _maxFeePerWithdrawal * _elAllocations[i].pubkeys.length;
-            emit RequestedELETHExits(
-                operatorIndex,
-                _elAllocations[i].pubkeys,
-                _elAllocations[i].withdrawalAmounts,
-                _elAllocations[i].reservedExitAmounts
-            );
+            totalFeePaid += feePaid;
         }
         if (requestedETHAmount > _remainingETHExitsDemand) {
             revert ExitsGreaterThanExitDemand(requestedETHAmount, _remainingETHExitsDemand);
         }
+    }
+
+    /// @notice Validates a single operator's EL exit allocation, reserves it, triggers the withdrawal and emits.
+    /// @dev Split out of `_requestELETHExits` to keep the per-operator locals off the caller's stack (the loop
+    ///      otherwise hits "stack too deep" when compiled without `viaIR`, e.g. under `forge coverage`).
+    /// @return elExitAmount The total reserved exit amount (wei) for this operator
+    /// @return feePaid The withdrawal fee paid for this operator
+    function _requestSingleELETHExit(
+        IWithdrawV1 _withdraw,
+        ELExitETHAllocation calldata _operatorAllocation,
+        uint256 _maxFeePerWithdrawal
+    ) private returns (uint256 elExitAmount, uint256 feePaid) {
+        uint256 operatorIndex = _operatorAllocation.operatorIndex;
+
+        if (
+            _operatorAllocation.pubkeys.length != _operatorAllocation.withdrawalAmounts.length
+                || _operatorAllocation.pubkeys.length != _operatorAllocation.reservedExitAmounts.length
+        ) {
+            revert InvalidELExitETHAllocationLength();
+        }
+
+        OperatorsV3.Operator storage operator = OperatorsV3.get(operatorIndex);
+        if (!operator.active) {
+            revert InactiveOperator(operatorIndex);
+        }
+
+        for (uint256 j = 0; j < _operatorAllocation.reservedExitAmounts.length; ++j) {
+            uint64 withdrawalAmount = _operatorAllocation.withdrawalAmounts[j];
+            uint64 reservedExitAmount = _operatorAllocation.reservedExitAmounts[j];
+            // The reserved amount feeds the per-operator headroom cap, so it must always be a positive
+            // value within the allowed bound — for both partial and full exits.
+            if (reservedExitAmount == 0 || reservedExitAmount > MAX_EL_EXIT_AMOUNT_GWEI) {
+                revert InvalidELExitETHAllocationAmount(operatorIndex, withdrawalAmount, reservedExitAmount);
+            }
+            // A non-zero wire amount denotes a partial exit, which must withdraw exactly what it reserves.
+            // A zero wire amount denotes a full exit, whose reserved value is the projected balance.
+            if (withdrawalAmount != 0 && withdrawalAmount != reservedExitAmount) {
+                revert ELExitReservedWithdrawalMismatch(operatorIndex, withdrawalAmount, reservedExitAmount);
+            }
+            elExitAmount += uint256(reservedExitAmount) * 1 gwei;
+        }
+
+        _reserveOperatorExit(operator, operatorIndex, elExitAmount, true);
+
+        feePaid = _maxFeePerWithdrawal * _operatorAllocation.pubkeys.length;
+        _withdraw.withdraw{value: feePaid}(
+            _operatorAllocation.pubkeys, _operatorAllocation.withdrawalAmounts, _maxFeePerWithdrawal, msg.sender
+        );
+        emit RequestedELETHExits(
+            operatorIndex,
+            _operatorAllocation.pubkeys,
+            _operatorAllocation.withdrawalAmounts,
+            _operatorAllocation.reservedExitAmounts
+        );
     }
 
     /// @notice Internal utility to reserve an exit against an operator's available ETH.

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -34,7 +34,17 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
 
     uint256 private constant MIN_ETH_AMOUNT = 1 ether;
 
+    // The maximum effective validator balance (MaxEB) under EIP-7251. A full exit's reserved amount
+    // (the projected total balance) cannot exceed this.
     uint64 private constant MAX_EL_EXIT_AMOUNT_GWEI = 2_048_000_000_000; // 2048 ETH
+
+    // The minimum balance an active validator must retain (the activation floor). A full exit's reserved
+    // projected balance cannot realistically be below this for an active validator.
+    uint64 private constant MIN_VALIDATOR_BALANCE_GWEI = 32_000_000_000; // 32 ETH
+
+    // A partial withdrawal cannot drop a validator below the activation floor, so the most it can wire
+    // (and reserve) is MaxEB minus the 32 ETH floor.
+    uint64 private constant MAX_PARTIAL_EL_EXIT_AMOUNT_GWEI = 2_016_000_000_000; // 2048 - 32 ETH
 
     /// @inheritdoc IOperatorsRegistryV1
     function initOperatorsRegistryV1(address _admin, address _river) external init(0) {
@@ -438,16 +448,25 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
         for (uint256 j = 0; j < _operatorAllocation.reservedExitAmounts.length; ++j) {
             uint64 withdrawalAmount = _operatorAllocation.withdrawalAmounts[j];
             uint64 reservedExitAmount = _operatorAllocation.reservedExitAmounts[j];
-            // The reserved amount feeds the per-operator headroom cap, so it must always be a positive
-            // value within the allowed bound — for both partial and full exits.
-            if (reservedExitAmount == 0 || reservedExitAmount > MAX_EL_EXIT_AMOUNT_GWEI) {
-                revert InvalidELExitETHAllocationAmount(operatorIndex, withdrawalAmount, reservedExitAmount);
-            }
-            // A non-zero wire amount denotes a partial exit, which must withdraw exactly what it reserves.
-            // A zero wire amount denotes a full exit. In that case the reserved value is keeper-supplied
-            // accounting data (typically the projected balance) and is not validated on-chain.
-            if (withdrawalAmount != 0 && withdrawalAmount != reservedExitAmount) {
-                revert ELExitReservedWithdrawalMismatch(operatorIndex, withdrawalAmount, reservedExitAmount);
+            // The reserved amount feeds the per-operator headroom cap, so it must always sit within the
+            // bound that matches the kind of exit. The bound differs for full vs partial exits.
+            if (withdrawalAmount == 0) {
+                // A zero wire amount denotes a full exit. Its reserved value is keeper-supplied accounting
+                // data (typically the projected balance) and is not validated against the real balance here,
+                // but for an active validator it lies within [32 ETH activation floor, 2048 ETH MaxEB].
+                if (reservedExitAmount < MIN_VALIDATOR_BALANCE_GWEI || reservedExitAmount > MAX_EL_EXIT_AMOUNT_GWEI) {
+                    revert InvalidELExitETHAllocationAmount(operatorIndex, withdrawalAmount, reservedExitAmount);
+                }
+            } else {
+                // A non-zero wire amount denotes a partial exit. It cannot drop the validator below the
+                // 32 ETH activation floor, so the wire value is bounded by MaxEB - 32 ETH, and it must
+                // reserve exactly what it withdraws.
+                if (reservedExitAmount == 0 || reservedExitAmount > MAX_PARTIAL_EL_EXIT_AMOUNT_GWEI) {
+                    revert InvalidELExitETHAllocationAmount(operatorIndex, withdrawalAmount, reservedExitAmount);
+                }
+                if (withdrawalAmount != reservedExitAmount) {
+                    revert ELExitReservedWithdrawalMismatch(operatorIndex, withdrawalAmount, reservedExitAmount);
+                }
             }
             elExitAmount += uint256(reservedExitAmount) * 1 gwei;
         }

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -422,7 +422,6 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
     }
 
     /// @notice Validates a single operator's EL exit allocation, reserves it, triggers the withdrawal and emits.
-    ///      otherwise hits "stack too deep" when compiled without `viaIR`, e.g. under `forge coverage`).
     /// @return elExitAmount The total reserved exit amount (wei) for this operator
     /// @return feePaid The withdrawal fee paid for this operator
     function _requestSingleELETHExit(

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -404,8 +404,8 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
             }
 
             if (
-                _elAllocations[i].pubkeys.length != _elAllocations[i].isFullExit.length
-                    || _elAllocations[i].pubkeys.length != _elAllocations[i].amounts.length
+                _elAllocations[i].pubkeys.length != _elAllocations[i].withdrawalAmounts.length
+                    || _elAllocations[i].pubkeys.length != _elAllocations[i].reservedExitAmounts.length
             ) {
                 revert InvalidELExitETHAllocationLength();
             }
@@ -416,27 +416,35 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
             }
 
             uint256 elExitAmount;
-            uint64[] memory cachedAmounts = _elAllocations[i].amounts;
-            for (uint256 j = 0; j < _elAllocations[i].amounts.length; ++j) {
-                uint64 amount = _elAllocations[i].amounts[j];
-                bool isFullExit = _elAllocations[i].isFullExit[j];
-                if (amount == 0 || amount > MAX_EL_EXIT_AMOUNT_GWEI) {
-                    revert InvalidELExitETHAllocationAmount(operatorIndex, isFullExit, amount);
+            for (uint256 j = 0; j < _elAllocations[i].reservedExitAmounts.length; ++j) {
+                uint64 withdrawalAmount = _elAllocations[i].withdrawalAmounts[j];
+                uint64 reservedExitAmount = _elAllocations[i].reservedExitAmounts[j];
+                // The reserved amount feeds the per-operator headroom cap, so it must always be a positive
+                // value within the allowed bound — for both partial and full exits.
+                if (reservedExitAmount == 0 || reservedExitAmount > MAX_EL_EXIT_AMOUNT_GWEI) {
+                    revert InvalidELExitETHAllocationAmount(operatorIndex, withdrawalAmount, reservedExitAmount);
                 }
-                elExitAmount += uint256(amount) * 1 gwei;
-                if (isFullExit) {
-                    cachedAmounts[j] = 0;
+                // A non-zero wire amount denotes a partial exit, which must withdraw exactly what it reserves.
+                // A zero wire amount denotes a full exit, whose reserved value is the projected balance.
+                if (withdrawalAmount != 0 && withdrawalAmount != reservedExitAmount) {
+                    revert ELExitReservedWithdrawalMismatch(operatorIndex, withdrawalAmount, reservedExitAmount);
                 }
+                elExitAmount += uint256(reservedExitAmount) * 1 gwei;
             }
 
             _reserveOperatorExit(operator, operatorIndex, elExitAmount, true);
             requestedETHAmount += elExitAmount;
 
             withdraw.withdraw{value: _maxFeePerWithdrawal * _elAllocations[i].pubkeys.length}(
-                _elAllocations[i].pubkeys, cachedAmounts, _maxFeePerWithdrawal, msg.sender
+                _elAllocations[i].pubkeys, _elAllocations[i].withdrawalAmounts, _maxFeePerWithdrawal, msg.sender
             );
             totalFeePaid += _maxFeePerWithdrawal * _elAllocations[i].pubkeys.length;
-            emit RequestedELETHExits(operatorIndex, _elAllocations[i].pubkeys, _elAllocations[i].amounts);
+            emit RequestedELETHExits(
+                operatorIndex,
+                _elAllocations[i].pubkeys,
+                _elAllocations[i].withdrawalAmounts,
+                _elAllocations[i].reservedExitAmounts
+            );
         }
         if (requestedETHAmount > _remainingETHExitsDemand) {
             revert ExitsGreaterThanExitDemand(requestedETHAmount, _remainingETHExitsDemand);

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -446,6 +446,7 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
             // A non-zero wire amount denotes a partial exit, which must withdraw exactly what it reserves.
             // A zero wire amount denotes a full exit. In that case the reserved value is keeper-supplied
             // accounting data (typically the projected balance) and is not validated on-chain.
+            if (withdrawalAmount != 0 && withdrawalAmount != reservedExitAmount) {
                 revert ELExitReservedWithdrawalMismatch(operatorIndex, withdrawalAmount, reservedExitAmount);
             }
             elExitAmount += uint256(reservedExitAmount) * 1 gwei;

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -422,7 +422,6 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
     }
 
     /// @notice Validates a single operator's EL exit allocation, reserves it, triggers the withdrawal and emits.
-    /// @dev Split out of `_requestELETHExits` to keep the per-operator locals off the caller's stack (the loop
     ///      otherwise hits "stack too deep" when compiled without `viaIR`, e.g. under `forge coverage`).
     /// @return elExitAmount The total reserved exit amount (wei) for this operator
     /// @return feePaid The withdrawal fee paid for this operator

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -412,7 +412,7 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
             }
 
             (uint256 elExitAmount, uint256 feePaid) =
-                _requestSingleELETHExit(withdraw, _elAllocations[i], _maxFeePerWithdrawal);
+                _requestOperatorELETHExits(withdraw, _elAllocations[i], _maxFeePerWithdrawal);
             requestedETHAmount += elExitAmount;
             totalFeePaid += feePaid;
         }
@@ -424,7 +424,7 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
     /// @notice Validates a single operator's EL exit allocation, reserves it, triggers the withdrawal and emits.
     /// @return elExitAmount The total reserved exit amount (wei) for this operator
     /// @return feePaid The withdrawal fee paid for this operator
-    function _requestELETHExits(
+    function _requestOperatorELETHExits(
         IWithdrawV1 _withdraw,
         ELExitETHAllocation calldata _operatorAllocation,
         uint256 _maxFeePerWithdrawal

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -226,7 +226,7 @@ interface IOperatorsRegistryV1 {
 
     /// @notice Thrown when a partial EL exit's wire amount does not match its reserved accounting amount.
     ///         Partial exits (withdrawalAmount != 0) must wire exactly what they reserve; only full exits
-    ///         (withdrawalAmount == 0) are allowed to differ from the reserved projected balance.
+    ///         (withdrawalAmount == 0) are allowed to differ from the reserved (keeper-supplied) accounting amount.
     /// @param operatorIndex The operator index
     /// @param withdrawalAmount The wire amount (gwei) for this pubkey
     /// @param reservedExitAmount The reserved accounting amount (gwei) for this pubkey

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -30,13 +30,16 @@ interface IOperatorsRegistryV1 {
     /// @notice Structure representing an EL exit allocation for exits
     /// @param operatorIndex The index of the operator
     /// @param pubkeys The pubkeys through which the EL exits were requested
-    /// @param amounts The amounts (gwei) per pubkey that was requested for EL exits
-    /// @param isFullExit True if the EL exit is a full exit for each pubkey
+    /// @param withdrawalAmounts The wire amount (gwei) sent to the EIP-7002 withdrawal predeploy per pubkey.
+    ///                          0 signals a full exit; any non-zero value is a partial withdrawal.
+    /// @param reservedExitAmounts The accounting amount (gwei) reserved against the operator's exit headroom
+    ///                            per pubkey. Always set: for partial exits it equals the matching
+    ///                            withdrawalAmount; for full exits it is the keeper-supplied projected balance.
     struct ELExitETHAllocation {
         uint256 operatorIndex;
         bytes[] pubkeys; // 48 bytes
-        uint64[] amounts; // gwei, actual balance for full exits
-        bool[] isFullExit; // true if the EL exit is a full exit for each pubkey
+        uint64[] withdrawalAmounts; // gwei, wire value to the predeploy; 0 == full exit
+        uint64[] reservedExitAmounts; // gwei, accounting value reserved against headroom; always set
     }
 
     /// @notice Structure representing a per-operator funded ETH update
@@ -92,8 +95,11 @@ interface IOperatorsRegistryV1 {
     /// @notice The amount of ETH(gwei) that has been requested to be exited per pubkey via EL
     /// @param index The operator index
     /// @param pubkeys The pubkeys through which the EL exits were requested
-    /// @param amounts The amount per pubkey that was requested for EL exits (for full exits it is the actual balance)
-    event RequestedELETHExits(uint256 indexed index, bytes[] pubkeys, uint64[] amounts);
+    /// @param withdrawalAmounts The wire amount (gwei) sent to the predeploy per pubkey (0 for full exits)
+    /// @param reservedExitAmounts The accounting amount (gwei) reserved against headroom per pubkey
+    event RequestedELETHExits(
+        uint256 indexed index, bytes[] pubkeys, uint64[] withdrawalAmounts, uint64[] reservedExitAmounts
+    );
 
     /// @notice The exit request demand has been updated
     /// @param previousETHExitsDemand The previous exit request demand in ETH(wei)
@@ -212,11 +218,19 @@ interface IOperatorsRegistryV1 {
     /// @param ethAmount The incorrect ETH(wei) amount
     error AllocationWithIncorrectAmount(uint256 ethAmount);
 
-    /// @notice Thrown when an EL exit allocation amount is invalid (e.g. zero or above the allowed cap)
+    /// @notice Thrown when an EL exit allocation's reserved amount is invalid (zero or above the allowed cap)
     /// @param operatorIndex The operator index
-    /// @param isFullExit True if the EL exit allocation is marked as a full exit for this pubkey
-    /// @param amount The EL exit accounting amount in gwei
-    error InvalidELExitETHAllocationAmount(uint256 operatorIndex, bool isFullExit, uint64 amount);
+    /// @param withdrawalAmount The wire amount (gwei) for this pubkey (0 for full exits)
+    /// @param reservedExitAmount The reserved accounting amount (gwei) for this pubkey
+    error InvalidELExitETHAllocationAmount(uint256 operatorIndex, uint64 withdrawalAmount, uint64 reservedExitAmount);
+
+    /// @notice Thrown when a partial EL exit's wire amount does not match its reserved accounting amount.
+    ///         Partial exits (withdrawalAmount != 0) must wire exactly what they reserve; only full exits
+    ///         (withdrawalAmount == 0) are allowed to differ from the reserved projected balance.
+    /// @param operatorIndex The operator index
+    /// @param withdrawalAmount The wire amount (gwei) for this pubkey
+    /// @param reservedExitAmount The reserved accounting amount (gwei) for this pubkey
+    error ELExitReservedWithdrawalMismatch(uint256 operatorIndex, uint64 withdrawalAmount, uint64 reservedExitAmount);
 
     /// @notice Thrown when the provided active CL ETH array length does not match the operator count
     error InvalidActiveCLETHArrayLength();
@@ -249,7 +263,7 @@ interface IOperatorsRegistryV1 {
     /// @param excess The excess fee
     error UnsentRefund(address sender, uint256 excess);
 
-    /// @notice Thrown when an EL exit allocation has mismatched pubkeys/amounts/isFullExit lengths
+    /// @notice Thrown when an EL exit allocation has mismatched pubkeys/withdrawalAmounts/reservedExitAmounts lengths
     error InvalidELExitETHAllocationLength();
 
     /// @notice Thrown when the total EL exit amount requested is greater than the remaining exit demand

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -218,7 +218,9 @@ interface IOperatorsRegistryV1 {
     /// @param ethAmount The incorrect ETH(wei) amount
     error AllocationWithIncorrectAmount(uint256 ethAmount);
 
-    /// @notice Thrown when an EL exit allocation's reserved amount is invalid (zero or above the allowed cap)
+    /// @notice Thrown when an EL exit allocation's reserved amount falls outside the bounds for its exit kind.
+    ///         Full exits (withdrawalAmount == 0) must reserve within [32 ETH, 2048 ETH]; partial exits
+    ///         (withdrawalAmount != 0) must reserve within (0, 2016 ETH] (MaxEB minus the 32 ETH floor).
     /// @param operatorIndex The operator index
     /// @param withdrawalAmount The wire amount (gwei) for this pubkey (0 for full exits)
     /// @param reservedExitAmount The reserved accounting amount (gwei) for this pubkey

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -34,7 +34,7 @@ interface IOperatorsRegistryV1 {
     ///                          0 signals a full exit; any non-zero value is a partial withdrawal.
     /// @param reservedExitAmounts The accounting amount (gwei) reserved against the operator's exit headroom
     ///                            per pubkey. Always set: for partial exits it equals the matching
-    ///                            withdrawalAmount; for full exits it is the keeper-supplied projected balance.
+    ///                            withdrawalAmounts[i]; for full exits it should be the keeper-supplied projected balance (not validated on-chain).
     struct ELExitETHAllocation {
         uint256 operatorIndex;
         bytes[] pubkeys; // 48 bytes

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -2232,6 +2232,11 @@ contract OperatorsRegistryV1ELExitTests is Test {
 
     // 8 ETH expressed in gwei — must be a multiple of 1 gwei (1e9) to pass the % check
     uint64 internal constant EIGHT_ETH_IN_GWEI = 8_000_000_000;
+    // 32 ETH expressed in gwei — the activation floor / minimum reserved amount for a full exit
+    uint64 internal constant THIRTY_TWO_ETH_IN_GWEI = 32_000_000_000;
+    // 2048 ETH (MaxEB) and 2016 ETH (MaxEB - 32 ETH floor) expressed in gwei — the full / partial reserved caps
+    uint64 internal constant MAX_EL_EXIT_AMOUNT_GWEI = 2_048_000_000_000;
+    uint64 internal constant MAX_PARTIAL_EL_EXIT_AMOUNT_GWEI = 2_016_000_000_000;
     // 48-byte placeholder pubkey
     bytes internal constant PUBKEY_48 =
         hex"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -2436,17 +2441,18 @@ contract OperatorsRegistryV1ELExitTests is Test {
         reg.sudoSetFundedV3(0, 32 ether);
         reg.sudoSetActiveCLETH(0, 32 ether);
         vm.prank(river);
-        reg.demandETHExits(8 ether, 32 ether);
+        reg.demandETHExits(32 ether, 32 ether);
 
         IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
-        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, EIGHT_ETH_IN_GWEI);
+        // Full exit reserving the 32 ETH activation-floor projected balance (the minimum allowed for a full exit).
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, THIRTY_TWO_ETH_IN_GWEI);
 
         vm.prank(keeper);
         reg.requestETHExits(empty, allocs, 0);
 
-        assertEq(reg.getOperator(0).requestedExits, 8 ether, "full exit reserves outstanding demand");
+        assertEq(reg.getOperator(0).requestedExits, 32 ether, "full exit reserves outstanding demand");
         assertEq(reg.getCurrentETHExitsDemand(), 0, "demand satisfied for full exit");
-        assertEq(reg.getTotalETHExitsRequested(), 8 ether, "total exits updated for full exit");
+        assertEq(reg.getTotalETHExitsRequested(), 32 ether, "total exits updated for full exit");
         assertEq(mockWithdraw.withdrawCallCount(), 1, "withdraw should be called once");
         assertEq(mockWithdraw.lastAmountsLength(), 1, "one amount forwarded");
         assertEq(mockWithdraw.lastAmounts(0), 0, "forwarded amount should be 0 (full exit)");
@@ -2574,17 +2580,17 @@ contract OperatorsRegistryV1ELExitTests is Test {
         reg.sudoSetFundedV3(0, 32 ether);
         reg.sudoSetActiveCLETH(0, 32 ether);
         vm.prank(river);
-        reg.demandETHExits(8 ether, 32 ether);
+        reg.demandETHExits(32 ether, 32 ether);
 
         IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
-        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, EIGHT_ETH_IN_GWEI);
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, THIRTY_TWO_ETH_IN_GWEI);
 
         vm.prank(keeper);
         reg.requestETHExits(empty, allocs, 0);
 
-        assertEq(reg.getOperator(0).requestedExits, 8 ether, "full exit should reserve the demanded ETH");
+        assertEq(reg.getOperator(0).requestedExits, 32 ether, "full exit should reserve the demanded ETH");
         assertEq(reg.getCurrentETHExitsDemand(), 0, "full exit should satisfy outstanding exit demand");
-        assertEq(reg.getTotalETHExitsRequested(), 8 ether, "full exit should update total requested exits");
+        assertEq(reg.getTotalETHExitsRequested(), 32 ether, "full exit should update total requested exits");
     }
 
     /// An allocation whose pubkeys/withdrawalAmounts/reservedExitAmounts arrays have mismatched lengths must revert.
@@ -2799,15 +2805,15 @@ contract OperatorsRegistryV1ELExitTests is Test {
     /// A full exit (wire amount 0) reserves its projected balance and forwards 0 to the predeploy,
     /// even when the reserved projected balance differs from any partial wire value.
     function testELExitFullExitReservesProjectedAndForwardsZero() public {
-        _setupSingleOperator(32 ether, 32 ether, 8 ether);
+        _setupSingleOperator(32 ether, 32 ether, 32 ether);
 
         IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
-        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, EIGHT_ETH_IN_GWEI);
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, THIRTY_TWO_ETH_IN_GWEI);
 
         vm.prank(keeper);
         reg.requestETHExits(empty, allocs, 0);
 
-        assertEq(reg.getOperator(0).requestedExits, 8 ether, "full exit reserves the projected balance");
+        assertEq(reg.getOperator(0).requestedExits, 32 ether, "full exit reserves the projected balance");
         assertEq(reg.getCurrentETHExitsDemand(), 0, "demand satisfied by the reserved projected balance");
         assertEq(mockWithdraw.lastAmounts(0), 0, "wire amount forwarded for a full exit should be 0");
     }
@@ -2861,5 +2867,87 @@ contract OperatorsRegistryV1ELExitTests is Test {
             keeperBalanceBefore - actualFee * totalPubkeys,
             "keeper only spends the actual fees after all refunds"
         );
+    }
+
+    /// A full exit (wire 0) whose reserved projected balance is below the 32 ETH activation floor must revert.
+    function testELExitRevertsWhenFullExitBelowActivationFloor() public {
+        _setupSingleOperator(32 ether, 32 ether, 8 ether);
+
+        IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
+        uint64 belowFloor = THIRTY_TWO_ETH_IN_GWEI - 1; // one gwei under the 32 ETH floor
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, belowFloor);
+
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector, uint256(0), uint64(0), belowFloor
+            )
+        );
+        reg.requestETHExits(empty, allocs, 0);
+    }
+
+    /// A full exit reserving exactly the 2048 ETH MaxEB is the upper boundary and must be accepted.
+    function testELExitAcceptsFullExitAtMaxEffectiveBalance() public {
+        _setupSingleOperator(2048 ether, 2048 ether, 2048 ether);
+
+        IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, MAX_EL_EXIT_AMOUNT_GWEI);
+
+        vm.prank(keeper);
+        reg.requestETHExits(empty, allocs, 0);
+
+        assertEq(reg.getOperator(0).requestedExits, 2048 ether, "full exit reserves the MaxEB projected balance");
+        assertEq(reg.getCurrentETHExitsDemand(), 0, "demand satisfied at the MaxEB boundary");
+    }
+
+    /// A full exit reserving one gwei above the 2048 ETH MaxEB must revert.
+    function testELExitRevertsWhenFullExitExceedsMaxEffectiveBalance() public {
+        _setupSingleOperator(2048 ether, 2048 ether, 2048 ether);
+
+        IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
+        uint64 overMaxEB = MAX_EL_EXIT_AMOUNT_GWEI + 1;
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, overMaxEB);
+
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector, uint256(0), uint64(0), overMaxEB
+            )
+        );
+        reg.requestETHExits(empty, allocs, 0);
+    }
+
+    /// A partial exit reserving exactly MaxEB - 32 ETH (2016 ETH) is the upper boundary and must be accepted.
+    function testELExitAcceptsPartialAtMaxPartialCap() public {
+        _setupSingleOperator(2048 ether, 2048 ether, 2016 ether);
+
+        IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeELAlloc(0, MAX_PARTIAL_EL_EXIT_AMOUNT_GWEI);
+
+        vm.prank(keeper);
+        reg.requestETHExits(empty, allocs, 0);
+
+        assertEq(reg.getOperator(0).requestedExits, 2016 ether, "partial exit reserves up to the 2016 ETH cap");
+        assertEq(mockWithdraw.lastAmounts(0), MAX_PARTIAL_EL_EXIT_AMOUNT_GWEI, "wire amount forwarded at the cap");
+    }
+
+    /// A partial exit reserving one gwei above MaxEB - 32 ETH (2016 ETH) must revert.
+    function testELExitRevertsWhenPartialExceedsMaxPartialCap() public {
+        _setupSingleOperator(2048 ether, 2048 ether, 2048 ether);
+
+        IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
+        uint64 overPartialCap = MAX_PARTIAL_EL_EXIT_AMOUNT_GWEI + 1;
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeELAlloc(0, overPartialCap);
+
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector,
+                uint256(0),
+                overPartialCap,
+                overPartialCap
+            )
+        );
+        reg.requestETHExits(empty, allocs, 0);
     }
 }

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -2811,4 +2811,55 @@ contract OperatorsRegistryV1ELExitTests is Test {
         assertEq(reg.getCurrentETHExitsDemand(), 0, "demand satisfied by the reserved projected balance");
         assertEq(mockWithdraw.lastAmounts(0), 0, "wire amount forwarded for a full exit should be 0");
     }
+
+    /// Two operators exited in a single call exercise the per-operator loop: the reserved amounts
+    /// and forwarded fees must accumulate correctly across iterations (one withdrawal per operator).
+    function testELExitAccumulatesReservesAndFeesAcrossMultipleOperators() public {
+        uint256 actualFee = 1 gwei;
+        uint256 maxFee = 5 gwei;
+        _useWithdrawContract(actualFee);
+
+        vm.startPrank(admin);
+        reg.addOperator("Op0", makeAddr("op0addr"));
+        reg.addOperator("Op1", makeAddr("op1addr"));
+        vm.stopPrank();
+        reg.sudoSetFundedV3(0, 32 ether);
+        reg.sudoSetFundedV3(1, 32 ether);
+        reg.sudoSetActiveCLETH(0, 32 ether);
+        reg.sudoSetActiveCLETH(1, 32 ether);
+        vm.prank(river);
+        reg.demandETHExits(16 ether, 64 ether);
+
+        IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
+        // Ordered, single-pubkey partial exits for two distinct operators.
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = new IOperatorsRegistryV1.ELExitETHAllocation[](2);
+        allocs[0] = _makeELAlloc(0, EIGHT_ETH_IN_GWEI)[0];
+        allocs[1] = _makeELAlloc(1, EIGHT_ETH_IN_GWEI)[0];
+
+        // totalFeePaid = maxFee * (pubkeys0 + pubkeys1); send extra so the registry-level refund also runs.
+        uint256 totalPubkeys = 2;
+        uint256 valueSent = maxFee * totalPubkeys + 3 gwei;
+        vm.deal(keeper, valueSent);
+        uint256 keeperBalanceBefore = keeper.balance;
+
+        vm.prank(keeper);
+        reg.requestETHExits{value: valueSent}(empty, allocs, maxFee);
+
+        // requestedETHAmount accumulated across both operators.
+        assertEq(reg.getOperator(0).requestedExits, 8 ether, "op0 reserves its EL amount");
+        assertEq(reg.getOperator(1).requestedExits, 8 ether, "op1 reserves its EL amount");
+        assertEq(reg.getCurrentETHExitsDemand(), 0, "combined exits satisfy the 16 ETH demand");
+        assertEq(reg.getTotalETHExitsRequested(), 16 ether, "total requested is the sum of both operators");
+
+        // totalFeePaid accumulated across both operators: only the actual per-withdrawal fee is spent;
+        // each withdrawal's excess and the registry-level excess are refunded to the keeper.
+        assertEq(pectraWithdrawal.balance, actualFee * totalPubkeys, "actual fee paid for each withdrawal");
+        assertEq(address(withdrawContract).balance, 0, "withdraw retains no excess");
+        assertEq(address(reg).balance, 0, "registry retains no excess");
+        assertEq(
+            keeper.balance,
+            keeperBalanceBefore - actualFee * totalPubkeys,
+            "keeper only spends the actual fees after all refunds"
+        );
+    }
 }

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -2272,7 +2272,26 @@ contract OperatorsRegistryV1ELExitTests is Test {
         reg.sudoSetWithdrawAddress(address(withdrawContract));
     }
 
+    /// Build a single-pubkey partial EL exit: the wire amount equals the reserved amount.
     function _makeELAlloc(uint256 opIndex, uint64 gweiAmount)
+        internal
+        pure
+        returns (IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs)
+    {
+        return _makeELAllocWithAmounts(opIndex, gweiAmount, gweiAmount);
+    }
+
+    /// Build a single-pubkey full EL exit: the wire amount is 0 and the reserved amount is the projected balance.
+    function _makeFullELAlloc(uint256 opIndex, uint64 reservedGweiAmount)
+        internal
+        pure
+        returns (IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs)
+    {
+        return _makeELAllocWithAmounts(opIndex, 0, reservedGweiAmount);
+    }
+
+    /// Build a single-pubkey EL exit with explicit wire and reserved amounts.
+    function _makeELAllocWithAmounts(uint256 opIndex, uint64 withdrawalGwei, uint64 reservedGwei)
         internal
         pure
         returns (IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs)
@@ -2280,22 +2299,16 @@ contract OperatorsRegistryV1ELExitTests is Test {
         allocs = new IOperatorsRegistryV1.ELExitETHAllocation[](1);
         bytes[] memory pubkeys = new bytes[](1);
         pubkeys[0] = PUBKEY_48;
-        uint64[] memory amounts = new uint64[](1);
-        amounts[0] = gweiAmount;
-        bool[] memory isFullExit = new bool[](1);
-        isFullExit[0] = false;
+        uint64[] memory withdrawalAmounts = new uint64[](1);
+        withdrawalAmounts[0] = withdrawalGwei;
+        uint64[] memory reservedExitAmounts = new uint64[](1);
+        reservedExitAmounts[0] = reservedGwei;
         allocs[0] = IOperatorsRegistryV1.ELExitETHAllocation({
-            operatorIndex: opIndex, pubkeys: pubkeys, amounts: amounts, isFullExit: isFullExit
+            operatorIndex: opIndex,
+            pubkeys: pubkeys,
+            withdrawalAmounts: withdrawalAmounts,
+            reservedExitAmounts: reservedExitAmounts
         });
-    }
-
-    function _makeFullELAlloc(uint256 opIndex, uint64 accountingGweiAmount)
-        internal
-        pure
-        returns (IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs)
-    {
-        allocs = _makeELAlloc(opIndex, accountingGweiAmount);
-        allocs[0].isFullExit[0] = true;
     }
 
     /// Happy path: partial exit reduces demand and updates requestedExits.
@@ -2356,13 +2369,11 @@ contract OperatorsRegistryV1ELExitTests is Test {
         pubkeys[0] = PUBKEY_48;
         uint64[] memory amounts = new uint64[](1);
         amounts[0] = EIGHT_ETH_IN_GWEI;
-        bool[] memory isFullExit = new bool[](1);
-        isFullExit[0] = false;
         allocs[0] = IOperatorsRegistryV1.ELExitETHAllocation({
-            operatorIndex: 1, pubkeys: pubkeys, amounts: amounts, isFullExit: isFullExit
+            operatorIndex: 1, pubkeys: pubkeys, withdrawalAmounts: amounts, reservedExitAmounts: amounts
         });
         allocs[1] = IOperatorsRegistryV1.ELExitETHAllocation({
-            operatorIndex: 0, pubkeys: pubkeys, amounts: amounts, isFullExit: isFullExit
+            operatorIndex: 0, pubkeys: pubkeys, withdrawalAmounts: amounts, reservedExitAmounts: amounts
         });
 
         vm.prank(keeper);
@@ -2401,9 +2412,11 @@ contract OperatorsRegistryV1ELExitTests is Test {
 
         IOperatorsRegistryV1.ExitETHAllocation[] memory emptyFull = new IOperatorsRegistryV1.ExitETHAllocation[](0);
         IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = new IOperatorsRegistryV1.ELExitETHAllocation[](1);
-        bool[] memory isFullExit = new bool[](0);
         allocs[0] = IOperatorsRegistryV1.ELExitETHAllocation({
-            operatorIndex: 0, pubkeys: new bytes[](0), amounts: new uint64[](0), isFullExit: isFullExit
+            operatorIndex: 0,
+            pubkeys: new bytes[](0),
+            withdrawalAmounts: new uint64[](0),
+            reservedExitAmounts: new uint64[](0)
         });
 
         vm.prank(keeper);
@@ -2411,11 +2424,11 @@ contract OperatorsRegistryV1ELExitTests is Test {
         reg.requestETHExits(emptyFull, allocs, 0);
     }
 
-    // ── Tests for the per-pubkey EL exit amounts (each amount is converted from gwei to wei and summed) ──
-    // Partial and full exits reserve the provided gwei amount. Full exits are flagged explicitly
-    // and forwarded to the withdrawal contract with amount 0.
+    // ── Tests for the per-pubkey EL exit amounts (each reserved amount is converted from gwei to wei and summed) ──
+    // Partial and full exits both reserve the provided gwei amount. A full exit is signalled by a wire
+    // (withdrawal) amount of 0, while its reserved amount carries the projected balance.
 
-    /// A full-exit flag reserves the provided accounting amount, yet the request is still
+    /// A full exit (wire amount 0) reserves the provided projected amount, yet the request is still
     /// forwarded to the withdrawal contract with amount 0.
     function testELExitAcceptsFullExitAndForwardsZeroAmount() public {
         vm.prank(admin);
@@ -2479,11 +2492,8 @@ contract OperatorsRegistryV1ELExitTests is Test {
         uint64[] memory amounts = new uint64[](2);
         amounts[0] = EIGHT_ETH_IN_GWEI; // 8 ether
         amounts[1] = 1; // 1 gwei
-        bool[] memory isFullExit = new bool[](2);
-        isFullExit[0] = false;
-        isFullExit[1] = false;
         allocs[0] = IOperatorsRegistryV1.ELExitETHAllocation({
-            operatorIndex: 0, pubkeys: pubkeys, amounts: amounts, isFullExit: isFullExit
+            operatorIndex: 0, pubkeys: pubkeys, withdrawalAmounts: amounts, reservedExitAmounts: amounts
         });
 
         vm.prank(keeper);
@@ -2505,13 +2515,13 @@ contract OperatorsRegistryV1ELExitTests is Test {
         reg.demandETHExits(8 ether, 32 ether);
 
         IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
-        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeELAlloc(0, 0);
-        allocs[0].isFullExit[0] = true;
+        // Full exit (wire amount 0) whose reserved projected balance is also 0 — invalid, must reserve a positive amount.
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, 0);
 
         vm.prank(keeper);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector, uint256(0), true, uint64(0)
+                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector, uint256(0), uint64(0), uint64(0)
             )
         );
         reg.requestETHExits(empty, allocs, 0);
@@ -2526,12 +2536,13 @@ contract OperatorsRegistryV1ELExitTests is Test {
         reg.demandETHExits(8 ether, 32 ether);
 
         IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
-        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeELAlloc(0, 0);
+        // Partial exit (non-zero wire amount) whose reserved accounting amount is 0 — invalid, must reserve.
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeELAllocWithAmounts(0, EIGHT_ETH_IN_GWEI, 0);
 
         vm.prank(keeper);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector, uint256(0), false, uint64(0)
+                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector, uint256(0), EIGHT_ETH_IN_GWEI, uint64(0)
             )
         );
         reg.requestETHExits(empty, allocs, 0);
@@ -2576,7 +2587,7 @@ contract OperatorsRegistryV1ELExitTests is Test {
         assertEq(reg.getTotalETHExitsRequested(), 8 ether, "full exit should update total requested exits");
     }
 
-    /// An allocation whose pubkeys/amounts/isFullExit arrays have mismatched lengths must revert.
+    /// An allocation whose pubkeys/withdrawalAmounts/reservedExitAmounts arrays have mismatched lengths must revert.
     function testELExitRevertsOnMismatchedArrayLengths() public {
         vm.prank(admin);
         reg.addOperator("Op0", makeAddr("op0addr"));
@@ -2592,10 +2603,8 @@ contract OperatorsRegistryV1ELExitTests is Test {
         pubkeys[1] = PUBKEY_48;
         uint64[] memory amounts = new uint64[](1); // but only 1 amount
         amounts[0] = EIGHT_ETH_IN_GWEI;
-        bool[] memory isFullExit = new bool[](1);
-        isFullExit[0] = false;
         allocs[0] = IOperatorsRegistryV1.ELExitETHAllocation({
-            operatorIndex: 0, pubkeys: pubkeys, amounts: amounts, isFullExit: isFullExit
+            operatorIndex: 0, pubkeys: pubkeys, withdrawalAmounts: amounts, reservedExitAmounts: amounts
         });
 
         vm.prank(keeper);
@@ -2619,7 +2628,7 @@ contract OperatorsRegistryV1ELExitTests is Test {
         vm.prank(keeper);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector, uint256(0), false, overCap
+                IOperatorsRegistryV1.InvalidELExitETHAllocationAmount.selector, uint256(0), overCap, overCap
             )
         );
         reg.requestETHExits(empty, allocs, 0);
@@ -2757,9 +2766,49 @@ contract OperatorsRegistryV1ELExitTests is Test {
         IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeELAlloc(0, EIGHT_ETH_IN_GWEI);
 
         vm.expectEmit(true, false, false, true, address(reg));
-        emit IOperatorsRegistryV1.RequestedELETHExits(0, allocs[0].pubkeys, allocs[0].amounts);
+        emit IOperatorsRegistryV1.RequestedELETHExits(
+            0, allocs[0].pubkeys, allocs[0].withdrawalAmounts, allocs[0].reservedExitAmounts
+        );
 
         vm.prank(keeper);
         reg.requestETHExits(empty, allocs, 0);
+    }
+
+    /// A partial exit (non-zero wire amount) whose wire amount differs from its reserved amount must revert.
+    function testELExitRevertsOnReservedWithdrawalMismatch() public {
+        _setupSingleOperator(32 ether, 32 ether, 8 ether);
+
+        IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
+        // wire 8 ETH but reserve only 4 ETH — a partial exit must reserve exactly what it withdraws.
+        uint64 fourEthGwei = 4_000_000_000;
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs =
+            _makeELAllocWithAmounts(0, EIGHT_ETH_IN_GWEI, fourEthGwei);
+
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOperatorsRegistryV1.ELExitReservedWithdrawalMismatch.selector,
+                uint256(0),
+                EIGHT_ETH_IN_GWEI,
+                fourEthGwei
+            )
+        );
+        reg.requestETHExits(empty, allocs, 0);
+    }
+
+    /// A full exit (wire amount 0) reserves its projected balance and forwards 0 to the predeploy,
+    /// even when the reserved projected balance differs from any partial wire value.
+    function testELExitFullExitReservesProjectedAndForwardsZero() public {
+        _setupSingleOperator(32 ether, 32 ether, 8 ether);
+
+        IOperatorsRegistryV1.ExitETHAllocation[] memory empty = new IOperatorsRegistryV1.ExitETHAllocation[](0);
+        IOperatorsRegistryV1.ELExitETHAllocation[] memory allocs = _makeFullELAlloc(0, EIGHT_ETH_IN_GWEI);
+
+        vm.prank(keeper);
+        reg.requestETHExits(empty, allocs, 0);
+
+        assertEq(reg.getOperator(0).requestedExits, 8 ether, "full exit reserves the projected balance");
+        assertEq(reg.getCurrentETHExitsDemand(), 0, "demand satisfied by the reserved projected balance");
+        assertEq(mockWithdraw.lastAmounts(0), 0, "wire amount forwarded for a full exit should be 0");
     }
 }


### PR DESCRIPTION
implements some stricter tests on values ... fixes issues https://github.com/liquid-collective/liquid-collective-protocol/issues/527

## Description

This pull request refactors and improves the handling of Ethereum Execution Layer (EL) exit allocations in the `OperatorsRegistryV1` contract and its interface and tests. The main focus is on clarifying and separating the concepts of the "wire" withdrawal amount (sent to the withdrawal contract) and the "reserved" accounting amount (used for operator exit headroom), improving validation, and updating event and error reporting. The changes enhance correctness, clarity, and test coverage for both partial and full exits.

**Core logic and interface changes:**

* The `ELExitETHAllocation` struct now uses `withdrawalAmounts` (the actual amount sent to the withdrawal contract, with 0 signaling a full exit) and `reservedExitAmounts` (the amount reserved against the operator's exit headroom, always set), replacing the previous `amounts` and `isFullExit` fields.
* Length validation and event emission in the contract are updated to use the new fields, and the logic ensures that partial exits reserve exactly what they withdraw, while full exits reserve the projected balance but wire 0. [[1]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabL407-R408) [[2]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabL419-R447)
* The `RequestedELETHExits` event and related error types are updated to reflect the new struct fields and validation logic, providing clearer and more precise error reporting. [[1]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L95-R102) [[2]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L215-R233) [[3]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L252-R266)

**Testing improvements:**

* Test helpers and test cases are refactored to use the new struct fields, with new helper functions for constructing both partial and full exits, and explicit tests for the new validation rules (e.g., reserved/withdrawal mismatch, invalid reserved amounts, array length mismatches). [[1]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R2275-R2311) [[2]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2359-R2376) [[3]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2404-R2431) [[4]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2482-R2496) [[5]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2508-R2524) [[6]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2529-R2545) [[7]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2579-R2590) [[8]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2595-R2607) [[9]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2622-R2631) [[10]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2760-R2812)

**Summary of most important changes:**

**1. Struct and interface redesign**
- Replaced `amounts` and `isFullExit` in `ELExitETHAllocation` with `withdrawalAmounts` (wire value, 0 for full exit) and `reservedExitAmounts` (accounting value, always set), and updated all related interface documentation.

**2. Contract logic and validation**
- Updated contract logic to validate that array lengths match for `pubkeys`, `withdrawalAmounts`, and `reservedExitAmounts`, and that reserved amounts are always positive and within cap. Partial exits must reserve exactly what they withdraw; full exits wire 0 and reserve the projected balance. [[1]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabL407-R408) [[2]](diffhunk://#diff-1459c8eab6cd9b658f70260ee5fd5f17d6c8c1008b8412e52afea55db9804dabL419-R447)
- Updated event emission and error handling to use new struct fields and provide more detailed error information. [[1]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L95-R102) [[2]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L215-R233) [[3]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L252-R266)

**3. Test suite refactor and coverage**
- Refactored test helpers to support new struct fields and added explicit tests for reserved/withdrawal mismatches, invalid reserved amounts, and array length mismatches. [[1]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21R2275-R2311) [[2]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2359-R2376) [[3]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2404-R2431) [[4]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2482-R2496) [[5]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2508-R2524) [[6]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2529-R2545) [[7]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2579-R2590) [[8]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2595-R2607) [[9]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2622-R2631) [[10]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2760-R2812)

**4. Documentation and comments**
- Updated and clarified comments throughout the interface and tests to reflect the new logic and to explain the distinction between wire and reserved amounts for both partial and full exits. [[1]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L33-R42) [[2]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2404-R2431)

**5. Event and error reporting**
- Enhanced the `RequestedELETHExits` event and error types to provide full context for each exit request, including both withdrawal and reserved amounts per pubkey. [[1]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L95-R102) [[2]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L215-R233) [[3]](diffhunk://#diff-1fb73f6332a46939cddb1ec200b8f4bbdaac8ef610f23f49c9508b1fba26ac90L252-R266)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->