### PR TITLE
fix: standardize consolidation recipient resolution (BS-4274)

### DIFF
--- a/contracts/src/ExternalConsolidationRecipientMapping.sol
+++ b/contracts/src/ExternalConsolidationRecipientMapping.sol
@@ -15,7 +15,7 @@ import "./state/externalConsolidationRecipientMapping/ExternalConsolidationRecip
 
 /// @title External Consolidation Recipient Mapping (v1)
 /// @author Alluvial Finance Inc.
-/// @notice Maps withdrawal credential addresses to recipient addresses for external consolidation minting
+/// @notice Maps caller's withdrawal credentials to recipient addresses for external consolidation minting
 contract ExternalConsolidationRecipientMappingV1 is
     Initializable,
     IExternalConsolidationRecipientMappingV1,

--- a/contracts/src/ExternalConsolidationRecipientMapping.sol
+++ b/contracts/src/ExternalConsolidationRecipientMapping.sol
@@ -15,7 +15,7 @@ import "./state/externalConsolidationRecipientMapping/ExternalConsolidationRecip
 
 /// @title External Consolidation Recipient Mapping (v1)
 /// @author Alluvial Finance Inc.
-/// @notice Maps callers' withdrawal credential addresses to recipient addresses for external consolidation minting
+/// @notice Maps withdrawal credential addresses to recipient addresses for external consolidation minting
 contract ExternalConsolidationRecipientMappingV1 is
     Initializable,
     IExternalConsolidationRecipientMappingV1,
@@ -40,8 +40,14 @@ contract ExternalConsolidationRecipientMappingV1 is
     }
 
     /// @inheritdoc IExternalConsolidationRecipientMappingV1
-    function getRecipient(address _withdrawalCredential) external view returns (address) {
-        return ExternalConsolidationRecipientMapping.get(_withdrawalCredential);
+    function getRecipient(address _withdrawalCredentialAddress) external view returns (address) {
+        return ExternalConsolidationRecipientMapping.get(_withdrawalCredentialAddress);
+    }
+
+    /// @inheritdoc IExternalConsolidationRecipientMappingV1
+    function resolveRecipient(address _withdrawalCredentialAddress) external view returns (address) {
+        address recipient = ExternalConsolidationRecipientMapping.get(_withdrawalCredentialAddress);
+        return recipient == address(0) ? _withdrawalCredentialAddress : recipient;
     }
 
     function version() external pure returns (string memory) {

--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -218,15 +218,10 @@ contract RiverV1 is
         allowlist.onlyAllowed(consolidation.withdrawalAddress, LibAllowlistMasks.CONSOLIDATE_MASK);
 
         address recipient = IExternalConsolidationRecipientMappingV1(ExternalConsolidationRecipientMappingAddress.get())
-            .getRecipient(consolidation.withdrawalAddress);
+            .resolveRecipient(consolidation.withdrawalAddress);
 
-        // if the recipient is not set, we use the withdrawalAddress
-        if (recipient == address(0)) {
-            recipient = consolidation.withdrawalAddress;
-        } else {
-            if (allowlist.isDenied(recipient)) {
-                revert Denied(recipient);
-            }
+        if (recipient != consolidation.withdrawalAddress && allowlist.isDenied(recipient)) {
+            revert Denied(recipient);
         }
 
         IAttestationVerifierV1 verifier = IAttestationVerifierV1(AttestationVerifierAddress.get());

--- a/contracts/src/interfaces/IExternalConsolidationRecipientMapping.1.sol
+++ b/contracts/src/interfaces/IExternalConsolidationRecipientMapping.1.sol
@@ -33,6 +33,7 @@ interface IExternalConsolidationRecipientMappingV1 {
 
     /// @notice Resolves the mint recipient for a withdrawal credential address
     /// @dev Returns the mapped recipient when set, otherwise falls back to the withdrawal credential address.
+    /// @dev Does not perform any validation on the recipient address.
     /// @param _withdrawalCredentialAddress The withdrawal credential address to resolve
     /// @return The recipient address to receive minted LsETH
     function resolveRecipient(address _withdrawalCredentialAddress) external view returns (address);

--- a/contracts/src/interfaces/IExternalConsolidationRecipientMapping.1.sol
+++ b/contracts/src/interfaces/IExternalConsolidationRecipientMapping.1.sol
@@ -3,16 +3,16 @@ pragma solidity 0.8.34;
 
 /// @title External Consolidation Recipient Mapping Interface (v1)
 /// @author Alluvial Finance Inc.
-/// @notice Maps callers' withdrawal credential addresses to recipient addresses for external consolidation minting
+/// @notice Maps withdrawal credential addresses to recipient addresses for external consolidation minting
 interface IExternalConsolidationRecipientMappingV1 {
     /// @notice The stored River address has changed
     /// @param river The new River address
     event SetRiver(address indexed river);
 
     /// @notice The recipient for a withdrawal credential address has changed
-    /// @param withdrawalCredential The withdrawal credential address
+    /// @param withdrawalCredentialAddress The address component of the validator withdrawal credentials
     /// @param recipient The recipient address
-    event SetRecipient(address indexed withdrawalCredential, address indexed recipient);
+    event SetRecipient(address indexed withdrawalCredentialAddress, address indexed recipient);
 
     /// @notice The requested recipient is denied on the allowlist
     error RecipientIsDenied();
@@ -22,12 +22,18 @@ interface IExternalConsolidationRecipientMappingV1 {
     function initExternalConsolidationRecipientMappingV1(address _riverAddress) external;
 
     /// @notice Sets the recipient address for the caller.
-    /// @dev The assumption is that the caller is the withdrawal credential address.
+    /// @dev The caller is the committee-attested withdrawal credential address.
     /// @param _recipient The address to receive minted LsETH
     function setRecipient(address _recipient) external;
 
-    /// @notice Retrieves the recipient address mapped to a withdrawal credential address
-    /// @param _withdrawalCredential The withdrawal credential address to query
+    /// @notice Retrieves the raw recipient address mapped to a withdrawal credential address
+    /// @param _withdrawalCredentialAddress The withdrawal credential address to query
     /// @return The mapped recipient address
-    function getRecipient(address _withdrawalCredential) external view returns (address);
+    function getRecipient(address _withdrawalCredentialAddress) external view returns (address);
+
+    /// @notice Resolves the mint recipient for a withdrawal credential address
+    /// @dev Returns the mapped recipient when set, otherwise falls back to the withdrawal credential address.
+    /// @param _withdrawalCredentialAddress The withdrawal credential address to resolve
+    /// @return The recipient address to receive minted LsETH
+    function resolveRecipient(address _withdrawalCredentialAddress) external view returns (address);
 }

--- a/contracts/src/state/externalConsolidationRecipientMapping/ExternalConsolidationRecipientMapping.sol
+++ b/contracts/src/state/externalConsolidationRecipientMapping/ExternalConsolidationRecipientMapping.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.34;
 
 /// @title External Consolidation Recipient Mapping Storage
-/// @notice Utility to manage withdrawal credential recipient mapping storage
+/// @notice Utility to manage withdrawal-credential-address recipient mapping storage
 library ExternalConsolidationRecipientMapping {
-    /// @notice Storage slot of the withdrawal credential recipient mapping
+    /// @notice Storage slot of the withdrawal-credential-address recipient mapping
     bytes32 internal constant EXTERNAL_CONSOLIDATION_RECIPIENT_MAPPING_SLOT =
         bytes32(uint256(keccak256("river.state.externalConsolidationRecipientMapping")) - 1);
 
@@ -15,9 +15,9 @@ library ExternalConsolidationRecipientMapping {
     }
 
     /// @notice Retrieve the recipient mapped to a withdrawal credential address
-    /// @param _withdrawalCredential The withdrawal credential address to query
+    /// @param _withdrawalCredentialAddress The withdrawal credential address to query
     /// @return The mapped recipient address
-    function get(address _withdrawalCredential) internal view returns (address) {
+    function get(address _withdrawalCredentialAddress) internal view returns (address) {
         bytes32 slot = EXTERNAL_CONSOLIDATION_RECIPIENT_MAPPING_SLOT;
 
         Slot storage r;
@@ -27,13 +27,13 @@ library ExternalConsolidationRecipientMapping {
             r.slot := slot
         }
 
-        return r.value[_withdrawalCredential];
+        return r.value[_withdrawalCredentialAddress];
     }
 
     /// @notice Set the recipient mapped to a withdrawal credential address
-    /// @param _withdrawalCredential The withdrawal credential address to update
+    /// @param _withdrawalCredentialAddress The withdrawal credential address to update
     /// @param _recipient The recipient address to set
-    function set(address _withdrawalCredential, address _recipient) internal {
+    function set(address _withdrawalCredentialAddress, address _recipient) internal {
         bytes32 slot = EXTERNAL_CONSOLIDATION_RECIPIENT_MAPPING_SLOT;
 
         Slot storage r;
@@ -43,6 +43,6 @@ library ExternalConsolidationRecipientMapping {
             r.slot := slot
         }
 
-        r.value[_withdrawalCredential] = _recipient;
+        r.value[_withdrawalCredentialAddress] = _recipient;
     }
 }

--- a/contracts/src/state/externalConsolidationRecipientMapping/ExternalConsolidationRecipientMapping.sol
+++ b/contracts/src/state/externalConsolidationRecipientMapping/ExternalConsolidationRecipientMapping.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.34;
 
 /// @title External Consolidation Recipient Mapping Storage
-/// @notice Utility to manage withdrawal-credential-address recipient mapping storage
+/// @notice Utility to manage withdrawal credentials to recipient address mapping storage
 library ExternalConsolidationRecipientMapping {
     /// @notice Storage slot of the withdrawal-credential-address recipient mapping
     bytes32 internal constant EXTERNAL_CONSOLIDATION_RECIPIENT_MAPPING_SLOT =
@@ -10,7 +10,7 @@ library ExternalConsolidationRecipientMapping {
 
     /// @notice Structure stored in storage slot
     struct Slot {
-        /// @custom:attribute Mapping from withdrawal credential addresses to recipient addresses
+        /// @custom:attribute Mapping from withdrawal credentials to recipient addresses
         mapping(address => address) value;
     }
 

--- a/contracts/test/ExternalConsolidationRecipientMapping.t.sol
+++ b/contracts/test/ExternalConsolidationRecipientMapping.t.sol
@@ -32,7 +32,7 @@ abstract contract ExternalConsolidationRecipientMappingV1TestBase is Test {
     address internal admin;
 
     event SetRiver(address indexed river);
-    event SetRecipient(address indexed withdrawalCredential, address indexed recipient);
+    event SetRecipient(address indexed withdrawalCredentialAddress, address indexed recipient);
 
     function _allowConsolidation(address account) internal {
         address[] memory accounts = new address[](1);
@@ -171,10 +171,28 @@ contract ExternalConsolidationRecipientMappingV1Tests is ExternalConsolidationRe
         vm.stopPrank();
 
         assertEq(mappingContract.getRecipient(sender), address(0));
+        assertEq(mappingContract.resolveRecipient(sender), sender);
     }
 
     function testGetRecipientUnset() external {
-        assertEq(mappingContract.getRecipient(makeAddr("withdrawalCredential")), address(0));
+        assertEq(mappingContract.getRecipient(makeAddr("withdrawalCredentialAddress")), address(0));
+    }
+
+    function testResolveRecipientUnsetReturnsWithdrawalCredentialAddress() external {
+        address withdrawalCredentialAddress = makeAddr("withdrawalCredentialAddress");
+
+        assertEq(mappingContract.resolveRecipient(withdrawalCredentialAddress), withdrawalCredentialAddress);
+    }
+
+    function testResolveRecipientSetReturnsMappedRecipient() external {
+        address withdrawalCredentialAddress = makeAddr("withdrawalCredentialAddress");
+        address recipient = makeAddr("recipient");
+        _allowConsolidation(withdrawalCredentialAddress);
+
+        vm.prank(withdrawalCredentialAddress);
+        mappingContract.setRecipient(recipient);
+
+        assertEq(mappingContract.resolveRecipient(withdrawalCredentialAddress), recipient);
     }
 
     function testVersion() external {


### PR DESCRIPTION
Refs #556

## Description

Closes #556 

Uses withdrawalCredentialAddress, because it is the `address` not the bytes32 withdrawalCredentials with the 0x01 or 0x02 prefix. 
Also adds a more elegant resolveRecipient function./

This pull request refines the handling of withdrawal credential to recipient address mapping for external consolidation minting, clarifies naming conventions, and introduces a new method to simplify recipient resolution logic. The major changes include the addition of a `resolveRecipient` function, consistent renaming of parameters for clarity, and updates to both implementation and tests to reflect these improvements.

**Enhancements to recipient mapping logic:**

* Added a new `resolveRecipient` function in both the `IExternalConsolidationRecipientMappingV1` interface and its implementation, which returns the mapped recipient if set, or falls back to the withdrawal credential address if not. This simplifies downstream logic that previously had to handle this fallback manually. [[1]](diffhunk://#diff-6386f21a8891def7c3be839371832c4c6a6acafa1df8251a5ae8bc668f2695aeL43-R50) [[2]](diffhunk://#diff-57a473ae53b8fe275da2b889da66caef5d69b6ebb32e377eba6430a673d62709L25-R38)

* Updated the `RiverV1` contract to use `resolveRecipient` instead of `getRecipient`, removing redundant fallback logic and ensuring allowlist checks are only performed when the recipient differs from the withdrawal credential address.

**Naming and documentation improvements:**

* Standardized parameter and event names from `_withdrawalCredential` to `_withdrawalCredentialAddress` and updated related comments and documentation for clarity across the codebase, including interface, implementation, storage library, and events. [[1]](diffhunk://#diff-6386f21a8891def7c3be839371832c4c6a6acafa1df8251a5ae8bc668f2695aeL18-R18) [[2]](diffhunk://#diff-57a473ae53b8fe275da2b889da66caef5d69b6ebb32e377eba6430a673d62709L6-R15) [[3]](diffhunk://#diff-b74dc93f96729de1efd6181a0d72752ccba38a856ffba009817f0dfce91a6f09L5-R7) [[4]](diffhunk://#diff-b74dc93f96729de1efd6181a0d72752ccba38a856ffba009817f0dfce91a6f09L18-R20) [[5]](diffhunk://#diff-b74dc93f96729de1efd6181a0d72752ccba38a856ffba009817f0dfce91a6f09L30-R36) [[6]](diffhunk://#diff-b74dc93f96729de1efd6181a0d72752ccba38a856ffba009817f0dfce91a6f09L46-R46) [[7]](diffhunk://#diff-6aeaa1d39b0aa8df21abbfaa1943447b3d75e788591f68cf73b4010bbcd092a2L35-R35)

**Testing updates:**

* Extended test coverage for the new `resolveRecipient` function, including cases where the mapping is unset (should return the credential address) and set (should return the mapped recipient).

These changes improve code clarity, reduce duplication, and make the recipient resolution process more robust and easier to use.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->