### PR TITLE
Fix consolidation source pubkey replay protection (BS-4423)

### DIFF
--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -653,32 +653,7 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         if (consolidation.totalAmount == 0) revert ZeroConsolidationTotalAmount();
         if (consolidation.withdrawalAddress == address(0)) revert ZeroConsolidationWithdrawalAddress();
 
-        // 2. Per-pair pubkey checks. Source hashes are retained for in-request
-        //    duplicate detection and EIP-712 array hashing; the processed-source
-        //    registry below keys on the raw pubkey.
-        bytes32[] memory sourcePubkeyHashes = new bytes32[](sourceLen);
-        bytes32[] memory targetPubkeyHashes = new bytes32[](targetLen);
-        for (uint256 i = 0; i < sourceLen; ++i) {
-            bytes calldata sourcePubkey = consolidation.sourcePubkeys[i];
-            if (sourcePubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
-                revert InvalidConsolidationPubkeyLength(i, sourcePubkey.length, true);
-            }
-            bytes32 sourcePubkeyHash = keccak256(sourcePubkey);
-            sourcePubkeyHashes[i] = sourcePubkeyHash;
-            for (uint256 j = 0; j < i; ++j) {
-                if (sourcePubkeyHashes[j] == sourcePubkeyHash) {
-                    revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
-                }
-            }
-
-            bytes calldata targetPubkey = consolidation.targetPubkeys[i];
-            if (targetPubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
-                revert InvalidConsolidationPubkeyLength(i, targetPubkey.length, false);
-            }
-            targetPubkeyHashes[i] = keccak256(targetPubkey);
-        }
-
-        // 3. Compute the EIP-712 digest the committee signed.
+        // 2. Compute the EIP-712 digest the committee signed.
         //    The struct's `signatures` field is NOT part of the typed data — only the four
         //    request fields are. `bytes[]` arrays follow EIP-712 array rules: each element
         //    becomes `keccak256(element)`, then the array hashes to `keccak256` over the
@@ -689,17 +664,35 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             abi.encode(
                 ATTEST_CONSOLIDATION_TYPEHASH,
                 consolidation.withdrawalAddress,
-                keccak256(abi.encodePacked(sourcePubkeyHashes)),
-                keccak256(abi.encodePacked(targetPubkeyHashes)),
+                _hashBytesArray(consolidation.sourcePubkeys),
+                _hashBytesArray(consolidation.targetPubkeys),
                 consolidation.totalAmount
             )
         );
 
-        // 4. Replay protection — reject any consolidation we've already accepted.
+        // 3. Replay protection — reject any consolidation we've already accepted.
         //    Checked BEFORE quorum verification so a previously-accepted request fails fast
         //    even if the supplied signatures happen to be valid again.
         if (ProcessedConsolidations.isProcessed(structHash)) {
             revert ConsolidationAlreadyProcessed(structHash);
+        }
+
+        // 4. Per-pair pubkey checks.
+        for (uint256 i = 0; i < sourceLen; ++i) {
+            bytes calldata sourcePubkey = consolidation.sourcePubkeys[i];
+            if (sourcePubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
+                revert InvalidConsolidationPubkeyLength(i, sourcePubkey.length, true);
+            }
+            for (uint256 j = 0; j < i; ++j) {
+                if (_bytesEqual(consolidation.sourcePubkeys[j], sourcePubkey)) {
+                    revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
+                }
+            }
+
+            bytes calldata targetPubkey = consolidation.targetPubkeys[i];
+            if (targetPubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
+                revert InvalidConsolidationPubkeyLength(i, targetPubkey.length, false);
+            }
         }
 
         // 5. Distinct requests can share a source while hashing differently, so source
@@ -815,6 +808,24 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         }
 
         if (validCount < quorum) revert InsufficientConsolidationAttestations(validCount, quorum);
+    }
+
+    /// @dev EIP-712 array hash for a `bytes[]` field. Each element is replaced by its
+    ///      `keccak256`, and the resulting `bytes32[]` is concatenated and hashed.
+    function _hashBytesArray(bytes[] calldata arr) internal pure returns (bytes32) {
+        bytes32[] memory hashes = new bytes32[](arr.length);
+        for (uint256 i = 0; i < arr.length; i++) {
+            hashes[i] = keccak256(arr[i]);
+        }
+        return keccak256(abi.encodePacked(hashes));
+    }
+
+    function _bytesEqual(bytes calldata a, bytes calldata b) internal pure returns (bool) {
+        if (a.length != b.length) return false;
+        for (uint256 i = 0; i < a.length; ++i) {
+            if (a[i] != b[i]) return false;
+        }
+        return true;
     }
 
     /// @notice Verify the BLS signatures of all initial deposits against the canonical River

--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -668,13 +668,12 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         //    concatenation of those 32-byte element hashes.
         bytes32 domainSep = ConsolidationDomainSeparator.get();
         if (domainSep == bytes32(0)) revert ZeroConsolidationDomainSeparator();
-        (bytes32 sourcePubkeysHash, bytes32[] memory sourcePubkeyHashes) =
-            _hashBytesArrayWithElementHashes(consolidation.sourcePubkeys);
+        bytes32[] memory sourcePubkeyHashes = _hashBytesArrayElements(consolidation.sourcePubkeys);
         bytes32 structHash = keccak256(
             abi.encode(
                 ATTEST_CONSOLIDATION_TYPEHASH,
                 consolidation.withdrawalAddress,
-                sourcePubkeysHash,
+                keccak256(abi.encodePacked(sourcePubkeyHashes)),
                 _hashBytesArray(consolidation.targetPubkeys),
                 consolidation.totalAmount
             )
@@ -812,20 +811,14 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     /// @dev EIP-712 array hash for a `bytes[]` field. Each element is replaced by its
     ///      `keccak256`, and the resulting `bytes32[]` is concatenated and hashed.
     function _hashBytesArray(bytes[] calldata arr) internal pure returns (bytes32) {
-        (bytes32 arrayHash,) = _hashBytesArrayWithElementHashes(arr);
-        return arrayHash;
+        return keccak256(abi.encodePacked(_hashBytesArrayElements(arr)));
     }
 
-    function _hashBytesArrayWithElementHashes(bytes[] calldata arr)
-        internal
-        pure
-        returns (bytes32 arrayHash, bytes32[] memory hashes)
-    {
+    function _hashBytesArrayElements(bytes[] calldata arr) internal pure returns (bytes32[] memory hashes) {
         hashes = new bytes32[](arr.length);
         for (uint256 i = 0; i < arr.length; i++) {
             hashes[i] = keccak256(arr[i]);
         }
-        arrayHash = keccak256(abi.encodePacked(hashes));
     }
 
     function _bytesEqual(bytes calldata a, bytes calldata b) internal pure returns (bool) {

--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -683,31 +683,20 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             if (sourcePubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
                 revert InvalidConsolidationPubkeyLength(i, sourcePubkey.length, true);
             }
-            for (uint256 j = 0; j < i; ++j) {
-                if (_bytesEqual(consolidation.sourcePubkeys[j], sourcePubkey)) {
-                    revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
-                }
+            if (ProcessedConsolidationSourcePubkeys.isProcessed(sourcePubkey)) {
+                revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
             }
-
             bytes calldata targetPubkey = consolidation.targetPubkeys[i];
             if (targetPubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
                 revert InvalidConsolidationPubkeyLength(i, targetPubkey.length, false);
             }
         }
 
-        // 5. Distinct requests can share a source while hashing differently, so source
-        //    consumption is checked separately from the request-level replay guard.
-        for (uint256 i = 0; i < sourceLen; ++i) {
-            if (ProcessedConsolidationSourcePubkeys.isProcessed(consolidation.sourcePubkeys[i])) {
-                revert ConsolidationSourceAlreadyProcessed(consolidation.sourcePubkeys[i]);
-            }
-        }
-
-        // 6. Verify the consolidation attestation quorum from the supplied signatures
+        // 5. Verify the consolidation attestation quorum from the supplied signatures
         bytes32 digest = ECDSA.toTypedDataHash(domainSep, structHash);
         _verifyConsolidationAttestationQuorum(digest, consolidation.signatures);
 
-        // 7. Mark the request and all of its sources as processed only after quorum
+        // 6. Mark the request and all of its sources as processed only after quorum
         //    succeeds, so malformed signatures cannot burn a source pubkey.
         ProcessedConsolidations.markProcessed(structHash);
         for (uint256 i = 0; i < sourceLen; ++i) {

--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -28,6 +28,7 @@ import "./state/attestationVerifier/DomainSeparator.sol";
 import "./state/attestationVerifier/ProcessedDepositDataBufferIds.sol";
 import "./state/attestationVerifier/PectraValidatorPubkeyLookup.sol";
 import "./state/attestationVerifier/PrePectraValidatorPubkeyLookup.sol";
+import "./state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol";
 import "./state/shared/RiverAddress.sol";
 
 /// @title AttestationVerifier (v1)
@@ -627,12 +628,11 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     }
 
     /// @inheritdoc IAttestationVerifierV1
-    /// @dev Trust boundary: this function only validates structural shape (array shapes
-    ///      and pubkey byte lengths) and the attestation quorum (ECDSA signature recovery
-    ///      against the consolidation committee). It does NOT check:
-    ///        - Source/target pubkey uniqueness within the request (EIP-7251 single-use
-    ///          source rule). A source pubkey appearing twice, or a pubkey appearing in
-    ///          both source and target arrays, is not rejected here.
+    /// @dev Trust boundary: this function validates structural shape (array shapes,
+    ///      pubkey byte lengths, and single-use source pubkeys) plus the attestation
+    ///      quorum (ECDSA signature recovery against the consolidation committee). It
+    ///      does NOT check:
+    ///        - Target pubkey uniqueness.
     ///        - `totalAmount` gwei alignment, upper bound, or correlation with the number
     ///          of (source, target) pairs.
     ///        - Whether the source validators actually exist on the consensus layer or
@@ -653,14 +653,29 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         if (consolidation.totalAmount == 0) revert ZeroConsolidationTotalAmount();
         if (consolidation.withdrawalAddress == address(0)) revert ZeroConsolidationWithdrawalAddress();
 
-        // 2. Per-pair pubkey length checks
-        for (uint256 i = 0; i < sourceLen; i++) {
-            if (consolidation.sourcePubkeys[i].length != CONSOLIDATION_PUBKEY_LENGTH) {
-                revert InvalidConsolidationPubkeyLength(i, consolidation.sourcePubkeys[i].length, true);
+        // 2. Per-pair pubkey checks. Source hashes are retained for in-request
+        //    duplicate detection and EIP-712 array hashing; the processed-source
+        //    registry below keys on the raw pubkey.
+        bytes32[] memory sourcePubkeyHashes = new bytes32[](sourceLen);
+        bytes32[] memory targetPubkeyHashes = new bytes32[](targetLen);
+        for (uint256 i = 0; i < sourceLen; ++i) {
+            bytes calldata sourcePubkey = consolidation.sourcePubkeys[i];
+            if (sourcePubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
+                revert InvalidConsolidationPubkeyLength(i, sourcePubkey.length, true);
             }
-            if (consolidation.targetPubkeys[i].length != CONSOLIDATION_PUBKEY_LENGTH) {
-                revert InvalidConsolidationPubkeyLength(i, consolidation.targetPubkeys[i].length, false);
+            bytes32 sourcePubkeyHash = keccak256(sourcePubkey);
+            sourcePubkeyHashes[i] = sourcePubkeyHash;
+            for (uint256 j = 0; j < i; ++j) {
+                if (sourcePubkeyHashes[j] == sourcePubkeyHash) {
+                    revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
+                }
             }
+
+            bytes calldata targetPubkey = consolidation.targetPubkeys[i];
+            if (targetPubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
+                revert InvalidConsolidationPubkeyLength(i, targetPubkey.length, false);
+            }
+            targetPubkeyHashes[i] = keccak256(targetPubkey);
         }
 
         // 3. Compute the EIP-712 digest the committee signed.
@@ -674,8 +689,8 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             abi.encode(
                 ATTEST_CONSOLIDATION_TYPEHASH,
                 consolidation.withdrawalAddress,
-                _hashBytesArray(consolidation.sourcePubkeys),
-                _hashBytesArray(consolidation.targetPubkeys),
+                keccak256(abi.encodePacked(sourcePubkeyHashes)),
+                keccak256(abi.encodePacked(targetPubkeyHashes)),
                 consolidation.totalAmount
             )
         );
@@ -687,12 +702,24 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             revert ConsolidationAlreadyProcessed(structHash);
         }
 
-        // 5. Verify the consolidation attestation quorum from the supplied signatures
+        // 5. Distinct requests can share a source while hashing differently, so source
+        //    consumption is checked separately from the request-level replay guard.
+        for (uint256 i = 0; i < sourceLen; ++i) {
+            if (ProcessedConsolidationSourcePubkeys.isProcessed(consolidation.sourcePubkeys[i])) {
+                revert ConsolidationSourceAlreadyProcessed(consolidation.sourcePubkeys[i]);
+            }
+        }
+
+        // 6. Verify the consolidation attestation quorum from the supplied signatures
         bytes32 digest = ECDSA.toTypedDataHash(domainSep, structHash);
         _verifyConsolidationAttestationQuorum(digest, consolidation.signatures);
 
-        // 6. Mark as processed and emit
+        // 7. Mark the request and all of its sources as processed only after quorum
+        //    succeeds, so malformed signatures cannot burn a source pubkey.
         ProcessedConsolidations.markProcessed(structHash);
+        for (uint256 i = 0; i < sourceLen; ++i) {
+            ProcessedConsolidationSourcePubkeys.markProcessed(consolidation.sourcePubkeys[i]);
+        }
         emit ConsolidationProcessed(structHash);
     }
 
@@ -788,16 +815,6 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         }
 
         if (validCount < quorum) revert InsufficientConsolidationAttestations(validCount, quorum);
-    }
-
-    /// @dev EIP-712 array hash for a `bytes[]` field. Each element is replaced by its
-    ///      `keccak256`, and the resulting `bytes32[]` is concatenated and hashed.
-    function _hashBytesArray(bytes[] calldata arr) internal pure returns (bytes32) {
-        bytes32[] memory hashes = new bytes32[](arr.length);
-        for (uint256 i = 0; i < arr.length; i++) {
-            hashes[i] = keccak256(arr[i]);
-        }
-        return keccak256(abi.encodePacked(hashes));
     }
 
     /// @notice Verify the BLS signatures of all initial deposits against the canonical River

--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -632,15 +632,11 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     ///      pubkey byte lengths, and single-use source pubkeys) plus the attestation
     ///      quorum (ECDSA signature recovery against the consolidation committee). It
     ///      does NOT check:
-    ///        - Target pubkey uniqueness.
     ///        - `totalAmount` gwei alignment, upper bound, or correlation with the number
     ///          of (source, target) pairs.
-    ///        - Whether the source validators actually exist on the consensus layer or
-    ///          carry the protocol's withdrawal credentials.
+    ///        - Whether the source validators actually exist on the consensus layer
     ///      These are the responsibility of the caller (off-chain pipeline) and the
-    ///      consolidation committee that signs the request. The eventual
-    ///      `mintLsETHForConsolidation` River integration is the place to enforce any
-    ///      additional financial caps on `totalAmount`.
+    ///      consolidation committee that signs the request.
     function validateConsolidation(IAttestationVerifierV1.ConsolidationObject calldata consolidation)
         external
         onlyRiver
@@ -653,7 +649,19 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         if (consolidation.totalAmount == 0) revert ZeroConsolidationTotalAmount();
         if (consolidation.withdrawalAddress == address(0)) revert ZeroConsolidationWithdrawalAddress();
 
-        // 2. Compute the EIP-712 digest the committee signed.
+        // 2. Per-pair pubkey length checks, before hashing dynamic bytes.
+        for (uint256 i = 0; i < sourceLen; ++i) {
+            uint256 sourcePubkeyLength = consolidation.sourcePubkeys[i].length;
+            if (sourcePubkeyLength != CONSOLIDATION_PUBKEY_LENGTH) {
+                revert InvalidConsolidationPubkeyLength(i, sourcePubkeyLength, true);
+            }
+            uint256 targetPubkeyLength = consolidation.targetPubkeys[i].length;
+            if (targetPubkeyLength != CONSOLIDATION_PUBKEY_LENGTH) {
+                revert InvalidConsolidationPubkeyLength(i, targetPubkeyLength, false);
+            }
+        }
+
+        // 3. Compute the EIP-712 digest the committee signed.
         //    The struct's `signatures` field is NOT part of the typed data — only the four
         //    request fields are. `bytes[]` arrays follow EIP-712 array rules: each element
         //    becomes `keccak256(element)`, then the array hashes to `keccak256` over the
@@ -672,19 +680,16 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             )
         );
 
-        // 3. Replay protection — reject any consolidation we've already accepted.
+        // 4. Replay protection — reject any consolidation we've already accepted.
         //    Checked BEFORE quorum verification so a previously-accepted request fails fast
         //    even if the supplied signatures happen to be valid again.
         if (ProcessedConsolidations.isProcessed(structHash)) {
             revert ConsolidationAlreadyProcessed(structHash);
         }
 
-        // 4. Per-pair pubkey checks.
+        // 5. Per-source single-use checks.
         for (uint256 i = 0; i < sourceLen; ++i) {
             bytes calldata sourcePubkey = consolidation.sourcePubkeys[i];
-            if (sourcePubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
-                revert InvalidConsolidationPubkeyLength(i, sourcePubkey.length, true);
-            }
             if (ProcessedConsolidationSourcePubkeys.isProcessed(sourcePubkey)) {
                 revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
             }
@@ -697,22 +702,16 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
                     revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
                 }
             }
-            bytes calldata targetPubkey = consolidation.targetPubkeys[i];
-            if (targetPubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
-                revert InvalidConsolidationPubkeyLength(i, targetPubkey.length, false);
-            }
         }
 
-        // 5. Verify the consolidation attestation quorum from the supplied signatures
+        // 6. Verify the consolidation attestation quorum from the supplied signatures
         bytes32 digest = ECDSA.toTypedDataHash(domainSep, structHash);
         _verifyConsolidationAttestationQuorum(digest, consolidation.signatures);
 
-        // 6. Mark the request and all of its sources as processed only after quorum
+        // 7. Mark the request and all of its sources as processed only after quorum
         //    succeeds, so malformed signatures cannot burn a source pubkey.
         ProcessedConsolidations.markProcessed(structHash);
-        for (uint256 i = 0; i < sourceLen; ++i) {
-            ProcessedConsolidationSourcePubkeys.markProcessed(consolidation.sourcePubkeys[i]);
-        }
+        ProcessedConsolidationSourcePubkeys.markProcessed(consolidation.sourcePubkeys);
         emit ConsolidationProcessed(structHash);
     }
 

--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -104,6 +104,11 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     /// @dev Expected length for BLS pubkeys in a ConsolidationObject (source or target).
     uint256 internal constant CONSOLIDATION_PUBKEY_LENGTH = 48;
 
+    /// @dev keccak256 of an all-zero 48-byte pubkey; used to reject zero source pubkeys.
+    bytes32 internal constant ZERO_CONSOLIDATION_PUBKEY_HASH = keccak256(
+        hex"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    );
+
     // -----------------------------------------------------------------------
     // Modifiers
     // -----------------------------------------------------------------------
@@ -693,6 +698,9 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
                 revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
             }
             bytes32 sourcePubkeyHash = sourcePubkeyHashes[i];
+            if (sourcePubkeyHash == ZERO_CONSOLIDATION_PUBKEY_HASH) {
+                revert ZeroConsolidationSourcePubkey(i);
+            }
             for (uint256 j = 0; j < i; ++j) {
                 if (
                     sourcePubkeyHash == sourcePubkeyHashes[j]
@@ -711,7 +719,9 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         //    succeeds, so malformed signatures cannot burn a source pubkey.
         ProcessedConsolidations.markProcessed(structHash);
         ProcessedConsolidationSourcePubkeys.markProcessed(consolidation.sourcePubkeys);
-        emit ConsolidationProcessed(structHash);
+        emit ConsolidationProcessed(
+            structHash, consolidation.sourcePubkeys, consolidation.targetPubkeys, consolidation.totalAmount
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/src/AttestationVerifier.1.sol
+++ b/contracts/src/AttestationVerifier.1.sol
@@ -660,11 +660,13 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
         //    concatenation of those 32-byte element hashes.
         bytes32 domainSep = ConsolidationDomainSeparator.get();
         if (domainSep == bytes32(0)) revert ZeroConsolidationDomainSeparator();
+        (bytes32 sourcePubkeysHash, bytes32[] memory sourcePubkeyHashes) =
+            _hashBytesArrayWithElementHashes(consolidation.sourcePubkeys);
         bytes32 structHash = keccak256(
             abi.encode(
                 ATTEST_CONSOLIDATION_TYPEHASH,
                 consolidation.withdrawalAddress,
-                _hashBytesArray(consolidation.sourcePubkeys),
+                sourcePubkeysHash,
                 _hashBytesArray(consolidation.targetPubkeys),
                 consolidation.totalAmount
             )
@@ -685,6 +687,15 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
             }
             if (ProcessedConsolidationSourcePubkeys.isProcessed(sourcePubkey)) {
                 revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
+            }
+            bytes32 sourcePubkeyHash = sourcePubkeyHashes[i];
+            for (uint256 j = 0; j < i; ++j) {
+                if (
+                    sourcePubkeyHash == sourcePubkeyHashes[j]
+                        && _bytesEqual(sourcePubkey, consolidation.sourcePubkeys[j])
+                ) {
+                    revert ConsolidationSourceAlreadyProcessed(sourcePubkey);
+                }
             }
             bytes calldata targetPubkey = consolidation.targetPubkeys[i];
             if (targetPubkey.length != CONSOLIDATION_PUBKEY_LENGTH) {
@@ -802,11 +813,20 @@ contract AttestationVerifierV1 is Initializable, IAttestationVerifierV1, IAttest
     /// @dev EIP-712 array hash for a `bytes[]` field. Each element is replaced by its
     ///      `keccak256`, and the resulting `bytes32[]` is concatenated and hashed.
     function _hashBytesArray(bytes[] calldata arr) internal pure returns (bytes32) {
-        bytes32[] memory hashes = new bytes32[](arr.length);
+        (bytes32 arrayHash,) = _hashBytesArrayWithElementHashes(arr);
+        return arrayHash;
+    }
+
+    function _hashBytesArrayWithElementHashes(bytes[] calldata arr)
+        internal
+        pure
+        returns (bytes32 arrayHash, bytes32[] memory hashes)
+    {
+        hashes = new bytes32[](arr.length);
         for (uint256 i = 0; i < arr.length; i++) {
             hashes[i] = keccak256(arr[i]);
         }
-        return keccak256(abi.encodePacked(hashes));
+        arrayHash = keccak256(abi.encodePacked(hashes));
     }
 
     function _bytesEqual(bytes calldata a, bytes calldata b) internal pure returns (bool) {

--- a/contracts/src/components/OracleManager.1.sol
+++ b/contracts/src/components/OracleManager.1.sol
@@ -17,7 +17,6 @@ import "../state/river/OracleAddress.sol";
 /// @notice values: the sum of all balances of all deposited validators and the count of
 /// @notice validators that have been activated on the consensus layer.
 abstract contract OracleManagerV1 is IOracleManagerV1 {
-
     /// @notice Handler called to retrieve the system administrator address
     /// @dev Must be overridden
     /// @return The system administrator address

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -250,6 +250,12 @@ interface IAttestationVerifierV1 {
     /// @notice The supplied consolidation has already been validated; replay rejected.
     /// @param consolidationHash The EIP-712 structHash of the consolidation request
     error ConsolidationAlreadyProcessed(bytes32 consolidationHash);
+
+    /// @notice A consolidation source pubkey was already consumed by a previous
+    ///         successful request or appears more than once in this request.
+    /// @param pubkey The offending 48-byte BLS source pubkey
+    error ConsolidationSourceAlreadyProcessed(bytes pubkey);
+
     /// @notice A top-up referenced a pubkey that has never been initial-deposited by River.
     ///         Without this check, a malicious committee could mark an attacker pubkey as a
     ///         top-up and bypass BLS verification.
@@ -368,14 +374,16 @@ interface IAttestationVerifierV1 {
     ///
     ///         Replay protection: the EIP-712 structHash is recorded in storage on success.
     ///         Subsequent calls with a struct that hashes to the same value revert with
-    ///         `ConsolidationAlreadyProcessed`. Note that this makes the function
-    ///         state-mutating (not `view`) and callable only by River.
+    ///         `ConsolidationAlreadyProcessed`. Each source pubkey is also recorded on
+    ///         success so distinct signed requests cannot reuse the same consolidation
+    ///         source. Note that this makes the function state-mutating (not `view`) and
+    ///         callable only by River.
     ///
     ///         Trust boundary: this function only validates structural shape and the attestation
     ///         quorum. The following are intentionally NOT checked here and are delegated to the
     ///         caller (off-chain pipeline / consolidation committee) or to the eventual River
     ///         integration:
-    ///           - Source/target pubkey uniqueness (EIP-7251 single-use source rule)
+    ///           - Target pubkey uniqueness
     ///           - `totalAmount` gwei alignment, upper bound, or correlation with pair count
     ///           - Financial caps (e.g. against committed/in-flight balances)
     /// @param consolidation The consolidation request to validate (withdrawal address,

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -379,10 +379,10 @@ interface IAttestationVerifierV1 {
     ///         source. Note that this makes the function state-mutating (not `view`) and
     ///         callable only by River.
     ///
-    ///         Trust boundary: this function only validates structural shape and the attestation
-    ///         quorum. The following are intentionally NOT checked here and are delegated to the
-    ///         caller (off-chain pipeline / consolidation committee) or to the eventual River
-    ///         integration:
+    ///         Trust boundary: this function validates structural shape, single-use source
+    ///         pubkeys, and the attestation quorum. The following are intentionally NOT checked
+    ///         here and are delegated to the caller (off-chain pipeline / consolidation committee)
+    ///         or to the eventual River integration:
     ///           - Target pubkey uniqueness
     ///           - `totalAmount` gwei alignment, upper bound, or correlation with pair count
     ///           - Financial caps (e.g. against committed/in-flight balances)

--- a/contracts/src/interfaces/IAttestationVerifier.1.sol
+++ b/contracts/src/interfaces/IAttestationVerifier.1.sol
@@ -75,7 +75,12 @@ interface IAttestationVerifierV1 {
     /// @notice Emitted when a consolidation request is successfully validated and
     ///         marked as processed for replay protection.
     /// @param consolidationHash The EIP-712 structHash of the consolidation request
-    event ConsolidationProcessed(bytes32 indexed consolidationHash);
+    /// @param sourcePubkeys The source pubkeys that were consolidated
+    /// @param targetPubkeys The target pubkeys that were consolidated
+    /// @param totalAmount The total amount that was consolidated
+    event ConsolidationProcessed(
+        bytes32 indexed consolidationHash, bytes[] sourcePubkeys, bytes[] targetPubkeys, uint256 totalAmount
+    );
 
     /// @notice Emitted when a batch of validator pubkeys is added to the Pectra lookup.
     /// @dev    Fires on every path that records membership in `PectraValidatorPubkeyLookup`:
@@ -220,6 +225,10 @@ interface IAttestationVerifierV1 {
     /// @param length The observed length
     /// @param isSource True if the offending pubkey is the source pubkey, false if it is the target pubkey
     error InvalidConsolidationPubkeyLength(uint256 index, uint256 length, bool isSource);
+
+    /// @notice A consolidation source pubkey is the all-zero 48-byte value.
+    /// @param index The pair index of the offending source pubkey
+    error ZeroConsolidationSourcePubkey(uint256 index);
 
     /// @notice The EIP-712 consolidation domain separator has not been initialized
     error ZeroConsolidationDomainSeparator();

--- a/contracts/src/libraries/LibOracleReporting.sol
+++ b/contracts/src/libraries/LibOracleReporting.sol
@@ -462,9 +462,8 @@ library LibOracleReporting {
         if (totalSupply > 0) {
             uint256 availableBalanceToRedeem = BalanceToRedeem.get();
             uint256 availableBalanceToDeposit = BalanceToDeposit.get();
-            uint256 redeemManagerDemandInEth = ISharesManagerV1(address(this)).underlyingBalanceFromShares(
-                IRedeemManagerV1(RedeemManagerAddress.get()).getRedeemDemand()
-            );
+            uint256 redeemManagerDemandInEth = ISharesManagerV1(address(this))
+                .underlyingBalanceFromShares(IRedeemManagerV1(RedeemManagerAddress.get()).getRedeemDemand());
 
             // if after all rebalancings, the redeem manager demand is still higher than the balance to redeem and exiting eth, we compute
             // the amount of ETH (wei) to exit in order to cover the remaining demand
@@ -686,10 +685,8 @@ library LibOracleReporting {
     /// @param _epoch The epoch to verify
     /// @return True if valid
     function _isValidEpoch(CLSpec.CLSpecStruct memory _cls, uint256 _epoch) internal view returns (bool) {
-        return (
-            _currentEpoch(_cls) >= _epoch + _cls.epochsToAssumedFinality
-                && _epoch > LastConsensusLayerReport.get().epoch && _epoch % _cls.epochsPerFrame == 0
-        );
+        return (_currentEpoch(_cls) >= _epoch + _cls.epochsToAssumedFinality
+                && _epoch > LastConsensusLayerReport.get().epoch && _epoch % _cls.epochsPerFrame == 0);
     }
 
     /// @notice Retrieves the maximum increase in balance based on current total underlying supply and period since last report

--- a/contracts/src/state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol
+++ b/contracts/src/state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol
@@ -1,0 +1,27 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../libraries/LibUnstructuredStorage.sol";
+
+/// @title ProcessedConsolidationSourcePubkeys
+/// @notice Unstructured-storage set of source pubkeys that have already been
+///         accepted by `validateConsolidation`.
+library ProcessedConsolidationSourcePubkeys {
+    bytes32 internal constant PROCESSED_CONSOLIDATION_SOURCE_PUBKEYS_MAPPING_BASE_SLOT =
+        bytes32(uint256(keccak256("attestationVerifier.state.processedConsolidationSourcePubkeys.mapping")) - 1);
+
+    /// @notice Check if a consolidation source pubkey has already been consumed.
+    /// @param sourcePubkey The raw 48-byte BLS source pubkey.
+    /// @return True if the source pubkey was already accepted by a successful consolidation.
+    function isProcessed(bytes calldata sourcePubkey) internal view returns (bool) {
+        bytes32 slot = keccak256(abi.encode(PROCESSED_CONSOLIDATION_SOURCE_PUBKEYS_MAPPING_BASE_SLOT, sourcePubkey));
+        return LibUnstructuredStorage.getStorageBool(slot);
+    }
+
+    /// @notice Mark a consolidation source pubkey as consumed.
+    /// @param sourcePubkey The raw 48-byte BLS source pubkey.
+    function markProcessed(bytes calldata sourcePubkey) internal {
+        bytes32 slot = keccak256(abi.encode(PROCESSED_CONSOLIDATION_SOURCE_PUBKEYS_MAPPING_BASE_SLOT, sourcePubkey));
+        LibUnstructuredStorage.setStorageBool(slot, true);
+    }
+}

--- a/contracts/src/state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol
+++ b/contracts/src/state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol
@@ -6,6 +6,7 @@ import "../../libraries/LibUnstructuredStorage.sol";
 /// @title ProcessedConsolidationSourcePubkeys
 /// @notice Unstructured-storage set of source pubkeys that have already been
 ///         accepted by `validateConsolidation`.
+/// @dev Please note that pubkeys should be migrated in case of updates if any.
 library ProcessedConsolidationSourcePubkeys {
     bytes32 internal constant PROCESSED_CONSOLIDATION_SOURCE_PUBKEYS_MAPPING_BASE_SLOT =
         bytes32(uint256(keccak256("attestationVerifier.state.processedConsolidationSourcePubkeys.mapping")) - 1);

--- a/contracts/src/state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol
+++ b/contracts/src/state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol
@@ -6,7 +6,8 @@ import "../../libraries/LibUnstructuredStorage.sol";
 /// @title ProcessedConsolidationSourcePubkeys
 /// @notice Unstructured-storage set of source pubkeys that have already been
 ///         accepted by `validateConsolidation`.
-/// @dev Please note that pubkeys should be migrated in case of updates if any.
+/// @dev    For upgrades: this mapping starts empty. To preserve replay protection for
+///         sources consolidated prior to this deployment/upgrade, an explicit backfill/migration step is required.
 library ProcessedConsolidationSourcePubkeys {
     bytes32 internal constant PROCESSED_CONSOLIDATION_SOURCE_PUBKEYS_MAPPING_BASE_SLOT =
         bytes32(uint256(keccak256("attestationVerifier.state.processedConsolidationSourcePubkeys.mapping")) - 1);

--- a/contracts/src/state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol
+++ b/contracts/src/state/attestationVerifier/ProcessedConsolidationSourcePubkeys.sol
@@ -18,10 +18,13 @@ library ProcessedConsolidationSourcePubkeys {
         return LibUnstructuredStorage.getStorageBool(slot);
     }
 
-    /// @notice Mark a consolidation source pubkey as consumed.
-    /// @param sourcePubkey The raw 48-byte BLS source pubkey.
-    function markProcessed(bytes calldata sourcePubkey) internal {
-        bytes32 slot = keccak256(abi.encode(PROCESSED_CONSOLIDATION_SOURCE_PUBKEYS_MAPPING_BASE_SLOT, sourcePubkey));
-        LibUnstructuredStorage.setStorageBool(slot, true);
+    /// @notice Mark consolidation source pubkeys as consumed.
+    /// @param sourcePubkeys The raw 48-byte BLS source pubkeys.
+    function markProcessed(bytes[] calldata sourcePubkeys) internal {
+        for (uint256 i = 0; i < sourcePubkeys.length; i++) {
+            bytes32 slot =
+                keccak256(abi.encode(PROCESSED_CONSOLIDATION_SOURCE_PUBKEYS_MAPPING_BASE_SLOT, sourcePubkeys[i]));
+            LibUnstructuredStorage.setStorageBool(slot, true);
+        }
     }
 }

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -4056,7 +4056,7 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         assertEq(river.totalSupply(), totalSupplyBeforeReplay);
     }
 
-    function testMintLsETHForConsolidationOverlappingSourceDistinctRequestsIsCommitteeInvariant() public {
+    function testRevert_mintLsETHForConsolidationOverlappingSourceDistinctRequestsDoesNotMint() public {
         _allowConsolidation(bob);
         bytes memory sourceA = _fakePubkey(2000);
         bytes memory sourceB = _fakePubkey(2001);
@@ -4087,9 +4087,17 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         assertEq(river.getBalanceToConsolidate(), 32 ether);
         assertEq(river.balanceOf(bob), 32 ether);
 
+        uint256 bufferBeforeReplay = river.getBalanceToConsolidate();
+        uint256 bobSharesBeforeReplay = river.balanceOf(bob);
+        uint256 totalSupplyBeforeReplay = river.totalSupply();
+
         vm.prank(consolidator);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
+        );
         river.mintLsETHForConsolidation(secondConsolidation);
-        assertEq(river.getBalanceToConsolidate(), 96 ether);
-        assertEq(river.balanceOf(bob), 96 ether);
+        assertEq(river.getBalanceToConsolidate(), bufferBeforeReplay);
+        assertEq(river.balanceOf(bob), bobSharesBeforeReplay);
+        assertEq(river.totalSupply(), totalSupplyBeforeReplay);
     }
 }

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -4101,10 +4101,7 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         assertEq(river.totalSupply(), totalSupplyBeforeReplay);
     }
 
-    /// @dev Duplicate source pubkeys within a single committee-signed request are allowed;
-    ///      the mint is driven solely by `totalAmount`, not by the source-pair count, so a
-    ///      [sourceA, sourceA] request mints exactly `totalAmount` (never doubled per pair).
-    function testMintLsETHForConsolidationDuplicateSourceWithinRequestMintsTotalAmount() public {
+    function testRevert_mintLsETHForConsolidationDuplicateSourceWithinRequestDoesNotMint() public {
         _allowConsolidation(bob);
         bytes memory sourceA = _fakePubkey(2300);
 
@@ -4123,26 +4120,13 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         uint256 totalSupplyBefore = river.totalSupply();
 
         vm.prank(consolidator);
-        river.mintLsETHForConsolidation(consolidation);
-
-        // Buffer and minted shares reflect `totalAmount` exactly, regardless of the two
-        // identical sources.
-        assertEq(river.getBalanceToConsolidate(), bufferBefore + totalAmount);
-        assertEq(river.balanceOf(bob), bobSharesBefore + totalAmount);
-        assertEq(river.totalSupply(), totalSupplyBefore + totalAmount);
-
-        // The duplicated source is consumed: any later request reusing it reverts.
-        bytes[] memory replaySources = new bytes[](1);
-        replaySources[0] = sourceA;
-        bytes[] memory replayTargets = new bytes[](1);
-        replayTargets[0] = _fakePubkey(2402);
-        IAttestationVerifierV1.ConsolidationObject memory replay =
-            _buildConsolidationWithPubkeys(bob, replaySources, replayTargets, 32 ether);
-
-        vm.prank(consolidator);
         vm.expectRevert(
             abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
         );
-        river.mintLsETHForConsolidation(replay);
+        river.mintLsETHForConsolidation(consolidation);
+
+        assertEq(river.getBalanceToConsolidate(), bufferBefore);
+        assertEq(river.balanceOf(bob), bobSharesBefore);
+        assertEq(river.totalSupply(), totalSupplyBefore);
     }
 }

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -3538,10 +3538,7 @@ contract RiverV1CoverageTests is RiverV1TestBase {
         assertEq(uint256(vm.load(address(river), CONSOLIDATION_BUFFER_SLOT)), 0);
         assertEq(river.getBalanceToConsolidate(), 0);
         // Confirm the stored report recorded the full reported amount.
-        assertEq(
-            river.getLastConsensusLayerReport().totalExternalConsolidationsAmountReported,
-            reportedConsolidations
-        );
+        assertEq(river.getLastConsensusLayerReport().totalExternalConsolidationsAmountReported, reportedConsolidations);
     }
 
     /// Regression guard: a report whose validatorsBalance increase is exactly matched by a consolidation
@@ -3674,9 +3671,7 @@ contract RiverV1CoverageTests is RiverV1TestBase {
 
         vm.prank(address(oracle));
         // The revert reports (reportedValidatorCount, lastReportedValidatorCount).
-        vm.expectRevert(
-            abi.encodeWithSignature("InvalidValidatorCountReport(uint256,uint256)", newCount, lastCount)
-        );
+        vm.expectRevert(abi.encodeWithSignature("InvalidValidatorCountReport(uint256,uint256)", newCount, lastCount));
         river.setConsensusLayerData(clr);
     }
 

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -4100,4 +4100,49 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         assertEq(river.balanceOf(bob), bobSharesBeforeReplay);
         assertEq(river.totalSupply(), totalSupplyBeforeReplay);
     }
+
+    /// @dev Duplicate source pubkeys within a single committee-signed request are allowed;
+    ///      the mint is driven solely by `totalAmount`, not by the source-pair count, so a
+    ///      [sourceA, sourceA] request mints exactly `totalAmount` (never doubled per pair).
+    function testMintLsETHForConsolidationDuplicateSourceWithinRequestMintsTotalAmount() public {
+        _allowConsolidation(bob);
+        bytes memory sourceA = _fakePubkey(2300);
+
+        bytes[] memory sources = new bytes[](2);
+        sources[0] = sourceA;
+        sources[1] = sourceA;
+        bytes[] memory targets = new bytes[](2);
+        targets[0] = _fakePubkey(2400);
+        targets[1] = _fakePubkey(2401);
+        uint256 totalAmount = 64 ether;
+        IAttestationVerifierV1.ConsolidationObject memory consolidation =
+            _buildConsolidationWithPubkeys(bob, sources, targets, totalAmount);
+
+        uint256 bufferBefore = river.getBalanceToConsolidate();
+        uint256 bobSharesBefore = river.balanceOf(bob);
+        uint256 totalSupplyBefore = river.totalSupply();
+
+        vm.prank(consolidator);
+        river.mintLsETHForConsolidation(consolidation);
+
+        // Buffer and minted shares reflect `totalAmount` exactly, regardless of the two
+        // identical sources.
+        assertEq(river.getBalanceToConsolidate(), bufferBefore + totalAmount);
+        assertEq(river.balanceOf(bob), bobSharesBefore + totalAmount);
+        assertEq(river.totalSupply(), totalSupplyBefore + totalAmount);
+
+        // The duplicated source is consumed: any later request reusing it reverts.
+        bytes[] memory replaySources = new bytes[](1);
+        replaySources[0] = sourceA;
+        bytes[] memory replayTargets = new bytes[](1);
+        replayTargets[0] = _fakePubkey(2402);
+        IAttestationVerifierV1.ConsolidationObject memory replay =
+            _buildConsolidationWithPubkeys(bob, replaySources, replayTargets, 32 ether);
+
+        vm.prank(consolidator);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
+        );
+        river.mintLsETHForConsolidation(replay);
+    }
 }

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -614,7 +614,7 @@ contract ConsolidationAttestationTest is Test {
         );
 
         vm.expectRevert(
-            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 0, 2)
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
         );
         _validateConsolidationAsRiver(
             IAttestationVerifierV1.ConsolidationObject({
@@ -623,6 +623,87 @@ contract ConsolidationAttestationTest is Test {
                 targetPubkeys: secondTargets,
                 totalAmount: secondAmount,
                 signatures: firstSigs
+            })
+        );
+    }
+
+    function testRevert_overlappingSourceDistinctValidRequest() public {
+        address user = address(0xCAFE);
+        bytes memory sourceA = _pubkey(810);
+        bytes memory sourceB = _pubkey(811);
+
+        bytes[] memory firstSources = new bytes[](1);
+        firstSources[0] = sourceA;
+        bytes[] memory firstTargets = new bytes[](1);
+        firstTargets[0] = _pubkey(910);
+        uint256 firstAmount = 32 ether;
+        bytes32 firstDigest = _consolidationDigest(user, firstSources, firstTargets, firstAmount);
+        bytes[] memory firstSigs = new bytes[](2);
+        firstSigs[0] = _sign(pk1, firstDigest);
+        firstSigs[1] = _sign(pk2, firstDigest);
+
+        bytes[] memory secondSources = new bytes[](2);
+        secondSources[0] = sourceA;
+        secondSources[1] = sourceB;
+        bytes[] memory secondTargets = new bytes[](2);
+        secondTargets[0] = _pubkey(911);
+        secondTargets[1] = _pubkey(912);
+        uint256 secondAmount = 64 ether;
+        bytes32 secondDigest = _consolidationDigest(user, secondSources, secondTargets, secondAmount);
+        bytes[] memory secondSigs = new bytes[](2);
+        secondSigs[0] = _sign(pk1, secondDigest);
+        secondSigs[1] = _sign(pk2, secondDigest);
+
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: firstSources,
+                targetPubkeys: firstTargets,
+                totalAmount: firstAmount,
+                signatures: firstSigs
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
+        );
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: secondSources,
+                targetPubkeys: secondTargets,
+                totalAmount: secondAmount,
+                signatures: secondSigs
+            })
+        );
+    }
+
+    function testRevert_duplicateSourceWithinConsolidationRequest() public {
+        address user = address(0xCAFE);
+        bytes memory sourceA = _pubkey(820);
+
+        bytes[] memory sources = new bytes[](2);
+        sources[0] = sourceA;
+        sources[1] = sourceA;
+        bytes[] memory targets = new bytes[](2);
+        targets[0] = _pubkey(920);
+        targets[1] = _pubkey(921);
+        uint256 totalAmount = 64 ether;
+        bytes32 digest = _consolidationDigest(user, sources, targets, totalAmount);
+        bytes[] memory sigs = new bytes[](2);
+        sigs[0] = _sign(pk1, digest);
+        sigs[1] = _sign(pk2, digest);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
+        );
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: sigs
             })
         );
     }

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -741,71 +741,71 @@ contract ConsolidationAttestationTest is Test {
         bytes memory sourceGood = _pubkey(831);
 
         // Consume `sourceTainted` via a first, valid single-pair request.
-        bytes[] memory firstSources = new bytes[](1);
-        firstSources[0] = sourceTainted;
-        bytes[] memory firstTargets = new bytes[](1);
-        firstTargets[0] = _pubkey(930);
-        uint256 firstAmount = 32 ether;
-        bytes32 firstDigest = _consolidationDigest(user, firstSources, firstTargets, firstAmount);
-        bytes[] memory firstSigs = new bytes[](2);
-        firstSigs[0] = _sign(pk1, firstDigest);
-        firstSigs[1] = _sign(pk2, firstDigest);
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = sourceTainted;
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(930);
+        uint256 totalAmount = 32 ether;
+        bytes32 digest = _consolidationDigest(user, sources, targets, totalAmount);
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = _sign(pk1, digest);
+        signatures[1] = _sign(pk2, digest);
         _validateConsolidationAsRiver(
             IAttestationVerifierV1.ConsolidationObject({
                 withdrawalAddress: user,
-                sourcePubkeys: firstSources,
-                targetPubkeys: firstTargets,
-                totalAmount: firstAmount,
-                signatures: firstSigs
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: signatures
             })
         );
 
         // Second request: [sourceGood, sourceTainted] — the tainted source is at index 1.
         // Quorum is valid, so the ONLY reason to revert is the already-consumed source.
-        bytes[] memory secondSources = new bytes[](2);
-        secondSources[0] = sourceGood;
-        secondSources[1] = sourceTainted;
-        bytes[] memory secondTargets = new bytes[](2);
-        secondTargets[0] = _pubkey(931);
-        secondTargets[1] = _pubkey(932);
-        uint256 secondAmount = 64 ether;
-        bytes32 secondDigest = _consolidationDigest(user, secondSources, secondTargets, secondAmount);
-        bytes[] memory secondSigs = new bytes[](2);
-        secondSigs[0] = _sign(pk1, secondDigest);
-        secondSigs[1] = _sign(pk2, secondDigest);
+        sources = new bytes[](2);
+        sources[0] = sourceGood;
+        sources[1] = sourceTainted;
+        targets = new bytes[](2);
+        targets[0] = _pubkey(931);
+        targets[1] = _pubkey(932);
+        totalAmount = 64 ether;
+        digest = _consolidationDigest(user, sources, targets, totalAmount);
+        signatures = new bytes[](2);
+        signatures[0] = _sign(pk1, digest);
+        signatures[1] = _sign(pk2, digest);
         vm.expectRevert(
             abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceTainted)
         );
         _validateConsolidationAsRiver(
             IAttestationVerifierV1.ConsolidationObject({
                 withdrawalAddress: user,
-                sourcePubkeys: secondSources,
-                targetPubkeys: secondTargets,
-                totalAmount: secondAmount,
-                signatures: secondSigs
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: signatures
             })
         );
 
         // `sourceGood` must still be free: a later request consuming it alone succeeds.
-        bytes[] memory thirdSources = new bytes[](1);
-        thirdSources[0] = sourceGood;
-        bytes[] memory thirdTargets = new bytes[](1);
-        thirdTargets[0] = _pubkey(933);
-        uint256 thirdAmount = 32 ether;
-        bytes32 thirdDigest = _consolidationDigest(user, thirdSources, thirdTargets, thirdAmount);
-        bytes[] memory thirdSigs = new bytes[](2);
-        thirdSigs[0] = _sign(pk1, thirdDigest);
-        thirdSigs[1] = _sign(pk2, thirdDigest);
-        bytes32 thirdStructHash = _consolidationStructHash(user, thirdSources, thirdTargets, thirdAmount);
+        sources = new bytes[](1);
+        sources[0] = sourceGood;
+        targets = new bytes[](1);
+        targets[0] = _pubkey(933);
+        totalAmount = 32 ether;
+        digest = _consolidationDigest(user, sources, targets, totalAmount);
+        signatures = new bytes[](2);
+        signatures[0] = _sign(pk1, digest);
+        signatures[1] = _sign(pk2, digest);
+        bytes32 structHash = _consolidationStructHash(user, sources, targets, totalAmount);
         vm.expectEmit(true, false, false, true);
-        emit IAttestationVerifierV1.ConsolidationProcessed(thirdStructHash);
+        emit IAttestationVerifierV1.ConsolidationProcessed(structHash);
         _validateConsolidationAsRiver(
             IAttestationVerifierV1.ConsolidationObject({
                 withdrawalAddress: user,
-                sourcePubkeys: thirdSources,
-                targetPubkeys: thirdTargets,
-                totalAmount: thirdAmount,
-                signatures: thirdSigs
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: signatures
             })
         );
     }

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -478,6 +478,48 @@ contract ConsolidationAttestationTest is Test {
         _validateConsolidationAsRiver(c);
     }
 
+    function testRevert_sourcePubkeyLengthCheckedBeforeDomainSeparator() public {
+        vm.store(address(verifier), CONSOLIDATION_DOMAIN_SEPARATOR_SLOT, bytes32(0));
+
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkeyOfLength(1, 47);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+
+        IAttestationVerifierV1.ConsolidationObject memory c = IAttestationVerifierV1.ConsolidationObject({
+            withdrawalAddress: address(0xAA),
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: 32 ether,
+            signatures: new bytes[](0)
+        });
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InvalidConsolidationPubkeyLength.selector, 0, 47, true)
+        );
+        _validateConsolidationAsRiver(c);
+    }
+
+    function testRevert_targetPubkeyLengthCheckedBeforeDomainSeparator() public {
+        vm.store(address(verifier), CONSOLIDATION_DOMAIN_SEPARATOR_SLOT, bytes32(0));
+
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = _pubkey(1);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkeyOfLength(2, 49);
+
+        IAttestationVerifierV1.ConsolidationObject memory c = IAttestationVerifierV1.ConsolidationObject({
+            withdrawalAddress: address(0xAA),
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: 32 ether,
+            signatures: new bytes[](0)
+        });
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InvalidConsolidationPubkeyLength.selector, 0, 49, false)
+        );
+        _validateConsolidationAsRiver(c);
+    }
+
     // -----------------------------------------------------------------------
     // Signature / bufferId derivation tests
     // -----------------------------------------------------------------------
@@ -580,7 +622,7 @@ contract ConsolidationAttestationTest is Test {
         _validateConsolidationAsRiver(c);
     }
 
-    function testRevert_overlappingSourceDistinctRequestCannotReuseFirstRequestSignatures() public {
+    function testRevert_distinctRequestCannotReuseFirstRequestSignatures() public {
         address user = address(0xCAFE);
         bytes memory sourceA = _pubkey(800);
         bytes memory sourceB = _pubkey(801);
@@ -595,12 +637,57 @@ contract ConsolidationAttestationTest is Test {
         firstSigs[0] = _sign(pk1, firstDigest);
         firstSigs[1] = _sign(pk2, firstDigest);
 
+        bytes[] memory secondSources = new bytes[](1);
+        secondSources[0] = sourceB;
+        bytes[] memory secondTargets = new bytes[](1);
+        secondTargets[0] = _pubkey(901);
+        uint256 secondAmount = 32 ether;
+
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: firstSources,
+                targetPubkeys: firstTargets,
+                totalAmount: firstAmount,
+                signatures: firstSigs
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 0, 2)
+        );
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: secondSources,
+                targetPubkeys: secondTargets,
+                totalAmount: secondAmount,
+                signatures: firstSigs
+            })
+        );
+    }
+
+    function testRevert_overlappingSourceDistinctRequestRevertsBeforeSignatureVerification() public {
+        address user = address(0xCAFE);
+        bytes memory sourceA = _pubkey(805);
+        bytes memory sourceB = _pubkey(806);
+
+        bytes[] memory firstSources = new bytes[](1);
+        firstSources[0] = sourceA;
+        bytes[] memory firstTargets = new bytes[](1);
+        firstTargets[0] = _pubkey(905);
+        uint256 firstAmount = 32 ether;
+        bytes32 firstDigest = _consolidationDigest(user, firstSources, firstTargets, firstAmount);
+        bytes[] memory firstSigs = new bytes[](2);
+        firstSigs[0] = _sign(pk1, firstDigest);
+        firstSigs[1] = _sign(pk2, firstDigest);
+
         bytes[] memory secondSources = new bytes[](2);
         secondSources[0] = sourceA;
         secondSources[1] = sourceB;
         bytes[] memory secondTargets = new bytes[](2);
-        secondTargets[0] = _pubkey(901);
-        secondTargets[1] = _pubkey(902);
+        secondTargets[0] = _pubkey(906);
+        secondTargets[1] = _pubkey(907);
         uint256 secondAmount = 64 ether;
 
         _validateConsolidationAsRiver(

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -481,6 +481,23 @@ contract ConsolidationAttestationTest is Test {
         _validateConsolidationAsRiver(c);
     }
 
+    function testRevert_zeroSourcePubkey() public {
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = new bytes(48);
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(2);
+
+        IAttestationVerifierV1.ConsolidationObject memory c = IAttestationVerifierV1.ConsolidationObject({
+            withdrawalAddress: address(0xAA),
+            sourcePubkeys: sources,
+            targetPubkeys: targets,
+            totalAmount: 32 ether,
+            signatures: new bytes[](0)
+        });
+        vm.expectRevert(abi.encodeWithSelector(IAttestationVerifierV1.ZeroConsolidationSourcePubkey.selector, 0));
+        _validateConsolidationAsRiver(c);
+    }
+
     function testRevert_targetPubkeyWrongLength() public {
         bytes[] memory sources = new bytes[](1);
         sources[0] = _pubkey(1);
@@ -884,7 +901,7 @@ contract ConsolidationAttestationTest is Test {
         signatures[1] = _sign(pk2, digest);
         bytes32 structHash = _consolidationStructHash(user, sources, targets, totalAmount);
         vm.expectEmit(true, false, false, true);
-        emit IAttestationVerifierV1.ConsolidationProcessed(structHash);
+        emit IAttestationVerifierV1.ConsolidationProcessed(structHash, sources, targets, totalAmount);
         _validateConsolidationAsRiver(
             IAttestationVerifierV1.ConsolidationObject({
                 withdrawalAddress: user,
@@ -934,7 +951,7 @@ contract ConsolidationAttestationTest is Test {
         quorumSigs[1] = _sign(pk2, digest);
         bytes32 structHash = _consolidationStructHash(user, sources, targets, totalAmount);
         vm.expectEmit(true, false, false, true);
-        emit IAttestationVerifierV1.ConsolidationProcessed(structHash);
+        emit IAttestationVerifierV1.ConsolidationProcessed(structHash, sources, targets, totalAmount);
         _validateConsolidationAsRiver(
             IAttestationVerifierV1.ConsolidationObject({
                 withdrawalAddress: user,
@@ -959,7 +976,7 @@ contract ConsolidationAttestationTest is Test {
             )
         );
         vm.expectEmit(true, false, false, true);
-        emit IAttestationVerifierV1.ConsolidationProcessed(structHash);
+        emit IAttestationVerifierV1.ConsolidationProcessed(structHash, c.sourcePubkeys, c.targetPubkeys, c.totalAmount);
         _validateConsolidationAsRiver(c);
     }
 

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -678,7 +678,7 @@ contract ConsolidationAttestationTest is Test {
         );
     }
 
-    function testValidateConsolidation_duplicateSourceWithinSingleRequestConsumesSource() public {
+    function testRevert_duplicateSourceWithinSingleRequest() public {
         address user = address(0xCAFE);
         bytes memory sourceA = _pubkey(820);
 
@@ -694,9 +694,9 @@ contract ConsolidationAttestationTest is Test {
         sigs[0] = _sign(pk1, digest);
         sigs[1] = _sign(pk2, digest);
 
-        bytes32 structHash = _consolidationStructHash(user, sources, targets, totalAmount);
-        vm.expectEmit(true, false, false, true);
-        emit IAttestationVerifierV1.ConsolidationProcessed(structHash);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
+        );
         _validateConsolidationAsRiver(
             IAttestationVerifierV1.ConsolidationObject({
                 withdrawalAddress: user,
@@ -704,29 +704,6 @@ contract ConsolidationAttestationTest is Test {
                 targetPubkeys: targets,
                 totalAmount: totalAmount,
                 signatures: sigs
-            })
-        );
-
-        bytes[] memory replaySources = new bytes[](1);
-        replaySources[0] = sourceA;
-        bytes[] memory replayTargets = new bytes[](1);
-        replayTargets[0] = _pubkey(922);
-        uint256 replayAmount = 32 ether;
-        bytes32 replayDigest = _consolidationDigest(user, replaySources, replayTargets, replayAmount);
-        bytes[] memory replaySigs = new bytes[](2);
-        replaySigs[0] = _sign(pk1, replayDigest);
-        replaySigs[1] = _sign(pk2, replayDigest);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
-        );
-        _validateConsolidationAsRiver(
-            IAttestationVerifierV1.ConsolidationObject({
-                withdrawalAddress: user,
-                sourcePubkeys: replaySources,
-                targetPubkeys: replayTargets,
-                totalAmount: replayAmount,
-                signatures: replaySigs
             })
         );
     }

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -678,7 +678,7 @@ contract ConsolidationAttestationTest is Test {
         );
     }
 
-    function testRevert_duplicateSourceWithinConsolidationRequest() public {
+    function testValidateConsolidation_duplicateSourceWithinSingleRequestConsumesSource() public {
         address user = address(0xCAFE);
         bytes memory sourceA = _pubkey(820);
 
@@ -694,9 +694,9 @@ contract ConsolidationAttestationTest is Test {
         sigs[0] = _sign(pk1, digest);
         sigs[1] = _sign(pk2, digest);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
-        );
+        bytes32 structHash = _consolidationStructHash(user, sources, targets, totalAmount);
+        vm.expectEmit(true, false, false, true);
+        emit IAttestationVerifierV1.ConsolidationProcessed(structHash);
         _validateConsolidationAsRiver(
             IAttestationVerifierV1.ConsolidationObject({
                 withdrawalAddress: user,
@@ -704,6 +704,29 @@ contract ConsolidationAttestationTest is Test {
                 targetPubkeys: targets,
                 totalAmount: totalAmount,
                 signatures: sigs
+            })
+        );
+
+        bytes[] memory replaySources = new bytes[](1);
+        replaySources[0] = sourceA;
+        bytes[] memory replayTargets = new bytes[](1);
+        replayTargets[0] = _pubkey(922);
+        uint256 replayAmount = 32 ether;
+        bytes32 replayDigest = _consolidationDigest(user, replaySources, replayTargets, replayAmount);
+        bytes[] memory replaySigs = new bytes[](2);
+        replaySigs[0] = _sign(pk1, replayDigest);
+        replaySigs[1] = _sign(pk2, replayDigest);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceA)
+        );
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: replaySources,
+                targetPubkeys: replayTargets,
+                totalAmount: replayAmount,
+                signatures: replaySigs
             })
         );
     }

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -25,6 +25,12 @@ contract MockRiverAdmin {
     }
 }
 
+contract AttestationVerifierBytesEqualHarness is AttestationVerifierV1 {
+    function exposedBytesEqual(bytes calldata a, bytes calldata b) external pure returns (bool) {
+        return _bytesEqual(a, b);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ConsolidationAttestationTest — exercises the consolidation half of
 // AttestationVerifierV1. The verifier now takes a `ConsolidationObject` directly
@@ -216,6 +222,22 @@ contract ConsolidationAttestationTest is Test {
     function _validateConsolidationAsRiver(IAttestationVerifierV1.ConsolidationObject memory consolidation) internal {
         vm.prank(address(river));
         verifier.validateConsolidation(consolidation);
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helper coverage
+    // -----------------------------------------------------------------------
+
+    function testBytesEqual_returnsFalseForDifferentLengths() public {
+        AttestationVerifierBytesEqualHarness harness = new AttestationVerifierBytesEqualHarness();
+
+        assertFalse(harness.exposedBytesEqual(hex"0102", hex"010203"));
+    }
+
+    function testBytesEqual_returnsFalseForSameLengthDifferentBytes() public {
+        AttestationVerifierBytesEqualHarness harness = new AttestationVerifierBytesEqualHarness();
+
+        assertFalse(harness.exposedBytesEqual(hex"010203", hex"010204"));
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -731,6 +731,135 @@ contract ConsolidationAttestationTest is Test {
         );
     }
 
+    /// @dev Sources are marked processed only AFTER quorum succeeds, and the per-source loop
+    ///      reverts on the FIRST already-consumed source. A request whose tainted source sits
+    ///      at a non-zero index must revert without consuming the (valid) sibling sources that
+    ///      precede it — otherwise a failed request would silently burn good source pubkeys.
+    function testValidateConsolidation_revertAtNonZeroIndexDoesNotConsumeSiblingSource() public {
+        address user = address(0xCAFE);
+        bytes memory sourceTainted = _pubkey(830);
+        bytes memory sourceGood = _pubkey(831);
+
+        // Consume `sourceTainted` via a first, valid single-pair request.
+        bytes[] memory firstSources = new bytes[](1);
+        firstSources[0] = sourceTainted;
+        bytes[] memory firstTargets = new bytes[](1);
+        firstTargets[0] = _pubkey(930);
+        uint256 firstAmount = 32 ether;
+        bytes32 firstDigest = _consolidationDigest(user, firstSources, firstTargets, firstAmount);
+        bytes[] memory firstSigs = new bytes[](2);
+        firstSigs[0] = _sign(pk1, firstDigest);
+        firstSigs[1] = _sign(pk2, firstDigest);
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: firstSources,
+                targetPubkeys: firstTargets,
+                totalAmount: firstAmount,
+                signatures: firstSigs
+            })
+        );
+
+        // Second request: [sourceGood, sourceTainted] — the tainted source is at index 1.
+        // Quorum is valid, so the ONLY reason to revert is the already-consumed source.
+        bytes[] memory secondSources = new bytes[](2);
+        secondSources[0] = sourceGood;
+        secondSources[1] = sourceTainted;
+        bytes[] memory secondTargets = new bytes[](2);
+        secondTargets[0] = _pubkey(931);
+        secondTargets[1] = _pubkey(932);
+        uint256 secondAmount = 64 ether;
+        bytes32 secondDigest = _consolidationDigest(user, secondSources, secondTargets, secondAmount);
+        bytes[] memory secondSigs = new bytes[](2);
+        secondSigs[0] = _sign(pk1, secondDigest);
+        secondSigs[1] = _sign(pk2, secondDigest);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.ConsolidationSourceAlreadyProcessed.selector, sourceTainted)
+        );
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: secondSources,
+                targetPubkeys: secondTargets,
+                totalAmount: secondAmount,
+                signatures: secondSigs
+            })
+        );
+
+        // `sourceGood` must still be free: a later request consuming it alone succeeds.
+        bytes[] memory thirdSources = new bytes[](1);
+        thirdSources[0] = sourceGood;
+        bytes[] memory thirdTargets = new bytes[](1);
+        thirdTargets[0] = _pubkey(933);
+        uint256 thirdAmount = 32 ether;
+        bytes32 thirdDigest = _consolidationDigest(user, thirdSources, thirdTargets, thirdAmount);
+        bytes[] memory thirdSigs = new bytes[](2);
+        thirdSigs[0] = _sign(pk1, thirdDigest);
+        thirdSigs[1] = _sign(pk2, thirdDigest);
+        bytes32 thirdStructHash = _consolidationStructHash(user, thirdSources, thirdTargets, thirdAmount);
+        vm.expectEmit(true, false, false, true);
+        emit IAttestationVerifierV1.ConsolidationProcessed(thirdStructHash);
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: thirdSources,
+                targetPubkeys: thirdTargets,
+                totalAmount: thirdAmount,
+                signatures: thirdSigs
+            })
+        );
+    }
+
+    /// @dev A request that fails quorum verification must not consume its source pubkeys,
+    ///      since marking happens only after quorum succeeds. The same source can then still
+    ///      be consumed by a subsequent, properly-attested request.
+    function testValidateConsolidation_failedQuorumDoesNotConsumeSource() public {
+        address user = address(0xCAFE);
+        bytes memory sourceX = _pubkey(840);
+
+        bytes[] memory sources = new bytes[](1);
+        sources[0] = sourceX;
+        bytes[] memory targets = new bytes[](1);
+        targets[0] = _pubkey(940);
+        uint256 totalAmount = 32 ether;
+        bytes32 digest = _consolidationDigest(user, sources, targets, totalAmount);
+
+        // Only one signature — below the quorum of 2 — so the request reverts at quorum
+        // verification, after the per-source checks but before any source is marked.
+        bytes[] memory underQuorumSigs = new bytes[](1);
+        underQuorumSigs[0] = _sign(pk1, digest);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 1, 2)
+        );
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: underQuorumSigs
+            })
+        );
+
+        // `sourceX` was not burned by the failed attempt: the same request now succeeds
+        // once a full quorum is supplied.
+        bytes[] memory quorumSigs = new bytes[](2);
+        quorumSigs[0] = _sign(pk1, digest);
+        quorumSigs[1] = _sign(pk2, digest);
+        bytes32 structHash = _consolidationStructHash(user, sources, targets, totalAmount);
+        vm.expectEmit(true, false, false, true);
+        emit IAttestationVerifierV1.ConsolidationProcessed(structHash);
+        _validateConsolidationAsRiver(
+            IAttestationVerifierV1.ConsolidationObject({
+                withdrawalAddress: user,
+                sourcePubkeys: sources,
+                targetPubkeys: targets,
+                totalAmount: totalAmount,
+                signatures: quorumSigs
+            })
+        );
+    }
+
     function testValidateConsolidation_emitsConsolidationProcessed() public {
         address user = address(0xBEEF);
         IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(user, 99);


### PR DESCRIPTION
## Summary
- Track successful consolidation source pubkeys on-chain and reject duplicate sources within or across consolidation requests.
- Reuse per-pubkey hashes for EIP-712 array hashing to avoid an extra calldata hashing pass.
- Update consolidation and River integration tests for overlapping-source reverts and no-mint accounting behavior.

Closes #553

## Test Plan
- forge test --match-path contracts/test/components/ConsolidationAttestation.t.sol -vvv
- forge test --match-contract RiverV1ConsolidationMintTests -vvv
- forge build contracts/src/AttestationVerifier.1.sol --sizes
- forge test -vvv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented consolidation requests from reusing source validator keys across successful requests.
  - Rejected duplicate source keys within the same consolidation request.
  - Ensured invalid or failed requests do not consume source keys or alter balances.
  - Added clearer errors for already-processed source keys and validated key lengths earlier.

- **Tests**
  - Added coverage for duplicate, reused, invalid-length, and failed-quorum consolidation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->