### PR TITLE
feat: mark DepositDataBuffer batch processed from River after attested deposit (BS-4394)

### DIFF
--- a/contracts/src/components/ConsensusLayerDepositManager.1.sol
+++ b/contracts/src/components/ConsensusLayerDepositManager.1.sol
@@ -163,8 +163,16 @@ abstract contract ConsensusLayerDepositManagerV1 is IConsensusLayerDepositManage
             depositDataBufferId, depositRootHash, signatures, depositContract, withdrawalCredentials, committedBalance
         );
 
-        // 5. Mark the batch ID processed BEFORE any external interactions.
+        // 5. Mark the batch ID processed in River's local replay guard before any external
+        //    interactions. This is the primary in-tx guard against double-processing.
         verifier.markDepositDataBufferIdProcessed(depositDataBufferId);
+
+        // 5b. Notify the external DepositDataBuffer to flip its own `processed` flag so the
+        //     batch can never be re-served/re-queued from the buffer side. Gated to River on
+        //     the buffer (msg.sender == this River contract). The buffer address is sourced
+        //     from the AttestationVerifier, the single owner of that dependency. A revert here
+        //     (unknown / already-processed batch) reverts the whole deposit.
+        IDepositDataBuffer(verifier.getDepositDataBuffer()).markDepositDataProcessed(depositDataBufferId);
 
         // 6. Update operator funded validator accounting
         _updateFundedETHFromBuffer(batch.deposits, batch.topUps);

--- a/contracts/src/interfaces/IDepositDataBuffer.sol
+++ b/contracts/src/interfaces/IDepositDataBuffer.sol
@@ -68,6 +68,10 @@ interface IDepositDataBuffer {
     /// @param topUpCount           Number of top-ups in the batch
     event DepositDataSubmitted(bytes32 indexed depositDataBufferId, uint256 depositCount, uint256 topUpCount);
 
+    /// @notice Emitted when River marks a queued batch as processed.
+    /// @param depositDataBufferId  The batch identifier that was flagged processed
+    event DepositDataProcessed(bytes32 indexed depositDataBufferId);
+
     // -----------------------------------------------------------------------
     // Errors
     // -----------------------------------------------------------------------
@@ -98,6 +102,18 @@ interface IDepositDataBuffer {
     /// @param depositDataBufferId  The batch identifier
     /// @return batch               The stored deposit batch
     function getDepositData(bytes32 depositDataBufferId) external view returns (DepositObject memory batch);
+
+    /// @notice Mark a queued batch as processed so it can never be served/queued again.
+    /// @dev Restricted to River on the buffer side. Called by River after a successful
+    ///      `depositToConsensusLayerWithAttestation`. Reverts if the batch is unknown or
+    ///      already processed, then emits `DepositDataProcessed`.
+    /// @param depositDataBufferId  The batch identifier to mark processed
+    function markDepositDataProcessed(bytes32 depositDataBufferId) external;
+
+    /// @notice Whether a queued batch has been marked processed.
+    /// @param depositDataBufferId  The batch identifier
+    /// @return True if the batch has been marked processed
+    function isDepositDataProcessed(bytes32 depositDataBufferId) external view returns (bool);
 
     /// @notice Returns the authorized writer address.
     /// @return The authorized writer address

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -35,6 +35,7 @@ import "../src/RedeemManager.1.sol";
 contract MockDepositDataBuffer is IDepositDataBuffer {
     mapping(bytes32 => DepositObject) internal _batches;
     mapping(bytes32 => bool) internal _exists;
+    mapping(bytes32 => bool) internal _processed;
 
     function submitDepositData(bytes32 depositDataBufferId, DepositObject calldata batch) external {
         if (_exists[depositDataBufferId]) revert DepositDataBufferIdAlreadyExists(depositDataBufferId);
@@ -52,6 +53,17 @@ contract MockDepositDataBuffer is IDepositDataBuffer {
     function getDepositData(bytes32 depositDataBufferId) external view returns (DepositObject memory) {
         if (!_exists[depositDataBufferId]) revert DepositDataBufferIdNotFound(depositDataBufferId);
         return _batches[depositDataBufferId];
+    }
+
+    function markDepositDataProcessed(bytes32 depositDataBufferId) external {
+        if (!_exists[depositDataBufferId]) revert DepositDataBufferIdNotFound(depositDataBufferId);
+        if (_processed[depositDataBufferId]) revert DepositDataBufferIdAlreadyExists(depositDataBufferId);
+        _processed[depositDataBufferId] = true;
+        emit DepositDataProcessed(depositDataBufferId);
+    }
+
+    function isDepositDataProcessed(bytes32 depositDataBufferId) external view returns (bool) {
+        return _processed[depositDataBufferId];
     }
 
     function getWriter() external pure returns (address) {

--- a/contracts/test/accounting/AccountingHarnessBase.sol
+++ b/contracts/test/accounting/AccountingHarnessBase.sol
@@ -36,6 +36,7 @@ import "../../src/state/operatorsRegistry/Operators.3.sol";
 contract AccountingMockDepositDataBuffer is IDepositDataBuffer {
     mapping(bytes32 => DepositObject) internal _batches;
     mapping(bytes32 => bool) internal _exists;
+    mapping(bytes32 => bool) internal _processed;
 
     function submitDepositData(bytes32 depositDataBufferId, DepositObject calldata batch) external {
         if (_exists[depositDataBufferId]) revert DepositDataBufferIdAlreadyExists(depositDataBufferId);
@@ -53,6 +54,17 @@ contract AccountingMockDepositDataBuffer is IDepositDataBuffer {
     function getDepositData(bytes32 depositDataBufferId) external view returns (DepositObject memory) {
         if (!_exists[depositDataBufferId]) revert DepositDataBufferIdNotFound(depositDataBufferId);
         return _batches[depositDataBufferId];
+    }
+
+    function markDepositDataProcessed(bytes32 depositDataBufferId) external {
+        if (!_exists[depositDataBufferId]) revert DepositDataBufferIdNotFound(depositDataBufferId);
+        if (_processed[depositDataBufferId]) revert DepositDataBufferIdAlreadyExists(depositDataBufferId);
+        _processed[depositDataBufferId] = true;
+        emit DepositDataProcessed(depositDataBufferId);
+    }
+
+    function isDepositDataProcessed(bytes32 depositDataBufferId) external view returns (bool) {
+        return _processed[depositDataBufferId];
     }
 
     function getWriter() external pure returns (address) {

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -27,6 +27,7 @@ import "../mocks/DepositContractInvalidMock.sol";
 contract MockDepositDataBuffer is IDepositDataBuffer {
     mapping(bytes32 => DepositObject) internal _batches;
     mapping(bytes32 => bool) internal _exists;
+    mapping(bytes32 => bool) internal _processed;
 
     function submitDepositData(bytes32 depositDataBufferId, DepositObject calldata batch) external {
         if (_exists[depositDataBufferId]) revert DepositDataBufferIdAlreadyExists(depositDataBufferId);
@@ -46,12 +47,33 @@ contract MockDepositDataBuffer is IDepositDataBuffer {
         return _batches[depositDataBufferId];
     }
 
+    function markDepositDataProcessed(bytes32 depositDataBufferId) external virtual {
+        if (!_exists[depositDataBufferId]) revert DepositDataBufferIdNotFound(depositDataBufferId);
+        if (_processed[depositDataBufferId]) revert DepositDataBufferIdAlreadyExists(depositDataBufferId);
+        _processed[depositDataBufferId] = true;
+        emit DepositDataProcessed(depositDataBufferId);
+    }
+
+    function isDepositDataProcessed(bytes32 depositDataBufferId) external view returns (bool) {
+        return _processed[depositDataBufferId];
+    }
+
     function getWriter() external pure returns (address) {
         return address(0);
     }
 
     function getAdmin() external pure returns (address) {
         return address(0);
+    }
+}
+
+/// @dev Buffer variant whose `markDepositDataProcessed` always reverts, used to prove River
+///      propagates a buffer-side failure (no swallowing) rather than completing the deposit.
+contract RevertOnMarkDepositDataBuffer is MockDepositDataBuffer {
+    error MarkRejected();
+
+    function markDepositDataProcessed(bytes32) external pure override {
+        revert MarkRejected();
     }
 }
 
@@ -267,6 +289,7 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
     event SetTotalDepositedETH(uint256 oldTotalDepositedETH, uint256 newTotalDepositedETH);
     event PubkeyFunded(bytes32 indexed depositDataBufferId, uint256 indexed operatorIdx, bytes pubkey, uint256 amount);
     event TopUp(bytes32 indexed depositDataBufferId, uint256 indexed operatorIdx, bytes pubkey, uint256 amount);
+    event DepositDataProcessed(bytes32 indexed depositDataBufferId);
 
     function _emptyDepositY() internal pure returns (BLS12_381.DepositY memory) {
         return BLS12_381.DepositY({
@@ -571,6 +594,59 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         assertEq(depositContract.deposit_count(), 2, "should have 2 total deposits");
         assertEq(dm.getTotalDepositedETH(), 64 ether);
         assertEq(dm.getCommittedBalance(), 64 ether);
+    }
+
+    // -----------------------------------------------------------------------
+    // DepositDataBuffer processed-flag cross-contract call (issue #621)
+    // -----------------------------------------------------------------------
+
+    /// @dev A successful attested deposit flips the buffer's own `processed` flag via the
+    ///      River-gated `markDepositDataProcessed` call (step 5b) and emits DepositDataProcessed.
+    function testSuccessfulDeposit_marksBufferProcessed() public {
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](1);
+        deposits[0] = _makeDeposit(0, 314);
+
+        (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits);
+
+        assertFalse(buffer.isDepositDataProcessed(bufferId), "batch must start unprocessed");
+
+        // The buffer flips its own processed flag as part of the deposit (step 5b).
+        vm.expectEmit(true, false, false, true, address(buffer));
+        emit DepositDataProcessed(bufferId);
+
+        vm.prank(keeper);
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+
+        assertTrue(buffer.isDepositDataProcessed(bufferId), "batch must be marked processed after deposit");
+    }
+
+    /// @dev A revert from the buffer's markDepositDataProcessed propagates and reverts the whole
+    ///      deposit — River does not swallow the failure. No deposits execute.
+    function testRevert_bufferMarkRejectionRevertsDeposit() public {
+        // Point the verifier (River's source of the buffer address) at a buffer whose
+        // markDepositDataProcessed always reverts.
+        RevertOnMarkDepositDataBuffer revertingBuffer = new RevertOnMarkDepositDataBuffer();
+        vm.prank(admin);
+        verifier.setDepositDataBuffer(address(revertingBuffer));
+
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](1);
+        deposits[0] = _makeDeposit(0, 271);
+        IDepositDataBuffer.DepositObject memory batch = _batchOf(deposits);
+        bytes32 bufferId = keccak256(abi.encode(batch));
+        revertingBuffer.submitDepositData(bufferId, batch);
+
+        bytes32 rootHash = depositContract.get_deposit_root();
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _signAttestation(rootAttesterPk1, bufferId, rootHash);
+        sigs[1] = _signAttestation(rootAttesterPk2, bufferId, rootHash);
+
+        vm.prank(keeper);
+        vm.expectRevert(RevertOnMarkDepositDataBuffer.MarkRejected.selector);
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+
+        // The whole tx reverted: nothing was deposited.
+        assertEq(depositContract.deposit_count(), 0, "no deposits should have executed");
+        assertEq(dm.getTotalDepositedETH(), 0, "total deposited must remain zero");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #621.

After River successfully executes `depositToConsensusLayerWithAttestation` for a batch it read from the on-chain `DepositDataBuffer`, River now makes a **cross-contract call to the buffer** to flip that batch's `processed` flag — so the buffer itself can never re-serve/re-queue the same batch. This adopts the buffer-side interface added in [AlluvialFinance/frontrun-mitigation#32](https://github.com/AlluvialFinance/frontrun-mitigation/pull/32) (`markDepositDataProcessed(bytes32)`, River-gated, emits `DepositDataProcessed`).

The existing **local** replay guard is unchanged and remains the primary in-tx protection: `AttestationVerifier` still marks processed ids in `ProcessedDepositDataBufferIds` via `verifier.markDepositDataBufferIdProcessed(...)`. This PR adds the missing *outward* notification to the buffer.

## Changes

- **`IDepositDataBuffer.sol`** — add `markDepositDataProcessed(bytes32)`, `isDepositDataProcessed(bytes32)`, and the `DepositDataProcessed` event.
- **`ConsensusLayerDepositManager.1.sol`** — new step **5b** in `depositToConsensusLayerWithAttestation`: `IDepositDataBuffer(verifier.getDepositDataBuffer()).markDepositDataProcessed(depositDataBufferId)`. The call originates from the River contract (so `msg.sender` at the buffer is the River proxy, matching the buffer's `RIVER` gate) and the buffer address is sourced from the verifier — no new River storage/init/setter. A buffer-side revert (unknown / already-processed) aborts the whole deposit (**hard revert**, no swallowing).
- **Test mocks** — implement the new interface members across the three `IDepositDataBuffer` mocks (`River.1.t.sol`, `ConsensusLayerDepositManagerAttestation.t.sol`, `AccountingHarnessBase.sol`).
- **Tests** — `testSuccessfulDeposit_marksBufferProcessed` (flag flips + `DepositDataProcessed` emitted) and `testRevert_bufferMarkRejectionRevertsDeposit` (buffer revert propagates, no deposits execute).

## Notes / scope

- **Interface divergence (out of scope):** the LC repo's `IDepositDataBuffer.sol` uses a different data model and `depositDataBufferId` derivation than the frontrun-mitigation buffer. This PR only adopts the `markDepositDataProcessed(bytes32)` method signature and stays self-consistent within this repo; reconciling the two data models is a separate integration concern.
- **Deployment:** the deployed buffer's immutable `RIVER` must be set to the River proxy address (a frontrun-mitigation deployment concern).

## Testing

- `forge test --match-path "contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol"` → 106 passed
- `forge test --match-contract RiverV1` → 116 passed
- Accounting suites → 57 passed
- `forge fmt --check` clean