### PR TITLE
test(accounting): assert activeCLETH == 0 after V2->V3 migration

### DIFF
--- a/contracts/test/accounting/scenarios/Migration.t.sol
+++ b/contracts/test/accounting/scenarios/Migration.t.sol
@@ -96,10 +96,14 @@ contract MigrationTest is Test {
         OperatorsV3.Operator memory v3Op0 = registry.getOperator(0);
         assertEq(v3Op0.funded, uint256(op0Funded) * 32 ether, "op0 funded ETH");
         assertEq(v3Op0.active, true, "op0 active");
+        // activeCLETH MUST be 0 post-migration until the first oracle report (see migration source);
+        // a non-zero value would let exits be allocated against unconfirmed CL balance.
+        assertEq(v3Op0.activeCLETH, 0, "op0 activeCLETH must be zero post-migration");
 
         OperatorsV3.Operator memory v3Op1 = registry.getOperator(1);
         assertEq(v3Op1.funded, uint256(op1Funded) * 32 ether, "op1 funded ETH");
         assertEq(v3Op1.active, true, "op1 active");
+        assertEq(v3Op1.activeCLETH, 0, "op1 activeCLETH must be zero post-migration");
 
         // Validate exited ETH per operator
         uint256[] memory exitedPerOp = registry.getExitedETHPerOperator();
@@ -140,6 +144,7 @@ contract MigrationTest is Test {
         assertEq(registry.getOperatorCount(), 1, "one operator");
         OperatorsV3.Operator memory op = registry.getOperator(0);
         assertEq(op.funded, uint256(funded) * 32 ether, "funded scaled");
+        assertEq(op.activeCLETH, 0, "activeCLETH must be zero post-migration");
 
         uint256[] memory exitedPerOp = registry.getExitedETHPerOperator();
         assertEq(exitedPerOp.length, 1, "one entry");

--- a/contracts/test/accounting/scenarios/Migration.t.sol
+++ b/contracts/test/accounting/scenarios/Migration.t.sol
@@ -96,8 +96,6 @@ contract MigrationTest is Test {
         OperatorsV3.Operator memory v3Op0 = registry.getOperator(0);
         assertEq(v3Op0.funded, uint256(op0Funded) * 32 ether, "op0 funded ETH");
         assertEq(v3Op0.active, true, "op0 active");
-        // activeCLETH MUST be 0 post-migration until the first oracle report (see migration source);
-        // a non-zero value would let exits be allocated against unconfirmed CL balance.
         assertEq(v3Op0.activeCLETH, 0, "op0 activeCLETH must be zero post-migration");
 
         OperatorsV3.Operator memory v3Op1 = registry.getOperator(1);


### PR DESCRIPTION
## What

Adds three assertions to the V2→V3 migration test confirming `activeCLETH == 0` for every migrated operator.

## Why

The migration resets `activeCLETH` to 0 (`OperatorsRegistry.1.sol`), and that zero is **spec-critical**: until the first post-upgrade oracle report lands, a non-zero `activeCLETH` would let exits be allocated against unconfirmed consensus-layer balance — the source comment flags this as an exit-deadlock risk. The test already verified the funded/exited ×32-ETH scaling but never checked `activeCLETH`, so a migration that left it non-zero would have passed on coverage alone.

## Changes

- `testMigrationV2toV3`: assert `activeCLETH == 0` for both operators.
- `testMigrationSingleOperatorNoStops`: assert `activeCLETH == 0` for the operator.

## Testing

- 4/4 `MigrationTest` pass.
- Full suite: 987 passed; the 1 failure is the pre-existing `TlcMigrationTest` that needs `MAINNET_FORK_RPC_URL` (unrelated).

Surfaced by the accounting test-adequacy audit (finding F-16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
