### PR TITLE
docs: note fundedETH sum invariant at registry trust boundary (#585)

### DIFF
--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -240,6 +240,8 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
                 revert MisalignedDeltaArrays(operatorIndex, delta.topUpPubkeys.length, delta.topUpAmounts.length);
             }
 
+            // Trusts delta.fundedETH == sum(deposit+topUp amounts) by construction (LibFundingDeltas.build).
+            // Revisit this assumption if any non-builder call path can reach here — see the NatSpec @dev.
             operator.funded += delta.fundedETH;
             // Emit initial-deposit pubkeys and top-up pubkeys on separate events so off-chain
             // indexers do not conflate a top-up (existing key, additional ETH) with a brand-new

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -346,6 +346,14 @@ interface IOperatorsRegistryV1 {
     /// @dev Reverts with OperatorIndicesUnsortedOrDuplicate when deltas are not strictly ascending
     /// @dev Reverts with InactiveOperator when a referenced operator is inactive
     /// @dev Reverts with OperatorIgnoredExitRequests when a referenced operator has unfulfilled exit requests
+    /// @dev `delta.fundedETH` is trusted to equal `sum(depositAmounts) + sum(topUpAmounts)` and is NOT
+    ///      re-derived on-chain. This holds by construction: the only path that builds these deltas is
+    ///      `LibFundingDeltas.build` (reached via River's `_incrementFundedETH`), which computes
+    ///      `fundedETH` and the per-key deposit/top-up amounts from the same source, so an explicit sum
+    ///      check would only add O(n) gas for a condition that cannot fail. If a future
+    ///      change lets deltas NOT produced by `LibFundingDeltas.build` reach this function, this
+    ///      invariant must be re-validated here (e.g. reinstate a `fundedETH == sum(amounts)` assertion)
+    ///      before the `operator.funded += delta.fundedETH` mutation can be trusted.
     /// @param _deltas The per-operator funded ETH updates
     function incrementFundedETH(OperatorFundingDelta[] calldata _deltas) external;
 


### PR DESCRIPTION
Document that incrementFundedETH trusts delta.fundedETH == sum(deposit + top-up amounts) by construction via LibFundingDeltas.build, and flag it to be re-validated if a future flow lets non-builder deltas reach the handler. Resolves the follow-up from #585 (comment over runtime assertion).

## Description

<!-- Please provide a detailed description of your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->