### PR TITLE
This fixes the issue with the init methods, first stab at cleaning them

### DIFF
--- a/contracts/src/Withdraw.1.sol
+++ b/contracts/src/Withdraw.1.sol
@@ -41,13 +41,17 @@ contract WithdrawV1 is IWithdrawV1, Initializable, ReentrancyGuard, IProtocolVer
     function initWithdrawV1_1(
         address _pectraWithdrawalContractAddress,
         address _pectraConsolidationContractAddress,
-        address _operatorsRegistry,
-        address _attestationVerifier
+        address _operatorsRegistry
     ) external init(1) {
         PectraWithdrawalContractAddress.set(_pectraWithdrawalContractAddress);
         PectraConsolidationContractAddress.set(_pectraConsolidationContractAddress);
         OperatorsRegistryAddress.set(_operatorsRegistry);
+    }
+
+    /// @inheritdoc IWithdrawV1
+    function initWithdrawV1_2(address _attestationVerifier) external init(2) {
         AttestationVerifierAddress.set(_attestationVerifier);
+        emit SetAttestationVerifier(_attestationVerifier);
     }
 
     /// @inheritdoc IWithdrawV1
@@ -131,7 +135,11 @@ contract WithdrawV1 is IWithdrawV1, Initializable, ReentrancyGuard, IProtocolVer
         uint256 totalFeeRequired = fee * totalNumOfConsolidationOperations;
         _validateSufficientValueForFee(msg.value, totalFeeRequired);
 
-        IAttestationVerifierV1 attestationVerifier = IAttestationVerifierV1(AttestationVerifierAddress.get());
+        address attestationVerifierAddress = AttestationVerifierAddress.get();
+        if (attestationVerifierAddress == address(0)) {
+            revert AttestationVerifierNotSet();
+        }
+        IAttestationVerifierV1 attestationVerifier = IAttestationVerifierV1(attestationVerifierAddress);
         for (uint256 i = 0; i < requests.length; i++) {
             _processConsolidationRequest(requests[i], consolidationContract, attestationVerifier, fee);
         }

--- a/contracts/src/interfaces/IWithdraw.1.sol
+++ b/contracts/src/interfaces/IWithdraw.1.sol
@@ -17,6 +17,10 @@ interface IWithdrawV1 {
     /// @param river The new River address
     event SetRiver(address river);
 
+    /// @notice Emitted when the linked AttestationVerifier address is set
+    /// @param attestationVerifier The new AttestationVerifier address
+    event SetAttestationVerifier(address indexed attestationVerifier);
+
     /// @notice Emitted when a Pectra withdrawal is requested for a validator
     /// @param pubkey Validator pubkey (48 bytes)
     /// @param amount Amount to withdraw (gwei)
@@ -70,6 +74,9 @@ interface IWithdrawV1 {
     /// @param pubkey The offending 48-byte BLS pubkey
     error SourcePubkeyNotFunded(bytes pubkey);
 
+    /// @notice Thrown when consolidation is attempted before the AttestationVerifier address has been wired
+    error AttestationVerifierNotSet();
+
     /// @param _river The address of the River contract
     function initializeWithdrawV1(address _river) external;
 
@@ -77,13 +84,18 @@ interface IWithdrawV1 {
     /// @param _pectraWithdrawalContractAddress The Pectra EL withdrawal contract address
     /// @param _pectraConsolidationContractAddress The Pectra EL consolidation contract address
     /// @param _operatorsRegistry The OperatorsRegistry address
-    /// @param _attestationVerifier The AttestationVerifier address
     function initWithdrawV1_1(
         address _pectraWithdrawalContractAddress,
         address _pectraConsolidationContractAddress,
-        address _operatorsRegistry,
-        address _attestationVerifier
+        address _operatorsRegistry
     ) external;
+
+    /// @notice Wire the AttestationVerifier address (callable once after initWithdrawV1_1).
+    /// @dev Added as a separate reinitializer rather than extending initWithdrawV1_1, so deployments
+    ///      that already consumed the 3-arg initWithdrawV1_1 (version == 2) can still wire the verifier
+    ///      without reverting on the already-consumed reinitializer.
+    /// @param _attestationVerifier The AttestationVerifier address
+    function initWithdrawV1_2(address _attestationVerifier) external;
 
     /// @notice Retrieve the withdrawal credentials to use
     /// @return The withdrawal credentials

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -2266,9 +2266,8 @@ contract OperatorsRegistryV1ELExitTests is Test {
         withdrawContract = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(withdrawContract));
         withdrawContract.initializeWithdrawV1(river);
-        withdrawContract.initWithdrawV1_1(
-            pectraWithdrawal, makeAddr("pectraConsolidation"), address(reg), makeAddr("attestationVerifier")
-        );
+        withdrawContract.initWithdrawV1_1(pectraWithdrawal, makeAddr("pectraConsolidation"), address(reg));
+        withdrawContract.initWithdrawV1_2(makeAddr("attestationVerifier"));
         reg.sudoSetWithdrawAddress(address(withdrawContract));
     }
 

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -3605,12 +3605,8 @@ contract RiverV1PectraTests is RiverV1TestBase {
         withdraw.initializeWithdrawV1(address(river));
         mockWithdrawal = new MockELWithdrawalForRiver();
         mockConsolidation = new MockELConsolidationForRiver();
-        withdraw.initWithdrawV1_1(
-            address(mockWithdrawal),
-            address(mockConsolidation),
-            address(operatorsRegistry),
-            address(attestationVerifier)
-        );
+        withdraw.initWithdrawV1_1(address(mockWithdrawal), address(mockConsolidation), address(operatorsRegistry));
+        withdraw.initWithdrawV1_2(address(attestationVerifier));
         _seedValidatorPubkey(VALID_PUBKEY_48);
         vm.startPrank(admin);
         river.setKeeper(keeper);

--- a/contracts/test/Withdraw.1.t.sol
+++ b/contracts/test/Withdraw.1.t.sol
@@ -333,12 +333,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         mockWithdrawal = new MockELWithdrawal();
         mockConsolidation = new MockELConsolidation();
         excessFeeRecipient = makeAddr("excessFeeRecipient");
-        withdraw.initWithdrawV1_1(
-            address(mockWithdrawal),
-            address(mockConsolidation),
-            address(operatorsRegistry),
-            address(attestationVerifier)
-        );
+        withdraw.initWithdrawV1_1(address(mockWithdrawal), address(mockConsolidation), address(operatorsRegistry));
+        withdraw.initWithdrawV1_2(address(attestationVerifier));
         _seedValidatorPubkey(VALID_PUBKEY_48);
     }
 
@@ -348,12 +344,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         w.initializeWithdrawV1(address(river));
         assertEq(w.getRiver(), address(river));
 
-        w.initWithdrawV1_1(
-            address(mockWithdrawal),
-            address(mockConsolidation),
-            address(operatorsRegistry),
-            address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(mockWithdrawal), address(mockConsolidation), address(operatorsRegistry));
         // Unstructured storage slots match PectraWithdrawalContractAddress, PectraConsolidationContractAddress,
         // OperatorsRegistryAddress (see ../src/state/shared/*.sol)
         assertEq(
@@ -368,6 +359,9 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
             vm.load(address(w), bytes32(uint256(keccak256("river.state.operatorsRegistryAddress")) - 1)),
             bytes32(uint256(uint160(address(operatorsRegistry))))
         );
+
+        // The AttestationVerifier address is wired by the separate initWithdrawV1_2 reinitializer.
+        w.initWithdrawV1_2(address(attestationVerifier));
         assertEq(
             vm.load(address(w), bytes32(uint256(keccak256("river.state.attestationVerifierAddress")) - 1)),
             bytes32(uint256(uint160(address(attestationVerifier))))
@@ -375,12 +369,32 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
     }
 
     function testReinitWithdrawV1_1Reverts() external {
-        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization(uint256,uint256)", 1, 2));
-        withdraw.initWithdrawV1_1(
-            address(mockWithdrawal),
-            address(mockConsolidation),
-            address(operatorsRegistry),
-            address(attestationVerifier)
+        // setUp consumed init(0), init(1) and init(2), so Version == 3.
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization(uint256,uint256)", 1, 3));
+        withdraw.initWithdrawV1_1(address(mockWithdrawal), address(mockConsolidation), address(operatorsRegistry));
+    }
+
+    function testReinitWithdrawV1_2Reverts() external {
+        // setUp consumed init(0), init(1) and init(2), so Version == 3.
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization(uint256,uint256)", 2, 3));
+        withdraw.initWithdrawV1_2(address(attestationVerifier));
+    }
+
+    function testInitWithdrawV1_2WiresVerifierOnAlreadyInitializedV1_1() external {
+        // Mirrors an already-deployed instance that consumed the 3-arg initWithdrawV1_1 (Version == 2)
+        // before the verifier wiring existed: initWithdrawV1_2 must still run and set the verifier.
+        WithdrawV1 w = new WithdrawV1();
+        LibImplementationUnbricker.unbrick(vm, address(w));
+        w.initializeWithdrawV1(address(river));
+        w.initWithdrawV1_1(address(mockWithdrawal), address(mockConsolidation), address(operatorsRegistry));
+
+        vm.expectEmit(true, false, false, true, address(w));
+        emit IWithdrawV1.SetAttestationVerifier(address(attestationVerifier));
+        w.initWithdrawV1_2(address(attestationVerifier));
+
+        assertEq(
+            vm.load(address(w), bytes32(uint256(keccak256("river.state.attestationVerifierAddress")) - 1)),
+            bytes32(uint256(uint160(address(attestationVerifier))))
         );
     }
 
@@ -421,6 +435,26 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         vm.prank(address(river));
         vm.expectRevert(IWithdrawV1.InvalidEmptyArray.selector);
         withdraw.consolidate{value: 0}(requests, 1 gwei, excessFeeRecipient);
+    }
+
+    function testConsolidateRevertsWhenVerifierNotSet() external {
+        // A deployment that ran initWithdrawV1_1 but never initWithdrawV1_2 has no verifier wired:
+        // consolidate must fail loudly with AttestationVerifierNotSet rather than call address(0).
+        WithdrawV1 w = new WithdrawV1();
+        LibImplementationUnbricker.unbrick(vm, address(w));
+        w.initializeWithdrawV1(address(river));
+        w.initWithdrawV1_1(address(mockWithdrawal), address(mockConsolidation), address(operatorsRegistry));
+
+        bytes[] memory srcPubkeys = new bytes[](1);
+        srcPubkeys[0] = VALID_PUBKEY_48;
+        IWithdrawV1.ConsolidationRequest[] memory requests = new IWithdrawV1.ConsolidationRequest[](1);
+        requests[0] = IWithdrawV1.ConsolidationRequest({srcPubkeys: srcPubkeys, targetPubkey: VALID_PUBKEY_48});
+
+        uint256 fee = 1 gwei;
+        vm.deal(address(river), fee);
+        vm.prank(address(river));
+        vm.expectRevert(IWithdrawV1.AttestationVerifierNotSet.selector);
+        w.consolidate{value: fee}(requests, fee, excessFeeRecipient);
     }
 
     function testWithdrawLengthMismatchReverts() external {
@@ -609,9 +643,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         WithdrawV1 w = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
-        w.initWithdrawV1_1(
-            address(mockFail), address(mockConsolidation), address(operatorsRegistry), address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(mockFail), address(mockConsolidation), address(operatorsRegistry));
+        w.initWithdrawV1_2(address(attestationVerifier));
 
         bytes[] memory pubkeys = new bytes[](1);
         pubkeys[0] = VALID_PUBKEY_48;
@@ -631,12 +664,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         WithdrawV1 w = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
-        w.initWithdrawV1_1(
-            address(mockWithdrawal),
-            address(mockConsolidationFeeReadFails),
-            address(operatorsRegistry),
-            address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(mockWithdrawal), address(mockConsolidationFeeReadFails), address(operatorsRegistry));
+        w.initWithdrawV1_2(address(attestationVerifier));
 
         bytes[] memory srcPubkeys = new bytes[](1);
         srcPubkeys[0] = VALID_PUBKEY_48;
@@ -776,12 +805,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         WithdrawV1 w = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
-        w.initWithdrawV1_1(
-            address(mockWithdrawal),
-            address(mockConsolidationFails),
-            address(operatorsRegistry),
-            address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(mockWithdrawal), address(mockConsolidationFails), address(operatorsRegistry));
+        w.initWithdrawV1_2(address(attestationVerifier));
 
         bytes[] memory srcPubkeys = new bytes[](1);
         srcPubkeys[0] = VALID_PUBKEY_48;
@@ -889,12 +914,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         WithdrawV1 w = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
-        w.initWithdrawV1_1(
-            address(mockWithdrawalFeeReadFails),
-            address(mockConsolidation),
-            address(operatorsRegistry),
-            address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(mockWithdrawalFeeReadFails), address(mockConsolidation), address(operatorsRegistry));
+        w.initWithdrawV1_2(address(attestationVerifier));
 
         bytes[] memory pubkeys = new bytes[](1);
         pubkeys[0] = VALID_PUBKEY_48;
@@ -932,12 +953,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         WithdrawV1 w = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
-        w.initWithdrawV1_1(
-            address(mockWithdrawalFails),
-            address(mockConsolidation),
-            address(operatorsRegistry),
-            address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(mockWithdrawalFails), address(mockConsolidation), address(operatorsRegistry));
+        w.initWithdrawV1_2(address(attestationVerifier));
 
         bytes[] memory pubkeys = new bytes[](1);
         pubkeys[0] = VALID_PUBKEY_48;
@@ -1173,9 +1190,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         WithdrawV1 w = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
-        w.initWithdrawV1_1(
-            address(shortMock), address(mockConsolidation), address(operatorsRegistry), address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(shortMock), address(mockConsolidation), address(operatorsRegistry));
+        w.initWithdrawV1_2(address(attestationVerifier));
 
         bytes[] memory pubkeys = new bytes[](1);
         pubkeys[0] = VALID_PUBKEY_48;
@@ -1197,9 +1213,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         WithdrawV1 w = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
-        w.initWithdrawV1_1(
-            address(mockWithdrawal), address(shortMock), address(operatorsRegistry), address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(mockWithdrawal), address(shortMock), address(operatorsRegistry));
+        w.initWithdrawV1_2(address(attestationVerifier));
 
         bytes[] memory srcPubkeys = new bytes[](1);
         srcPubkeys[0] = VALID_PUBKEY_48;
@@ -1220,9 +1235,8 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         WithdrawV1 w = new WithdrawV1();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
-        w.initWithdrawV1_1(
-            address(shortMock), address(mockConsolidation), address(operatorsRegistry), address(attestationVerifier)
-        );
+        w.initWithdrawV1_1(address(shortMock), address(mockConsolidation), address(operatorsRegistry));
+        w.initWithdrawV1_2(address(attestationVerifier));
 
         bytes[] memory pubkeys = new bytes[](1);
         pubkeys[0] = VALID_PUBKEY_48;


### PR DESCRIPTION
all up ...

This addresses https://github.com/liquid-collective/liquid-collective-protocol/issues/573

## Description

This pull request refactors the initialization process for wiring the `AttestationVerifier` address in the `WithdrawV1` contract, splitting it into a separate initializer to support both new and already-deployed contracts. It also updates the interface and test suite to match this change, and adds explicit error handling for missing verifier configuration.

Key changes:

**Initialization Refactor:**

- Split the original `initWithdrawV1_1` initializer into two steps: 
  - `initWithdrawV1_1` now only sets withdrawal, consolidation, and operator registry addresses.
  - New `initWithdrawV1_2` initializer wires the `AttestationVerifier` address, emits a `SetAttestationVerifier` event, and is callable once after `initWithdrawV1_1`. This allows already-deployed contracts (which previously used the 3-arg initializer) to wire the verifier without re-initialization issues. [[1]](diffhunk://#diff-865957c3c5c4b8bbd276c2f684d6877d63be543bdebef39218ba8eaa8b343be0L44-R54) [[2]](diffhunk://#diff-984b02abbb24a29ef36d5b26931fab83ad9df15d29714c4a53269f9f8354b39fR77-R99)

**Interface and Event Updates:**

- Added `SetAttestationVerifier` event and `AttestationVerifierNotSet` error to the `IWithdrawV1` interface. Updated documentation to reflect the new two-step initialization. [[1]](diffhunk://#diff-984b02abbb24a29ef36d5b26931fab83ad9df15d29714c4a53269f9f8354b39fR20-R23) [[2]](diffhunk://#diff-984b02abbb24a29ef36d5b26931fab83ad9df15d29714c4a53269f9f8354b39fR77-R99)

**Error Handling Improvements:**

- Added a check in the `consolidate` function to revert with `AttestationVerifierNotSet` if the verifier address is not set, preventing accidental calls to the zero address.

**Test Suite Updates:**

- Updated all tests and contract deployments to use the new two-step initialization pattern (`initWithdrawV1_1` followed by `initWithdrawV1_2`). Added specific tests to verify correct error handling and event emission when the verifier is not set or when re-initializers are misused. [[1]](diffhunk://#diff-d676752bfc62e0f8383e9785a7a6b7111cb8e0658b4e32648929d626f6399a21L2269-R2270) [[2]](diffhunk://#diff-c9c1475a717fd5a1288e856446dc3a2ed5607ed4e7a128533962b3915fffe238L3608-R3609) [[3]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL336-R337) [[4]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL351-R347) [[5]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebR362-R397) [[6]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebR440-R459) [[7]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL612-R647) [[8]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL634-R668) [[9]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL779-R809) [[10]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL892-R918) [[11]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL935-R957) [[12]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL1176-R1194) [[13]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL1200-R1217) [[14]](diffhunk://#diff-91cc20cc358901da2875b996fb4c4efab794db204f2451f4996b84f8bed898ebL1223-R1239)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->