### PR TITLE
fix(deposit/consolidation): pre-pectra pubkeys cannot be deposited to unless they undergo self-consolidation first

### DIFF
--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -457,6 +457,13 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             if (PectraValidatorPubkeyLookup.isPubkeyFunded(d.pubkey)) {
                 revert PubkeyAlreadyFunded(d.pubkey);
             }
+            // A migrated pre-Pectra (0x01) key must be promoted via self-consolidation, not
+            // reintroduced as a fresh initial deposit. Gating here keeps the pre-Pectra lookup
+            // authoritative and preserves the migration state machine even if a producer or
+            // attester batch is malformed.
+            if (PrePectraValidatorPubkeyLookup.isPubkeyFunded(d.pubkey)) {
+                revert PrePectraValidatorPubkeyNotConsolidated(d.pubkey);
+            }
             for (uint256 j = 0; j < i; j++) {
                 if (pubkeyHashes[j] == pkHash) {
                     revert PubkeyAlreadyFunded(d.pubkey);
@@ -476,6 +483,12 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             }
             totalAmount += t.amount;
 
+            // Explicitly reject migrated pre-Pectra keys with a distinct error. Such a key is not
+            // in the Pectra lookup so it would otherwise revert as TopUpPubkeyNotFunded; the
+            // dedicated error tells producers the key must be self-consolidated first.
+            if (PrePectraValidatorPubkeyLookup.isPubkeyFunded(t.pubkey)) {
+                revert PrePectraValidatorPubkeyNotConsolidated(t.pubkey);
+            }
             if (!PectraValidatorPubkeyLookup.isPubkeyFunded(t.pubkey)) {
                 revert TopUpPubkeyNotFunded(t.pubkey);
             }

--- a/contracts/src/interfaces/IAttestationVerifierPectraMigration.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifierPectraMigration.1.sol
@@ -36,6 +36,12 @@ interface IAttestationVerifierPectraMigrationV1 {
     /// @param pubkey The 48-byte BLS pubkey
     error PrePectraValidatorPubkeyNotFunded(bytes pubkey);
 
+    /// @notice A batch referenced a pubkey still in the pre-Pectra lookup as if it were a
+    ///         Pectra validator. Migrated legacy keys must first be promoted via
+    ///         self-consolidation before they can be initial-deposited or topped up.
+    /// @param pubkey The offending 48-byte BLS pubkey
+    error PrePectraValidatorPubkeyNotConsolidated(bytes pubkey);
+
     /// @notice The self consolidation batch is empty.
     error InvalidSelfConsolidationEmptyPubkeys();
 

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -1197,6 +1197,43 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         assertTrue(verifier.isPubkeyFunded(pk1), "pk1 added to post-Pectra");
     }
 
+    // After a self-consolidation promotes a migrated pre-Pectra key, the pre-Pectra gate must
+    // stop firing and the Pectra gate must take over: the key is now usable for top-ups and is
+    // rejected from re-deposit as already funded. Proves the promotion completes the migration
+    // state machine end-to-end (removal from the pre-Pectra lookup is load-bearing for gating).
+    function testSelfConsolidation_promotedPubkeyIsTopUpableAndNotRedepositable() public {
+        uint256 operatorIdx = 3;
+        uint256 seed = 622;
+        prePectraRegistry.setPrePectraFundedValidatorCount(operatorIdx, 1);
+        bytes memory pubkey = _seedPrePectraValidator(operatorIdx, 0, seed);
+
+        vm.prank(admin);
+        verifier.migratePrePectraValidatorPubkeys(operatorIdx, 0, 1);
+
+        bytes[] memory pubkeys = new bytes[](1);
+        pubkeys[0] = pubkey;
+        vm.prank(address(dm));
+        verifier.validateSelfConsolidation(pubkeys);
+
+        assertFalse(verifier.isPrePectraValidatorPubkeyFunded(pubkey), "pre-Pectra entry cleared by promotion");
+        assertTrue(verifier.isPubkeyFunded(pubkey), "post-Pectra entry added by promotion");
+
+        // Top-up now succeeds: the key is a recognised Pectra validator.
+        IDepositDataBuffer.TopUp[] memory topUps = new IDepositDataBuffer.TopUp[](1);
+        topUps[0] = _makeTopUpDeposit(operatorIdx, seed);
+        (bytes32 topUpId, bytes32 topUpRoot, bytes[] memory topUpSigs) = _prepareTopUps(topUps);
+        vm.prank(keeper);
+        dm.depositToConsensusLayerWithAttestation(topUpId, topUpRoot, topUpSigs);
+
+        // Re-deposit of the promoted key is rejected as already funded, not as a fresh deposit.
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](1);
+        deposits[0] = _makeDeposit(operatorIdx, seed);
+        (bytes32 depositId, bytes32 depositRoot, bytes[] memory depositSigs) = _prepareDeposit(deposits);
+        vm.prank(keeper);
+        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.PubkeyAlreadyFunded.selector, deposits[0].pubkey));
+        dm.depositToConsensusLayerWithAttestation(depositId, depositRoot, depositSigs);
+    }
+
     function testValidateSelfConsolidation_revertsWhenCallerNotRiver() public {
         uint256 operatorIdx = 9;
         prePectraRegistry.setPrePectraFundedValidatorCount(operatorIdx, 1);
@@ -1350,8 +1387,41 @@ contract ConsensusLayerDepositManagerAttestationTest is Test {
         (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareTopUps(topUps);
 
         vm.prank(keeper);
-        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.TopUpPubkeyNotFunded.selector, topUps[0].pubkey));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAttestationVerifierPectraMigrationV1.PrePectraValidatorPubkeyNotConsolidated.selector, topUps[0].pubkey
+            )
+        );
         dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+    }
+
+    function testDeposit_migratedPrePectraPubkeyRevertsInValidate() public {
+        uint256 operatorIdx = 3;
+        uint256 seed = 621;
+        prePectraRegistry.setPrePectraFundedValidatorCount(operatorIdx, 1);
+        bytes memory pubkey = _seedPrePectraValidator(operatorIdx, 0, seed);
+
+        vm.prank(admin);
+        verifier.migratePrePectraValidatorPubkeys(operatorIdx, 0, 1);
+        assertTrue(verifier.isPrePectraValidatorPubkeyFunded(pubkey), "pre-Pectra lookup migration");
+        assertFalse(verifier.isPubkeyFunded(pubkey), "runtime lookup still empty");
+
+        IDepositDataBuffer.Deposit[] memory deposits = new IDepositDataBuffer.Deposit[](1);
+        deposits[0] = _makeDeposit(operatorIdx, seed);
+        (bytes32 bufferId, bytes32 rootHash, bytes[] memory sigs) = _prepareDeposit(deposits);
+
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAttestationVerifierPectraMigrationV1.PrePectraValidatorPubkeyNotConsolidated.selector,
+                deposits[0].pubkey
+            )
+        );
+        dm.depositToConsensusLayerWithAttestation(bufferId, rootHash, sigs);
+
+        // The migrated key must never be recorded as a fresh Pectra deposit.
+        assertFalse(verifier.isPubkeyFunded(pubkey), "runtime lookup must remain empty after revert");
+        assertTrue(verifier.isPrePectraValidatorPubkeyFunded(pubkey), "pre-Pectra lookup unchanged after revert");
     }
 
     /// @dev Re-using a processed `depositDataBufferId` must revert with `DepositDataBufferIdAlreadyProcessed`.


### PR DESCRIPTION
## Description

This addresses this issue : https://github.com/liquid-collective/liquid-collective-protocol/issues/591

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->
This pull request introduces stricter checks and clearer error handling for migrated pre-Pectra validator keys to ensure the correct migration flow and prevent malformed state transitions. The changes enforce that a migrated pre-Pectra (0x01) key must be promoted via self-consolidation before it can be used for initial deposits or top-ups, and provides dedicated error messages for these scenarios. Comprehensive tests have been added to verify the migration state machine and error handling.

**Validator key migration enforcement and error handling:**

* Added a check in `AttestationVerifierV1` to reject deposits and top-ups for migrated pre-Pectra keys that have not been promoted via self-consolidation, reverting with a new `PrePectraValidatorPubkeyNotConsolidated` error. This ensures the migration state machine is preserved and prevents malformed batches from bypassing the intended process. [[1]](diffhunk://#diff-2cbbaf82cf40abbadf2169784f860b0a4a2fc2bf356e6e03305e081c2a69b90aR460-R466) [[2]](diffhunk://#diff-2cbbaf82cf40abbadf2169784f860b0a4a2fc2bf356e6e03305e081c2a69b90aR486-R491)
* Introduced the `PrePectraValidatorPubkeyNotConsolidated` custom error in `IAttestationVerifierPectraMigrationV1` to provide clearer feedback when such keys are incorrectly referenced as Pectra validators.

**Test coverage improvements:**

* Added tests in `ConsensusLayerDepositManagerAttestation.t.sol` to verify that after self-consolidation, a promoted key can be topped up and cannot be re-deposited, confirming the end-to-end correctness of the migration state machine.
* Updated and expanded tests to check that attempts to deposit or top-up a migrated pre-Pectra key before self-consolidation are rejected with the new error, and that the key's state remains unchanged after such reverts.

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deposit validation for migrated validator keys, rejecting invalid deposits earlier and with clearer errors.
  * Top-ups now correctly distinguish between not-yet-consolidated migrated keys and keys that are simply unfunded.
  * Promoted keys can be topped up after consolidation, while duplicate redeposits still fail as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->