### PR TITLE
test: add consolidation attestation parity coverage (BS-4265)

### DIFF
--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -3865,6 +3865,43 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         vm.stopPrank();
     }
 
+    function _buildConsolidationWithPubkeys(
+        address withdrawalAddress,
+        bytes[] memory sources,
+        bytes[] memory targets,
+        uint256 totalAmount
+    ) internal view returns (IAttestationVerifierV1.ConsolidationObject memory consolidation) {
+        bytes32 digest = _consolidationDigest(withdrawalAddress, sources, targets, totalAmount);
+
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _signConsolidation(consolidationCommitteeAttesterPk1, digest);
+        sigs[1] = _signConsolidation(consolidationCommitteeAttesterPk2, digest);
+
+        consolidation = IAttestationVerifierV1.ConsolidationObject({
+            withdrawalAddress: withdrawalAddress,
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: totalAmount,
+            signatures: sigs
+        });
+    }
+
+    function _consolidationStructHash(IAttestationVerifierV1.ConsolidationObject memory consolidation)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                ATTEST_CONSOLIDATION_TYPEHASH,
+                consolidation.withdrawalAddress,
+                _hashBytesArray(consolidation.sourcePubkeys),
+                _hashBytesArray(consolidation.targetPubkeys),
+                consolidation.totalAmount
+            )
+        );
+    }
+
     function testOnlyConsolidatorCanMintForConsolidation() public {
         address notConsolidator = makeAddr("notConsolidator");
         IAttestationVerifierV1.ConsolidationObject memory consolidation = _buildConsolidation(bob, 1 ether, 1);
@@ -3885,13 +3922,6 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         IAttestationVerifierV1.ConsolidationObject memory consolidation = _buildConsolidation(bob, 0, 3);
         vm.prank(consolidator);
         vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.ZeroConsolidationTotalAmount.selector));
-        river.mintLsETHForConsolidation(consolidation);
-    }
-
-    function testMintLsETHForConsolidationZeroUserRevertsAtAllowlist() public {
-        IAttestationVerifierV1.ConsolidationObject memory consolidation = _buildConsolidation(address(0), 1 ether, 4);
-        vm.prank(consolidator);
-        vm.expectRevert(abi.encodeWithSignature("Unauthorized(address)", address(0)));
         river.mintLsETHForConsolidation(consolidation);
     }
 
@@ -3931,6 +3961,7 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         vm.prank(bob);
         externalConsolidationRecipientMapping.setRecipient(joe);
         IAttestationVerifierV1.ConsolidationObject memory consolidation = _buildConsolidation(bob, amount, 7);
+        uint256 totalSupplyBefore = river.totalSupply();
 
         vm.expectEmit(true, true, true, true);
         emit IRiverV1.LsETHMintedForConsolidation(joe, amount, amount);
@@ -3940,6 +3971,7 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         assertEq(river.getBalanceToConsolidate(), amount);
         assertEq(river.balanceOf(bob), 0);
         assertEq(river.balanceOf(joe), amount);
+        assertEq(river.totalSupply(), totalSupplyBefore + amount);
     }
 
     function testMintLsETHForConsolidationMappedDeniedRecipientReverts() public {
@@ -3970,5 +4002,104 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         assertEq(river.getBalanceToConsolidate(), 8 ether);
         assertEq(river.balanceOf(bob), 5 ether);
         assertEq(river.balanceOf(joe), 3 ether);
+    }
+
+    function testRevert_mintLsETHForConsolidationAlreadyProcessedDoesNotMintOrIncrementBuffer() public {
+        uint256 amount = 13 ether;
+        _allowConsolidation(bob);
+        IAttestationVerifierV1.ConsolidationObject memory consolidation = _buildConsolidation(bob, amount, 17);
+
+        vm.prank(consolidator);
+        river.mintLsETHForConsolidation(consolidation);
+
+        uint256 bufferBeforeReplay = river.getBalanceToConsolidate();
+        uint256 bobSharesBeforeReplay = river.balanceOf(bob);
+        uint256 totalSupplyBeforeReplay = river.totalSupply();
+        bytes32 structHash = _consolidationStructHash(consolidation);
+
+        vm.prank(consolidator);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationAlreadyProcessed.selector, structHash)
+        );
+        river.mintLsETHForConsolidation(consolidation);
+
+        assertEq(river.getBalanceToConsolidate(), bufferBeforeReplay);
+        assertEq(river.balanceOf(bob), bobSharesBeforeReplay);
+        assertEq(river.totalSupply(), totalSupplyBeforeReplay);
+    }
+
+    function testRevert_mintLsETHForConsolidationReplayWithDifferentValidSignaturesDoesNotMint() public {
+        uint256 amount = 14 ether;
+        uint256 alternateCommitteeAttesterPk = 0xC3;
+        _allowConsolidation(bob);
+        vm.prank(admin);
+        attestationVerifier.setConsolidationCommitteeAttester(vm.addr(alternateCommitteeAttesterPk), true);
+
+        IAttestationVerifierV1.ConsolidationObject memory consolidation = _buildConsolidation(bob, amount, 18);
+        vm.prank(consolidator);
+        river.mintLsETHForConsolidation(consolidation);
+
+        bytes32 digest = _consolidationDigest(
+            consolidation.withdrawalAddress,
+            consolidation.sourcePubkeys,
+            consolidation.targetPubkeys,
+            consolidation.totalAmount
+        );
+        bytes[] memory alternateSigs = new bytes[](2);
+        alternateSigs[0] = _signConsolidation(consolidationCommitteeAttesterPk1, digest);
+        alternateSigs[1] = _signConsolidation(alternateCommitteeAttesterPk, digest);
+        consolidation.signatures = alternateSigs;
+
+        uint256 bufferBeforeReplay = river.getBalanceToConsolidate();
+        uint256 bobSharesBeforeReplay = river.balanceOf(bob);
+        uint256 totalSupplyBeforeReplay = river.totalSupply();
+        bytes32 structHash = _consolidationStructHash(consolidation);
+
+        vm.prank(consolidator);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationAlreadyProcessed.selector, structHash)
+        );
+        river.mintLsETHForConsolidation(consolidation);
+
+        assertEq(river.getBalanceToConsolidate(), bufferBeforeReplay);
+        assertEq(river.balanceOf(bob), bobSharesBeforeReplay);
+        assertEq(river.totalSupply(), totalSupplyBeforeReplay);
+    }
+
+    function testMintLsETHForConsolidationOverlappingSourceDistinctRequestsIsCommitteeInvariant() public {
+        _allowConsolidation(bob);
+        bytes memory sourceA = _fakePubkey(2000);
+        bytes memory sourceB = _fakePubkey(2001);
+
+        bytes[] memory firstSources = new bytes[](1);
+        firstSources[0] = sourceA;
+        bytes[] memory firstTargets = new bytes[](1);
+        firstTargets[0] = _fakePubkey(2100);
+        IAttestationVerifierV1.ConsolidationObject memory firstConsolidation =
+            _buildConsolidationWithPubkeys(bob, firstSources, firstTargets, 32 ether);
+
+        bytes[] memory secondSources = new bytes[](2);
+        secondSources[0] = sourceA;
+        secondSources[1] = sourceB;
+        bytes[] memory secondTargets = new bytes[](2);
+        secondTargets[0] = _fakePubkey(2200);
+        secondTargets[1] = _fakePubkey(2201);
+        IAttestationVerifierV1.ConsolidationObject memory secondConsolidation =
+            _buildConsolidationWithPubkeys(bob, secondSources, secondTargets, 64 ether);
+
+        assertTrue(
+            _consolidationStructHash(firstConsolidation) != _consolidationStructHash(secondConsolidation),
+            "overlap must not collapse distinct requests into replay"
+        );
+
+        vm.prank(consolidator);
+        river.mintLsETHForConsolidation(firstConsolidation);
+        assertEq(river.getBalanceToConsolidate(), 32 ether);
+        assertEq(river.balanceOf(bob), 32 ether);
+
+        vm.prank(consolidator);
+        river.mintLsETHForConsolidation(secondConsolidation);
+        assertEq(river.getBalanceToConsolidate(), 96 ether);
+        assertEq(river.balanceOf(bob), 96 ether);
     }
 }

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -163,6 +163,23 @@ contract ConsolidationAttestationTest is Test {
         return keccak256(abi.encodePacked("\x19\x01", domainSep, structHash));
     }
 
+    function _consolidationStructHash(
+        address withdrawalAddress,
+        bytes[] memory sources,
+        bytes[] memory targets,
+        uint256 totalAmount
+    ) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                ATTEST_CONSOLIDATION_TYPEHASH,
+                withdrawalAddress,
+                _hashBytesArray(sources),
+                _hashBytesArray(targets),
+                totalAmount
+            )
+        );
+    }
+
     /// @dev Sign a precomputed EIP-712 digest with the given private key.
     function _sign(uint256 pk, bytes32 digest) internal view returns (bytes memory) {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
@@ -542,6 +559,72 @@ contract ConsolidationAttestationTest is Test {
             abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationAlreadyProcessed.selector, structHash)
         );
         _validateConsolidationAsRiver(c);
+    }
+
+    function testRevert_consolidationAlreadyProcessedWithDifferentValidSignatures() public {
+        address user = address(0xBEEF);
+        IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(user, 321);
+        _validateConsolidationAsRiver(c);
+
+        bytes32 digest = _consolidationDigest(c.withdrawalAddress, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
+        bytes[] memory alternateSigs = new bytes[](2);
+        alternateSigs[0] = _sign(pk2, digest);
+        alternateSigs[1] = _sign(pk3, digest);
+        c.signatures = alternateSigs;
+
+        bytes32 structHash =
+            _consolidationStructHash(c.withdrawalAddress, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationAlreadyProcessed.selector, structHash)
+        );
+        _validateConsolidationAsRiver(c);
+    }
+
+    function testRevert_overlappingSourceDistinctRequestCannotReuseFirstRequestSignatures() public {
+        address user = address(0xCAFE);
+        bytes memory sourceA = _pubkey(800);
+        bytes memory sourceB = _pubkey(801);
+
+        bytes[] memory firstSources = new bytes[](1);
+        firstSources[0] = sourceA;
+        bytes[] memory firstTargets = new bytes[](1);
+        firstTargets[0] = _pubkey(900);
+        uint256 firstAmount = 32 ether;
+        bytes32 firstDigest = _consolidationDigest(user, firstSources, firstTargets, firstAmount);
+        bytes[] memory firstSigs = new bytes[](2);
+        firstSigs[0] = _sign(pk1, firstDigest);
+        firstSigs[1] = _sign(pk2, firstDigest);
+
+        bytes[] memory secondSources = new bytes[](2);
+        secondSources[0] = sourceA;
+        secondSources[1] = sourceB;
+        bytes[] memory secondTargets = new bytes[](2);
+        secondTargets[0] = _pubkey(901);
+        secondTargets[1] = _pubkey(902);
+        uint256 secondAmount = 64 ether;
+
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: firstSources,
+                targetPubkeys: firstTargets,
+                totalAmount: firstAmount,
+                signatures: firstSigs
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 0, 2)
+        );
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: secondSources,
+                targetPubkeys: secondTargets,
+                totalAmount: secondAmount,
+                signatures: firstSigs
+            })
+        );
     }
 
     function testValidateConsolidation_emitsConsolidationProcessed() public {


### PR DESCRIPTION
Refs #558

## Description

This pull request adds comprehensive tests to ensure the correctness and robustness of the consolidation minting logic, particularly focusing on replay protection, signature uniqueness, and committee invariance when handling overlapping source pubkeys. The changes introduce new helper functions for struct hashing and consolidation object creation, enhance test coverage for edge cases, and ensure that replayed or altered consolidation requests are properly handled.

**Enhancements to consolidation replay protection and signature handling:**

* Added tests to ensure that attempting to mint with a consolidation object that has already been processed (even with different, valid signatures) does not mint or increment the buffer, and emits the correct revert (`ConsolidationAlreadyProcessed`). (`contracts/test/River.1.t.sol`, [[1]](diffhunk://#diff-c9c1475a717fd5a1288e856446dc3a2ed5607ed4e7a128533962b3915fffe238R4006-R4104); `contracts/test/components/ConsolidationAttestation.t.sol`, [[2]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646R564-R680)
* Introduced helper functions `_consolidationStructHash` and `_buildConsolidationWithPubkeys` for consistent struct hashing and flexible consolidation object creation, improving code reuse and test clarity. (`contracts/test/River.1.t.sol`, [[1]](diffhunk://#diff-c9c1475a717fd5a1288e856446dc3a2ed5607ed4e7a128533962b3915fffe238R3868-R3904); `contracts/test/components/ConsolidationAttestation.t.sol`, [[2]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646R166-R182)

**Committee invariance and overlapping source pubkey tests:**

* Added tests to verify that consolidation requests with overlapping source pubkeys but different targets or amounts are treated as distinct (committee invariant), preventing accidental replay or signature reuse. (`contracts/test/River.1.t.sol`, [[1]](diffhunk://#diff-c9c1475a717fd5a1288e856446dc3a2ed5607ed4e7a128533962b3915fffe238R4006-R4104); `contracts/test/components/ConsolidationAttestation.t.sol`, [[2]](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646R564-R680)
* Added negative tests to ensure that signatures from one consolidation request cannot be reused for another with overlapping sources but different targets/amounts, enforcing signature uniqueness and attestation sufficiency. (`contracts/test/components/ConsolidationAttestation.t.sol`, [contracts/test/components/ConsolidationAttestation.t.solR564-R680](diffhunk://#diff-f6fea7effab6d72bda31e7c18ebf8217bc793c5d8d690e192ead23dda178f646R564-R680))

**Test coverage improvements:**

* Improved assertions for total supply and buffer invariants following consolidation minting, ensuring state consistency after successful or reverted operations. (`contracts/test/River.1.t.sol`, [[1]](diffhunk://#diff-c9c1475a717fd5a1288e856446dc3a2ed5607ed4e7a128533962b3915fffe238R3964) [[2]](diffhunk://#diff-c9c1475a717fd5a1288e856446dc3a2ed5607ed4e7a128533962b3915fffe238R3974)

**Test cleanup:**

* Removed redundant or obsolete test for zero user allowlist revert, as coverage is now provided by other tests. (`contracts/test/River.1.t.sol`, [contracts/test/River.1.t.solL3891-L3897](diffhunk://#diff-c9c1475a717fd5a1288e856446dc3a2ed5607ed4e7a128533962b3915fffe238L3891-L3897))

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing



- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced replay protection validation for consolidation requests to prevent already-processed consolidations from being replayed
  * Strengthened signature validation tests, including coverage for signature reuse attempts
  * Added test coverage for overlapping consolidation requests to ensure proper request distinction and handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->