### PR TITLE
test: strengthen accounting coverage

### DIFF
--- a/contracts/test/accounting/AccountingInvariants.sol
+++ b/contracts/test/accounting/AccountingInvariants.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.34;
 import "./BeaconChainSimulator.sol";
 import "../../src/state/operatorsRegistry/Operators.3.sol";
 import "../../src/state/river/ReportBounds.sol";
+import "../../src/state/redeemManager/WithdrawalStack.sol";
 
 abstract contract AccountingInvariants is BeaconChainSimulator {
     uint256 private _snapTotalUnderlying;
@@ -13,6 +14,7 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
     uint256 private _snapExitDemand;
     bool private _allowSharePriceDecrease;
     bool private _lastReportWasContainment;
+    uint256 private _observedWithdrawalEventCount;
 
     /// @dev Snapshot of ReportBounds captured by `_pushRelaxedLowerBound`, restored by `_popBounds`.
     struct BoundsSnapshot {
@@ -29,7 +31,8 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
         vm.prank(admin);
         river.setReportBounds(
             ReportBounds.ReportBoundsStruct({
-                annualAprUpperBound: cur.annualAprUpperBound, relativeLowerBound: relLowerBps
+                annualAprUpperBound: cur.annualAprUpperBound,
+                relativeLowerBound: relLowerBps
             })
         );
         _setAllowSharePriceDecrease(true);
@@ -49,7 +52,7 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
     /// @notice Implements the oracle report step: warps time to the required finality epoch,
     ///         funds the withdrawal contract with newly skimmed/exited ETH, builds the CL report,
     ///         snapshots pre-report state, submits the report as the oracle member, and then
-    ///         asserts all six accounting invariants (I1–I6).
+    ///         asserts the accounting invariants.
     /// @param rebalance            Whether to request deposit-to-redeem rebalancing mode.
     /// @param slashingContainment  Whether to submit the report in slashing-containment mode.
     function sim_oracleReport(bool rebalance, bool slashingContainment) internal virtual override {
@@ -76,7 +79,11 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
 
         _lastReportedSkimmed = _simCumulativeSkimmed;
         _lastReportedExited = _simCumulativeExited;
+        _lastReportedAutocompounded = _simCumulativeAutocompounded;
+        _lastReportedLosses = _simCumulativeLosses;
         _lastReportEpoch = reportEpoch;
+        _simLastReportedValidatorCount = _simActivatedCount();
+        _syncWithdrawnETH();
         // Sync sim in-flight to what the oracle just confirmed: oracle sets InFlightDeposit = _pendingETH().
         _simInFlightDeposit = _pendingETH();
 
@@ -93,7 +100,9 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
         // in-flight value (_simInFlightDeposit), which mirrors what the contract should hold:
         // cumulative ETH sent to the deposit contract minus what the oracle has already confirmed.
         assertEq(
-            river.getInFlightDeposit(), _simInFlightDeposit, "I3 (pre-report): InFlightDeposit != sim in-flight deposit"
+            river.getInFlightDeposit(),
+            _simInFlightDeposit,
+            "I3 (pre-report): InFlightDeposit != sim in-flight deposit"
         );
 
         _snapTotalUnderlying = river.totalUnderlyingSupply();
@@ -111,6 +120,16 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
         _allowSharePriceDecrease = allow;
     }
 
+    /// @dev Accounts independently observable ETH transfers from River to RedeemManager.
+    function _syncWithdrawnETH() internal {
+        uint256 count = redeemManager.getWithdrawalEventCount();
+        for (uint256 i = _observedWithdrawalEventCount; i < count; i++) {
+            WithdrawalStack.WithdrawalEvent memory withdrawal = redeemManager.getWithdrawalEventDetails(uint32(i));
+            _simCumulativeWithdrawn += withdrawal.withdrawnEth;
+        }
+        _observedWithdrawalEventCount = count;
+    }
+
     /// @notice Executes all post-report invariant assertions (I1–I12) in sequence.
     function _assertAllInvariants() internal {
         _assertI1_SharePriceNonDecrease();
@@ -121,7 +140,7 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
         _assertI6_ExitedETHAggregate();
         _assertI7_DepositActivationDecomposition();
         _assertI8_RequestedExitsGeExited();
-        _assertI9_TotalRequestedGeExited();
+        _assertI9_TotalRequestedConsistency();
         _assertI10_ActivatedETHNonDecreasing();
         _assertI11_ActiveCLETHConsistency();
         _assertI12_ContainmentSuppressesDemand();
@@ -140,19 +159,17 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
         assertGe(lhs, rhs, "I1: share price decreased unexpectedly");
     }
 
-    /// @notice I2: Verifies ETH conservation — `totalUnderlyingSupply` must never exceed
-    ///         tracked principal plus cumulative skimmed rewards plus autocompounded rewards.
+    /// @notice I2: Verifies exact ETH conservation against independently tracked simulator state.
     ///         `_simTotalUserDeposited` captures all principal sources (user deposits and
-    ///         consolidation principal). All values are tracked independently of contract
-    ///         storage, making this a non-tautological check. Also asserts non-zero whenever
-    ///         principal has been deposited.
+    ///         consolidation principal), while reported rewards, losses, and ETH transferred
+    ///         to RedeemManager account for every change to River's underlying balance.
     function _assertI2_ETHConservation() internal {
-        uint256 upperBound = _simTotalUserDeposited + _simCumulativeSkimmed + _simCumulativeAutocompounded;
-        assertLe(river.totalUnderlyingSupply(), upperBound, "I2: total underlying exceeds deposited + rewards");
-        // Also: must be > 0 if any user deposited
-        if (_simTotalUserDeposited > 0) {
-            assertGt(river.totalUnderlyingSupply(), 0, "I2: total underlying is zero after deposits");
-        }
+        uint256 expected = _simTotalUserDeposited +
+            _lastReportedSkimmed +
+            _lastReportedAutocompounded -
+            _lastReportedLosses -
+            _simCumulativeWithdrawn;
+        assertEq(river.totalUnderlyingSupply(), expected, "I2: total underlying accounting mismatch");
     }
 
     /// @notice I3: In-flight deposit consistency check.
@@ -167,8 +184,8 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
 
     /// @notice I4: Verifies per-operator ETH consistency — for each operator, the on-chain
     ///         `funded` ETH must equal the simulator's sum of deposited ETH, and the on-chain
-    ///         `exitedETHPerOperator` must match the simulator's sum of exited ETH. Also asserts
-    ///         that `exited <= funded` and `requestedExits <= funded` for every operator.
+    ///         `exitedETHPerOperator` must match the simulator's sum of exited ETH. Exited ETH may
+    ///         exceed principal when 0x02 rewards autocompound before exit.
     function _assertI4_PerOperatorETH() internal {
         uint256 opCount = operatorsRegistry.getOperatorCount();
         uint256[] memory exitedPerOp = operatorsRegistry.getExitedETHPerOperator();
@@ -191,13 +208,7 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
 
             assertEq(op.funded, simFunded, string(abi.encodePacked("I4: op", vm.toString(i), " funded mismatch")));
             uint256 onChainExited = exitedPerOp.length > i ? exitedPerOp[i] : 0;
-            assertLe(onChainExited, op.funded, string(abi.encodePacked("I4: op", vm.toString(i), " exited > funded")));
             assertEq(onChainExited, simExited, string(abi.encodePacked("I4: op", vm.toString(i), " exited mismatch")));
-            assertLe(
-                op.requestedExits,
-                op.funded,
-                string(abi.encodePacked("I4: op", vm.toString(i), " requestedExits > funded"))
-            );
         }
     }
 
@@ -210,7 +221,7 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
     /// @notice I6: Verifies that the aggregate exited ETH returned by `getExitedAndRequestedETHExits`
     ///         equals the sum of all per-operator exited ETH values from `getExitedETHPerOperator`.
     function _assertI6_ExitedETHAggregate() internal {
-        (uint256 totalExited,) = operatorsRegistry.getExitedAndRequestedETHExits();
+        (uint256 totalExited, ) = operatorsRegistry.getExitedAndRequestedETHExits();
         uint256[] memory perOp = operatorsRegistry.getExitedETHPerOperator();
         uint256 sum = 0;
         for (uint256 i = 0; i < perOp.length; i++) {
@@ -258,9 +269,15 @@ abstract contract AccountingInvariants is BeaconChainSimulator {
     ///         the aggregate would not be caught here. Slashed validators are exited via the
     ///         oracle report path; `_setExitedETH` bumps `TotalETHExitsRequested` to match, so
     ///         the invariant holds for slashing scenarios.
-    function _assertI9_TotalRequestedGeExited() internal {
-        (uint256 totalExited,) = operatorsRegistry.getExitedAndRequestedETHExits();
+    function _assertI9_TotalRequestedConsistency() internal {
+        (uint256 totalExited, ) = operatorsRegistry.getExitedAndRequestedETHExits();
         uint256 totalRequested = operatorsRegistry.getTotalETHExitsRequested();
+        uint256 requestedSum;
+        uint256 opCount = operatorsRegistry.getOperatorCount();
+        for (uint256 i = 0; i < opCount; i++) {
+            requestedSum += operatorsRegistry.getOperator(i).requestedExits;
+        }
+        assertEq(totalRequested, requestedSum, "I9: TotalETHExitsRequested aggregate mismatch");
         assertGe(totalRequested, totalExited, "I9: TotalETHExitsRequested < totalExited");
     }
 

--- a/contracts/test/accounting/BeaconChainSimulator.sol
+++ b/contracts/test/accounting/BeaconChainSimulator.sol
@@ -43,6 +43,10 @@ abstract contract BeaconChainSimulator is AccountingHarnessBase {
     /// @dev Cumulative autocompounded ETH (monotonically increasing).
     ///      Tracks 0x02 rewards that increase validator CL balances rather than being swept.
     uint256 internal _simCumulativeAutocompounded;
+    /// @dev Cumulative principal lost to slashing and exit-time penalties.
+    uint256 internal _simCumulativeLosses;
+    /// @dev Cumulative ETH transferred from River to RedeemManager withdrawal events.
+    uint256 internal _simCumulativeWithdrawn;
     /// @dev Cumulative exited ETH (monotonically increasing).
     uint256 internal _simCumulativeExited;
     /// @dev Mirrors the contract's InFlightDeposit: ETH sent to the deposit contract
@@ -59,7 +63,11 @@ abstract contract BeaconChainSimulator is AccountingHarnessBase {
 
     uint256 internal _lastReportedSkimmed;
     uint256 internal _lastReportedExited;
+    uint256 internal _lastReportedAutocompounded;
+    uint256 internal _lastReportedLosses;
     uint256 internal _lastReportEpoch;
+    /// @dev Simulator validator count captured when the latest report was submitted.
+    uint32 internal _simLastReportedValidatorCount;
 
     // ─── step functions ───────────────────────────────────────────────────────
 
@@ -139,8 +147,8 @@ abstract contract BeaconChainSimulator is AccountingHarnessBase {
             SimValidator storage v = _simValidators[i];
             if (v.state != ValidatorState.Active && v.state != ValidatorState.Exiting) continue;
             if (
-                (v.isCompounding && v.currentBalance >= MAX_EFFECTIVE_BALANCE)
-                    || (!v.isCompounding && v.currentBalance >= MIN_ACTIVATION_BALANCE)
+                (v.isCompounding && v.currentBalance >= MAX_EFFECTIVE_BALANCE) ||
+                (!v.isCompounding && v.currentBalance >= MIN_ACTIVATION_BALANCE)
             ) {
                 _simCumulativeSkimmed += rewardsPerValidator;
             }
@@ -155,8 +163,9 @@ abstract contract BeaconChainSimulator is AccountingHarnessBase {
             SimValidator storage v = _simValidators[i];
             if (v.state != ValidatorState.Active && v.state != ValidatorState.Exiting) continue;
             if (
-                !v.isCompounding || v.currentBalance >= MAX_EFFECTIVE_BALANCE
-                    || v.currentBalance < MIN_ACTIVATION_BALANCE
+                !v.isCompounding ||
+                v.currentBalance >= MAX_EFFECTIVE_BALANCE ||
+                v.currentBalance < MIN_ACTIVATION_BALANCE
             ) continue;
 
             uint256 space = MAX_EFFECTIVE_BALANCE - v.currentBalance;
@@ -209,6 +218,7 @@ abstract contract BeaconChainSimulator is AccountingHarnessBase {
             v.exitingETH -= toComplete;
             v.exitedETH += actualExited;
             _simCumulativeExited += actualExited;
+            _simCumulativeLosses += thisPenalty;
             remaining -= toComplete;
 
             if (v.currentBalance == 0) v.state = ValidatorState.Exited;
@@ -222,6 +232,7 @@ abstract contract BeaconChainSimulator is AccountingHarnessBase {
             if (v.operatorIndex == opIdx && v.state == ValidatorState.Active) {
                 require(penalty <= v.currentBalance, "sim_slash: penalty exceeds balance");
                 v.currentBalance -= penalty;
+                _simCumulativeLosses += penalty;
                 return;
             }
         }
@@ -258,12 +269,10 @@ abstract contract BeaconChainSimulator is AccountingHarnessBase {
 
     // ─── report builder ───────────────────────────────────────────────────────
 
-    function _buildReport(bool rebalance, bool slashingContainment)
-        internal
-        view
-        virtual
-        returns (IOracleManagerV1.ConsensusLayerReport memory report)
-    {
+    function _buildReport(
+        bool rebalance,
+        bool slashingContainment
+    ) internal view virtual returns (IOracleManagerV1.ConsensusLayerReport memory report) {
         uint256 validatorsBalance = 0;
         uint256 validatorsExiting = 0;
         uint32 activatedCount = 0;
@@ -317,11 +326,10 @@ abstract contract BeaconChainSimulator is AccountingHarnessBase {
     ///      to post-finality. Intended for adversarial tests that mutate the returned struct and
     ///      submit the mutated report directly via `oracle.reportConsensusLayerData(report)` with
     ///      `vm.prank(oracleMember)` + `vm.expectRevert(...)`. Does NOT submit the report itself.
-    function _buildBadReport(bool rebalance, bool slashingContainment)
-        internal
-        virtual
-        returns (IOracleManagerV1.ConsensusLayerReport memory report)
-    {
+    function _buildBadReport(
+        bool rebalance,
+        bool slashingContainment
+    ) internal virtual returns (IOracleManagerV1.ConsensusLayerReport memory report) {
         uint256 reportEpoch = river.getExpectedEpochId();
         uint256 targetTime = (SECONDS_PER_SLOT * SLOTS_PER_EPOCH) * (reportEpoch + EPOCHS_UNTIL_FINAL) + 1;
         if (block.timestamp < targetTime) {

--- a/contracts/test/accounting/fuzz/AccountingFuzz.t.sol
+++ b/contracts/test/accounting/fuzz/AccountingFuzz.t.sol
@@ -38,8 +38,14 @@ contract AccountingFuzzTest is AccountingInvariants {
         sim_activateValidators(n);
         sim_oracleReport();
         // Step 3: Accrue rewards and submit the oracle report.
+        uint256 underlyingBefore = river.totalUnderlyingSupply();
         sim_accrueSkimmedRewards(rewardWei);
         sim_oracleReport();
+        assertEq(
+            river.totalUnderlyingSupply(),
+            underlyingBefore + uint256(n) * uint256(rewardWei),
+            "skimmed rewards must be credited exactly"
+        );
     }
 
     /// @notice Fuzz test covering the full deposit → activate → report → exit → report flow

--- a/contracts/test/accounting/invariant/AccountingHandler.sol
+++ b/contracts/test/accounting/invariant/AccountingHandler.sol
@@ -17,8 +17,10 @@ interface IAccountingActions {
 
     function handler_pendingCount() external view returns (uint256);
     function handler_activeAvailableETH(uint256 opIdx) external view returns (uint256);
+    function handler_slashableETH(uint256 opIdx) external view returns (uint256);
     function handler_exitingETH(uint256 opIdx) external view returns (uint256);
     function handler_operatorIndex(uint256 which) external view returns (uint256);
+    function handler_depositsAllowed() external view returns (bool);
 }
 
 /// @title AccountingHandler
@@ -65,10 +67,13 @@ contract AccountingHandler is StdUtils {
     /// @param nSeed      Seed used to derive the number of validators to deposit, bounded to [1, 4].
     /// @param amountSeed Seed used to derive the per-validator deposit amount, bounded to [32, 2048] ETH.
     function deposit(uint256 opSeed, uint256 nSeed, uint256 amountSeed) external {
+        if (!_test.handler_depositsAllowed()) return;
         // Step 1: Select operator and bound the validator count and deposit amount to safe ranges.
         uint256 opIdx = (opSeed % 2 == 0) ? _opOne : _opTwo;
         uint256 n = bound(nSeed, 1, 4);
         uint256 amountEach = bound(amountSeed, MIN_DEPOSIT, MAX_DEPOSIT);
+        // AttestationVerifier rejects deposits that are not denominated in whole gwei.
+        amountEach = (amountEach / 1 gwei) * 1 gwei;
         // Step 2: Delegate the deposit to the test contract and update ghost/call counters.
         _test.handler_deposit(opIdx, n, amountEach);
         ghost_depositCount += n;
@@ -160,10 +165,11 @@ contract AccountingHandler is StdUtils {
     function slash(uint256 opSeed, uint256 penaltySeed) external {
         // Step 1: Select operator and guard — skip if no active validators exist.
         uint256 opIdx = (opSeed % 2 == 0) ? _opOne : _opTwo;
-        uint256 active = _test.handler_activeAvailableETH(opIdx);
-        if (active == 0) return;
+        uint256 slashable = _test.handler_slashableETH(opIdx);
+        if (slashable < 0.01 ether) return;
         // Step 2: Bound the penalty and delegate the slash to the test contract.
-        uint256 penalty = bound(penaltySeed, 0.01 ether, 16 ether);
+        uint256 maxPenalty = slashable < 16 ether ? slashable : 16 ether;
+        uint256 penalty = bound(penaltySeed, 0.01 ether, maxPenalty);
         _test.handler_slash(opIdx, penalty);
         // Step 3: Record that a slash occurred so the next oracle report uses containment mode.
         ghost_slashOccurred = true;

--- a/contracts/test/accounting/invariant/AccountingInvariantTest.t.sol
+++ b/contracts/test/accounting/invariant/AccountingInvariantTest.t.sol
@@ -97,20 +97,16 @@ contract AccountingInvariantTest is AccountingInvariants {
     /// @param rebalance            Whether to submit the report in rebalancing mode.
     /// @param slashingContainment  Whether to submit the report in slashing-containment mode.
     function handler_oracleReport(bool rebalance, bool slashingContainment) external {
-        // I21: capture the prior report's consolidation total BEFORE this report so the invariant verifies a
-        // genuine report-over-report non-decrease.
-        ghost_lastConsolidationsAmountReported =
-        river.getLastConsensusLayerReport().totalExternalConsolidationsAmountReported;
+        _snapshotPreviousReport();
         if (slashingContainment) {
-            _setAllowSharePriceDecrease(true);
+            // Stateful loss generation intentionally explores penalties beyond the production
+            // report bound; containment behavior is the property under test for these reports.
+            BoundsSnapshot memory bounds = _pushRelaxedLowerBound(10_000);
+            sim_oracleReport(rebalance, true);
+            _popBounds(bounds);
+        } else {
+            sim_oracleReport(rebalance, false);
         }
-        sim_oracleReport(rebalance, slashingContainment);
-        _setAllowSharePriceDecrease(false);
-        // Snapshot post-report state for monotonicity invariants (I15-I17)
-        IOracleManagerV1.StoredConsensusLayerReport memory report = river.getLastConsensusLayerReport();
-        ghost_lastSkimmedBalance = report.validatorsSkimmedBalance;
-        ghost_lastExitedBalance = report.validatorsExitedBalance;
-        ghost_lastExitedPerOp = operatorsRegistry.getExitedETHPerOperator();
     }
 
     /// @notice Delegates an external-consolidation report from the handler to the simulator. This is the only
@@ -128,9 +124,7 @@ contract AccountingInvariantTest is AccountingInvariants {
         if (river.getCLValidatorCount() == 0) return;
         uint256 delta = bound(deltaSeed, 1, 32 ether);
 
-        // I21: snapshot the prior report's consolidation total BEFORE this report (see handler_oracleReport).
-        ghost_lastConsolidationsAmountReported =
-        river.getLastConsensusLayerReport().totalExternalConsolidationsAmountReported;
+        _snapshotPreviousReport();
 
         // Credit the consolidation buffer and account the credited principal (keeps I2 conservation intact once
         // the principal lands in validatorsBalance via _buildReport). The buffer starts at 0 between reports, so
@@ -141,12 +135,16 @@ contract AccountingInvariantTest is AccountingInvariants {
         vm.store(address(river), CONSOLIDATION_BUFFER_SLOT, bytes32(oldBuffer + delta));
 
         sim_oracleReport(false, false);
+    }
 
-        // Snapshot post-report state for monotonicity invariants (I15-I17).
+    /// @dev Captures the previous report before a new report is submitted. The post-action
+    ///      invariants then compare the new stored values against genuinely older state.
+    function _snapshotPreviousReport() internal {
         IOracleManagerV1.StoredConsensusLayerReport memory report = river.getLastConsensusLayerReport();
         ghost_lastSkimmedBalance = report.validatorsSkimmedBalance;
         ghost_lastExitedBalance = report.validatorsExitedBalance;
         ghost_lastExitedPerOp = operatorsRegistry.getExitedETHPerOperator();
+        ghost_lastConsolidationsAmountReported = report.totalExternalConsolidationsAmountReported;
     }
 
     // ─── state readers (called by handler for precondition guards) ───────────────
@@ -172,6 +170,17 @@ contract AccountingInvariantTest is AccountingInvariants {
         }
     }
 
+    /// @notice Returns the unqueued balance of the first active validator selected by `sim_slash`.
+    function handler_slashableETH(uint256 opIdx) external view returns (uint256) {
+        for (uint256 i = 0; i < _simValidators.length; i++) {
+            SimValidator storage v = _simValidators[i];
+            if (v.operatorIndex == opIdx && v.state == ValidatorState.Active) {
+                return v.currentBalance - v.exitingETH;
+            }
+        }
+        return 0;
+    }
+
     /// @notice Returns the total ETH currently queued for exit for validators of `opIdx`.
     ///         Includes both partial exits (Active validators with exitingETH > 0) and
     ///         full exits (validators in Exiting state).
@@ -193,18 +202,25 @@ contract AccountingInvariantTest is AccountingInvariants {
         return which == 0 ? operatorOneIndex : operatorTwoIndex;
     }
 
+    /// @notice Deposits are intentionally disabled while the latest report keeps containment active.
+    function handler_depositsAllowed() external view returns (bool) {
+        return !river.getSlashingContainmentMode();
+    }
+
     // ═════════════════════════════════════════════════════════════════════════════
     // INVARIANTS — checked by Foundry after every handler call
     // ═════════════════════════════════════════════════════════════════════════════
 
     // ─── Existing invariants (I1-I6) adapted for continuous checking ─────────────
 
-    /// @dev I2: ETH conservation — totalUnderlying never exceeds user deposits + rewards.
+    /// @dev I2: Exact ETH conservation, including rewards and simulated losses.
     function invariant_I2_ethConservation() public {
-        if (_simTotalUserDeposited == 0) return;
-        uint256 upperBound = _simTotalUserDeposited + _simCumulativeSkimmed + _simCumulativeAutocompounded;
-        assertLe(river.totalUnderlyingSupply(), upperBound, "I2: total underlying exceeds deposited + rewards");
-        assertGt(river.totalUnderlyingSupply(), 0, "I2: total underlying is zero after deposits");
+        uint256 expected = _simTotalUserDeposited +
+            _lastReportedSkimmed +
+            _lastReportedAutocompounded -
+            _lastReportedLosses -
+            _simCumulativeWithdrawn;
+        assertEq(river.totalUnderlyingSupply(), expected, "I2: total underlying accounting mismatch");
     }
 
     /// @dev I3: InFlightDeposit consistency — contract value matches simulator tracking.
@@ -212,19 +228,9 @@ contract AccountingInvariantTest is AccountingInvariants {
         assertEq(river.getInFlightDeposit(), _simInFlightDeposit, "I3: InFlightDeposit != sim in-flight");
     }
 
-    /// @dev I5: TotalDepositedETH is monotonically non-decreasing.
-    ///      We check it never falls below what we've ever deposited via sim_deposit.
-    function invariant_I5_totalDepositedETHMonotonic() public {
-        uint256 totalSimDeposited = 0;
-        for (uint256 i = 0; i < _simValidators.length; i++) {
-            totalSimDeposited += _simValidators[i].depositedETH;
-        }
-        assertGe(river.getTotalDepositedETH(), totalSimDeposited, "I5: TotalDepositedETH < sim total deposited");
-    }
-
     /// @dev I6: ExitedETH aggregate — sum of per-operator exited == reported total.
     function invariant_I6_exitedETHAggregate() public {
-        (uint256 totalExited,) = operatorsRegistry.getExitedAndRequestedETHExits();
+        (uint256 totalExited, ) = operatorsRegistry.getExitedAndRequestedETHExits();
         uint256[] memory perOp = operatorsRegistry.getExitedETHPerOperator();
         uint256 sum = 0;
         for (uint256 i = 0; i < perOp.length; i++) {
@@ -235,16 +241,15 @@ contract AccountingInvariantTest is AccountingInvariants {
 
     // ─── New invariants (I7-I12) ────────────────────────────────────────────────
 
-    /// @dev I7: Asset balance decomposition — totalUnderlying >= EL components.
-    ///      The difference is storedReport.validatorsBalance which must be >= 0.
+    /// @dev I7: Exact asset decomposition across CL and all tracked EL components.
     function invariant_I7_assetBalanceDecomposition() public {
-        uint256 elComponents = river.getCommittedBalance() + river.getBalanceToDeposit() + river.getBalanceToRedeem()
-            + river.getInFlightDeposit();
-        assertGe(
-            river.totalUnderlyingSupply(),
-            elComponents,
-            "I7: totalUnderlying < EL components (negative validatorsBalance)"
-        );
+        uint256 expected = river.getLastConsensusLayerReport().validatorsBalance +
+            river.getCommittedBalance() +
+            river.getBalanceToDeposit() +
+            river.getBalanceToRedeem() +
+            river.getInFlightDeposit() +
+            river.getBalanceToConsolidate();
+        assertEq(river.totalUnderlyingSupply(), expected, "I7: asset decomposition mismatch");
     }
 
     /// @dev I8: TotalDepositedETH == sum of per-operator funded ETH.
@@ -257,11 +262,6 @@ contract AccountingInvariantTest is AccountingInvariants {
             sumFunded += op.funded;
         }
         assertEq(totalDeposited, sumFunded, "I8: TotalDepositedETH != sum of per-operator funded");
-    }
-
-    /// @dev I9: InFlightDeposit bounded by TotalDepositedETH.
-    function invariant_I9_inFlightBoundedByDeposited() public {
-        assertLe(river.getInFlightDeposit(), river.getTotalDepositedETH(), "I9: InFlightDeposit > TotalDepositedETH");
     }
 
     /// @dev I10: EL solvency — River's ETH balance covers tracked EL amounts.
@@ -280,10 +280,14 @@ contract AccountingInvariantTest is AccountingInvariants {
         }
     }
 
-    /// @dev I12: Cumulative exited ETH never exceeds TotalDepositedETH.
-    function invariant_I12_exitedBoundedByDeposited() public {
-        (uint256 totalExited,) = operatorsRegistry.getExitedAndRequestedETHExits();
-        assertLe(totalExited, river.getTotalDepositedETH(), "I12: total exited > TotalDepositedETH");
+    /// @dev I12: Cumulative exited ETH is bounded by principal plus reported autocompounded rewards.
+    function invariant_I12_exitedBoundedByDepositsAndCompounding() public {
+        (uint256 totalExited, ) = operatorsRegistry.getExitedAndRequestedETHExits();
+        assertLe(
+            totalExited,
+            river.getTotalDepositedETH() + _lastReportedAutocompounded,
+            "I12: total exited exceeds principal plus compounding"
+        );
     }
 
     // ─── New invariants (I14-I20) ──────────────────────────────────────────────
@@ -311,22 +315,24 @@ contract AccountingInvariantTest is AccountingInvariants {
         }
     }
 
-    /// @dev I18: Per-operator requestedExits <= funded and exited <= funded (continuous check).
-    function invariant_I18_exitRequestsBounded() public {
+    /// @dev I18: Requested exits cover all reported exits and the aggregate equals the per-operator sum.
+    function invariant_I18_exitRequestsCoverExited() public {
         uint256 opCount = operatorsRegistry.getOperatorCount();
         uint256[] memory perOp = operatorsRegistry.getExitedETHPerOperator();
+        uint256 requestedSum;
         for (uint256 i = 0; i < opCount; i++) {
             OperatorsV3.Operator memory op = operatorsRegistry.getOperator(i);
             uint256 exited = (i < perOp.length) ? perOp[i] : 0;
-            assertLe(op.requestedExits, op.funded, "I18: requestedExits > funded");
-            assertLe(exited, op.funded, "I18: exited > funded");
+            assertGe(op.requestedExits, exited, "I18: requestedExits < exited");
+            requestedSum += op.requestedExits;
         }
+        assertEq(requestedSum, operatorsRegistry.getTotalETHExitsRequested(), "I18: requested exits sum mismatch");
     }
 
-    /// @dev I19: On-chain CLValidatorCount never exceeds total sim validators created.
-    function invariant_I19_clValidatorCountBounded() public {
+    /// @dev I19: On-chain CLValidatorCount exactly matches the independently captured report count.
+    function invariant_I19_clValidatorCountExactMatch() public {
         uint256 onChainCount = river.getCLValidatorCount();
-        assertLe(onChainCount, _simValidators.length, "I19: CLValidatorCount exceeds total validators created");
+        assertEq(onChainCount, _simLastReportedValidatorCount, "I19: CLValidatorCount != last reported sim count");
     }
 
     /// @dev I20: TotalDepositedETH exactly equals sum of all sim validator deposits.

--- a/contracts/test/accounting/scenarios/ExitDemand.t.sol
+++ b/contracts/test/accounting/scenarios/ExitDemand.t.sol
@@ -55,17 +55,20 @@ contract ExitDemandTest is AccountingInvariants {
     function _requestETHExits(uint256[] memory opIdxs, uint256[] memory ethAmounts) internal {
         require(opIdxs.length == ethAmounts.length, "exit allocation length mismatch");
 
-        IOperatorsRegistryV1.ExitETHAllocation[] memory allocations =
-            new IOperatorsRegistryV1.ExitETHAllocation[](opIdxs.length);
+        IOperatorsRegistryV1.ExitETHAllocation[] memory allocations = new IOperatorsRegistryV1.ExitETHAllocation[](
+            opIdxs.length
+        );
         for (uint256 i = 0; i < opIdxs.length; i++) {
-            allocations[i] =
-                IOperatorsRegistryV1.ExitETHAllocation({operatorIndex: opIdxs[i], ethAmount: ethAmounts[i]});
+            allocations[i] = IOperatorsRegistryV1.ExitETHAllocation({
+                operatorIndex: opIdxs[i],
+                ethAmount: ethAmounts[i]
+            });
         }
 
         // Post-Pectra requestETHExits takes EL allocations + a max fee. This test only exercises the
         // CL-exit path, so the EL allocation array is empty and the fee is zero (no msg.value needed).
-        IOperatorsRegistryV1.ELExitETHAllocation[] memory elAllocations =
-            new IOperatorsRegistryV1.ELExitETHAllocation[](0);
+        IOperatorsRegistryV1.ELExitETHAllocation[]
+            memory elAllocations = new IOperatorsRegistryV1.ELExitETHAllocation[](0);
 
         vm.prank(keeper);
         operatorsRegistry.requestETHExits(allocations, elAllocations, 0);
@@ -90,7 +93,9 @@ contract ExitDemandTest is AccountingInvariants {
         _requestETHExit(operatorOneIndex, requestedExitAmount);
         uint256 demandAfterRequest = operatorsRegistry.getCurrentETHExitsDemand();
         assertEq(
-            demandAfterRequest, demandAfterFirst - requestedExitAmount, "keeper request should consume current demand"
+            demandAfterRequest,
+            demandAfterFirst - requestedExitAmount,
+            "keeper request should consume current demand"
         );
 
         sim_requestExit(operatorOneIndex, DEPOSIT_SIZE);
@@ -202,7 +207,11 @@ contract ExitDemandTest is AccountingInvariants {
         assertEq(redeemManager.getWithdrawalEventCount(), withdrawalCountBefore + 1, "rebalancing should service part");
         assertLt(redeemDemandAfter, redeemDemandBefore, "redeem demand should be partially serviced");
         assertEq(redeemDemandAfter, 2 * DEPOSIT_SIZE, "residual redeem demand");
-        assertEq(operatorsRegistry.getCurrentETHExitsDemand(), 2 * DEPOSIT_SIZE, "residual demand should require exits");
+        assertEq(
+            operatorsRegistry.getCurrentETHExitsDemand(),
+            2 * DEPOSIT_SIZE,
+            "residual demand should require exits"
+        );
     }
 
     /// @notice When rebalancing is disabled, an available deposit buffer is left untouched and the
@@ -217,13 +226,19 @@ contract ExitDemandTest is AccountingInvariants {
         _depositAndRedeem(2 * DEPOSIT_SIZE);
 
         assertGt(river.getBalanceToDeposit(), 0, "should have balance to deposit");
+        uint256 depositSideBefore = river.getBalanceToDeposit() + river.getCommittedBalance();
         uint256 withdrawalCountBefore = redeemManager.getWithdrawalEventCount();
 
         // Rebalancing disabled (false), no containment (false): the deposit buffer must NOT be used to
         // service redeem demand via rebalancing; instead the shortfall is covered by demanding exits.
         sim_oracleReport(false, false);
 
-        assertGt(operatorsRegistry.getCurrentETHExitsDemand(), 0, "shortfall covered by exit demand");
+        assertEq(operatorsRegistry.getCurrentETHExitsDemand(), 2 * DEPOSIT_SIZE, "exact shortfall demanded as exits");
+        assertEq(
+            river.getBalanceToDeposit() + river.getCommittedBalance(),
+            depositSideBefore,
+            "disabled rebalancing must preserve deposit-side funds"
+        );
         assertEq(
             redeemManager.getWithdrawalEventCount(),
             withdrawalCountBefore,

--- a/contracts/test/accounting/scenarios/HappyPath.t.sol
+++ b/contracts/test/accounting/scenarios/HappyPath.t.sol
@@ -47,8 +47,7 @@ contract HappyPathTest is AccountingInvariants {
         //         Expected rewards: 10 validators × 0.008 ETH × 2 epochs = 0.16 ETH.
         uint256 expectedRewards = 10 * 0.008 ether * 2;
         uint256 totalUnderlying = river.totalUnderlyingSupply();
-        assertGt(totalUnderlying, 10 * DEPOSIT_SIZE, "rewards accrued");
-        assertLe(totalUnderlying, 10 * DEPOSIT_SIZE + expectedRewards, "underlying within expected reward bound");
+        assertEq(totalUnderlying, 10 * DEPOSIT_SIZE + expectedRewards, "rewards credited exactly");
     }
 
     /// @notice Verifies that multiple sequential deposit batches for the same operator

--- a/contracts/test/accounting/scenarios/Migration.t.sol
+++ b/contracts/test/accounting/scenarios/Migration.t.sol
@@ -6,6 +6,8 @@ import "../../../src/OperatorsRegistry.1.sol";
 import "../../../src/interfaces/IOperatorRegistry.1.sol";
 import "../../../src/state/operatorsRegistry/Operators.2.sol";
 import "../../../src/state/operatorsRegistry/Operators.3.sol";
+import "../../../src/state/operatorsRegistry/CurrentValidatorExitsDemand.sol";
+import "../../../src/state/operatorsRegistry/TotalValidatorExitsRequested.sol";
 import "../../utils/LibImplementationUnbricker.sol";
 
 /// @dev Subclass of OperatorsRegistryV1 that exposes internal V2 storage writes for migration testing.
@@ -38,6 +40,11 @@ contract MigrationOperatorsRegistry is OperatorsRegistryV1 {
     function sudoSetStoppedValidators(uint32[] calldata _stoppedValidators) external {
         OperatorsV2.setRawStoppedValidators(_stoppedValidators);
     }
+
+    function sudoSetLegacyExitTotals(uint256 currentDemand, uint256 totalRequested) external {
+        CurrentValidatorExitsDemand.set(currentDemand);
+        TotalValidatorExitsRequested.set(totalRequested);
+    }
 }
 
 contract MigrationTest is Test {
@@ -69,10 +76,13 @@ contract MigrationTest is Test {
         uint32 op1Funded = 5;
         uint32 op0Stopped = 1;
         uint32 op1Stopped = 2;
+        uint32 op0Requested = 1;
+        uint32 op1Requested = 2;
 
         // Push two V2 operators directly
-        registry.sudoPushV2Operator("OpAlpha", op1Addr, op0Funded, 0, op0Funded, op0Funded);
-        registry.sudoPushV2Operator("OpBeta", op2Addr, op1Funded, 0, op1Funded, op1Funded);
+        registry.sudoPushV2Operator("OpAlpha", op1Addr, op0Funded, op0Requested, op0Funded, op0Funded);
+        registry.sudoPushV2Operator("OpBeta", op2Addr, op1Funded, op1Requested, op1Funded, op1Funded);
+        registry.sudoSetLegacyExitTotals(1, op0Requested + op1Requested);
 
         // Set stopped validators array: [total, op0Stopped, op1Stopped]
         uint32 totalStopped = op0Stopped + op1Stopped;
@@ -93,13 +103,19 @@ contract MigrationTest is Test {
 
         OperatorsV3.Operator memory v3Op0 = registry.getOperator(0);
         assertEq(v3Op0.funded, uint256(op0Funded) * 32 ether, "op0 funded ETH");
+        assertEq(v3Op0.requestedExits, uint256(op0Requested) * 32 ether, "op0 requested exits ETH");
         assertEq(v3Op0.active, true, "op0 active");
         assertEq(v3Op0.activeCLETH, 0, "op0 activeCLETH must be zero post-migration");
+        assertEq(v3Op0.name, "OpAlpha", "op0 name");
+        assertEq(v3Op0.operator, op1Addr, "op0 address");
 
         OperatorsV3.Operator memory v3Op1 = registry.getOperator(1);
         assertEq(v3Op1.funded, uint256(op1Funded) * 32 ether, "op1 funded ETH");
+        assertEq(v3Op1.requestedExits, uint256(op1Requested) * 32 ether, "op1 requested exits ETH");
         assertEq(v3Op1.active, true, "op1 active");
         assertEq(v3Op1.activeCLETH, 0, "op1 activeCLETH must be zero post-migration");
+        assertEq(v3Op1.name, "OpBeta", "op1 name");
+        assertEq(v3Op1.operator, op2Addr, "op1 address");
 
         // Validate exited ETH per operator
         uint256[] memory exitedPerOp = registry.getExitedETHPerOperator();
@@ -108,8 +124,19 @@ contract MigrationTest is Test {
         assertEq(exitedPerOp[1], uint256(op1Stopped) * 32 ether, "op1 exited ETH");
 
         // Validate aggregate exited ETH
-        (uint256 totalExited,) = registry.getExitedAndRequestedETHExits();
+        (uint256 totalExited, uint256 totalRequestedAndDemanded) = registry.getExitedAndRequestedETHExits();
         assertEq(totalExited, uint256(totalStopped) * 32 ether, "total exited ETH");
+        assertEq(
+            registry.getTotalETHExitsRequested(),
+            uint256(op0Requested + op1Requested) * 32 ether,
+            "aggregate requested exits"
+        );
+        assertEq(registry.getCurrentETHExitsDemand(), 32 ether, "current exit demand");
+        assertEq(
+            totalRequestedAndDemanded,
+            uint256(op0Requested + op1Requested + 1) * 32 ether,
+            "total requested plus current demand"
+        );
     }
 
     /// @notice Verifies that running the full V1_1 → V1_2 migration on an empty registry
@@ -140,7 +167,11 @@ contract MigrationTest is Test {
         assertEq(registry.getOperatorCount(), 1, "one operator");
         OperatorsV3.Operator memory op = registry.getOperator(0);
         assertEq(op.funded, uint256(funded) * 32 ether, "funded scaled");
+        assertEq(op.requestedExits, 0, "no requested exits");
         assertEq(op.activeCLETH, 0, "activeCLETH must be zero post-migration");
+        assertEq(op.active, true, "operator active");
+        assertEq(op.name, "Solo", "operator name");
+        assertEq(op.operator, op1Addr, "operator address");
 
         uint256[] memory exitedPerOp = registry.getExitedETHPerOperator();
         assertEq(exitedPerOp.length, 1, "one entry");
@@ -180,7 +211,10 @@ contract MigrationTest is Test {
         uint256 op1RequestedExitETH = uint256(op1RequestedExitCount) * 32 ether;
         vm.expectRevert(
             abi.encodeWithSelector(
-                IOperatorsRegistryV1.InvalidOperatorState.selector, 1, op1FundedETH, op1RequestedExitETH
+                IOperatorsRegistryV1.InvalidOperatorState.selector,
+                1,
+                op1FundedETH,
+                op1RequestedExitETH
             )
         );
         registry.initOperatorsRegistryV1_2(makeAddr("withdraw"));

--- a/contracts/test/accounting/scenarios/RebalancingMode.t.sol
+++ b/contracts/test/accounting/scenarios/RebalancingMode.t.sol
@@ -4,37 +4,86 @@ pragma solidity 0.8.34;
 import "../AccountingInvariants.sol";
 
 contract RebalancingModeTest is AccountingInvariants {
-    /// @notice Verifies that an oracle report submitted with `rebalanceDepositToRedeemMode = true`
-    ///         still satisfies all accounting invariants (ETH conservation, in-flight consistency,
-    ///         per-operator integrity). No assertion on specific values — invariant checks inside
-    ///         `sim_oracleReport` act as the oracle.
-    ///         All assertions are checked inside sim_oracleReport via _assertAllInvariants().
-    function testRebalancingModePreservesConservation() public {
-        // Step 1: Fund river with enough ETH for 3 validators and deposit them for operator one.
-        _fundRiver(6 * DEPOSIT_SIZE);
-        sim_deposit(operatorOneIndex, _amounts(3, DEPOSIT_SIZE));
-        // Step 2: Activate all 3 validators and submit the initial normal oracle report.
-        sim_activateValidators(3);
-        sim_oracleReport();
-        // Step 3: Submit a rebalancing-mode oracle report (rebalance=true, slashingContainment=false)
-        //         and assert that all accounting invariants still hold.
-        sim_oracleReport(true, false);
+    function _depositAndRedeem(string memory label, uint256 ethAmount) internal {
+        address user = makeAddr(label);
+        _allowUser(user);
+        _simTotalUserDeposited += ethAmount;
+        vm.deal(user, ethAmount);
+        vm.prank(user);
+        river.deposit{value: ethAmount}();
+        sim_requestRedeem(user, river.balanceOf(user));
     }
 
-    /// @notice Verifies that the protocol can correctly resume normal oracle reporting after
-    ///         a rebalancing-mode report. Ensures accounting invariants hold throughout the full
-    ///         sequence: normal report → rebalancing report → normal report.
-    ///         All assertions are checked inside sim_oracleReport via _assertAllInvariants().
+    function _addDepositBuffer(string memory label, uint256 ethAmount) internal {
+        _simTotalUserDeposited += ethAmount;
+        address depositor = makeAddr(label);
+        _allowUser(depositor);
+        vm.deal(depositor, ethAmount);
+        vm.prank(depositor);
+        river.deposit{value: ethAmount}();
+    }
+
+    /// @notice Exercises a real deposit-to-redeem rebalance and verifies both exact movement
+    ///         and conservation rather than merely submitting the mode flag.
+    function testRebalancingModePreservesConservation() public {
+        _fundRiver(3 * DEPOSIT_SIZE);
+        sim_deposit(operatorOneIndex, _amounts(3, DEPOSIT_SIZE));
+        sim_activateValidators(3);
+        sim_oracleReport();
+
+        _addDepositBuffer("rebalanceBuffer", 2 * DEPOSIT_SIZE);
+        _depositAndRedeem("rebalanceRedeemer", 2 * DEPOSIT_SIZE);
+        uint256 underlyingBefore = river.totalUnderlyingSupply();
+        uint256 redeemManagerBalanceBefore = address(redeemManager).balance;
+        uint256 depositSideBefore = river.getBalanceToDeposit() + river.getCommittedBalance();
+        uint256 withdrawalCountBefore = redeemManager.getWithdrawalEventCount();
+
+        sim_oracleReport(true, false);
+
+        assertEq(
+            river.totalUnderlyingSupply(),
+            underlyingBefore - 2 * DEPOSIT_SIZE,
+            "serviced redemption leaves River exactly"
+        );
+        assertEq(
+            river.totalUnderlyingSupply() + address(redeemManager).balance,
+            underlyingBefore + redeemManagerBalanceBefore,
+            "rebalancing conserves system ETH"
+        );
+        assertEq(
+            river.getBalanceToDeposit() + river.getCommittedBalance(),
+            depositSideBefore - 2 * DEPOSIT_SIZE,
+            "exact amount leaves deposit side"
+        );
+        assertEq(redeemManager.getRedeemDemand(), 0, "redeem demand fully serviced");
+        assertEq(redeemManager.getWithdrawalEventCount(), withdrawalCountBefore + 1, "withdrawal event created");
+        assertEq(operatorsRegistry.getCurrentETHExitsDemand(), 0, "no validator exits required");
+    }
+
+    /// @notice After a real rebalance, verifies a normal report leaves a new deposit buffer
+    ///         untouched and converts new redeem demand into an exact validator-exit demand.
     function testResumeAfterRebalancing() public {
-        // Step 1: Fund river with enough ETH for 4 validators and deposit them for operator one.
         _fundRiver(4 * DEPOSIT_SIZE);
         sim_deposit(operatorOneIndex, _amounts(4, DEPOSIT_SIZE));
-        // Step 2: Activate all 4 validators and submit the initial normal oracle report.
         sim_activateValidators(4);
         sim_oracleReport();
-        // Step 3: Submit a rebalancing-mode oracle report (rebalance=true).
+
+        _addDepositBuffer("firstBuffer", DEPOSIT_SIZE);
+        _depositAndRedeem("firstRedeemer", DEPOSIT_SIZE);
         sim_oracleReport(true, false);
-        // Step 4: Submit a regular oracle report to verify the protocol resumes normal operation.
+        assertEq(redeemManager.getRedeemDemand(), 0, "first demand serviced by rebalancing");
+
+        _addDepositBuffer("secondBuffer", DEPOSIT_SIZE);
+        _depositAndRedeem("secondRedeemer", DEPOSIT_SIZE);
+        uint256 depositSideBefore = river.getBalanceToDeposit() + river.getCommittedBalance();
+
         sim_oracleReport(false, false);
+
+        assertEq(
+            river.getBalanceToDeposit() + river.getCommittedBalance(),
+            depositSideBefore,
+            "normal mode must preserve deposit-side funds"
+        );
+        assertEq(operatorsRegistry.getCurrentETHExitsDemand(), DEPOSIT_SIZE, "normal mode demands exact exits");
     }
 }

--- a/contracts/test/accounting/scenarios/SlashingContainment.t.sol
+++ b/contracts/test/accounting/scenarios/SlashingContainment.t.sol
@@ -5,7 +5,7 @@ import "../AccountingInvariants.sol";
 
 contract SlashingContainmentTest is AccountingInvariants {
     /// @notice Verifies that a slashing event followed by an oracle report in slashing-containment
-    ///         mode correctly reduces `totalUnderlyingSupply` below the original principal.
+    ///         mode reduces `totalUnderlyingSupply` by the exact simulated penalty.
     ///         The share price is allowed to decrease during this test to reflect the penalty.
     function testSlashingContainmentModeActive() public {
         // Step 1: Fund river with enough ETH for 4 validators and deposit them for operator one.
@@ -14,6 +14,7 @@ contract SlashingContainmentTest is AccountingInvariants {
         // Step 2: Activate all 4 validators and submit the initial oracle report.
         sim_activateValidators(4);
         sim_oracleReport();
+        uint256 underlyingBefore = river.totalUnderlyingSupply();
         // Step 3: Apply a 4 ETH slash penalty to an active validator of operator one.
         sim_slash(operatorOneIndex, 4 ether);
         // Step 4: Submit an oracle report in slashing-containment mode (slashingContainment=true),
@@ -21,30 +22,9 @@ contract SlashingContainmentTest is AccountingInvariants {
         _setAllowSharePriceDecrease(true);
         sim_oracleReport(false, true);
         _setAllowSharePriceDecrease(false);
-        // Step 5: Assert that the total underlying supply has decreased below the original principal.
-        assertLt(river.totalUnderlyingSupply(), 4 * DEPOSIT_SIZE, "underlying reduced by slash");
-    }
-
-    /// @notice Verifies that no new validator exit requests are generated during a slashing-
-    ///         containment oracle report. The protocol must suppress exits while in containment
-    ///         mode to avoid compounding the impact of a slashing event.
-    function testNoExitRequestsDuringContainment() public {
-        // Step 1: Fund river with enough ETH for 4 validators and deposit them for operator one.
-        _fundRiver(4 * DEPOSIT_SIZE);
-        sim_deposit(operatorOneIndex, _amounts(4, DEPOSIT_SIZE));
-        // Step 2: Activate all 4 validators and submit the initial oracle report.
-        sim_activateValidators(4);
-        sim_oracleReport();
-        // Step 3: Snapshot the current total ETH exits requested before the slash.
-        uint256 exitsBefore = operatorsRegistry.getTotalETHExitsRequested();
-        // Step 4: Apply a 4 ETH slash penalty to operator one.
-        sim_slash(operatorOneIndex, 4 ether);
-        // Step 5: Submit the containment-mode oracle report and confirm no exits were created.
-        _setAllowSharePriceDecrease(true);
-        sim_oracleReport(false, true);
-        _setAllowSharePriceDecrease(false);
-        uint256 exitsAfter = operatorsRegistry.getTotalETHExitsRequested();
-        assertEq(exitsBefore, exitsAfter, "no exits during slashing containment");
+        // Step 5: Assert the exact loss and persisted containment mode.
+        assertEq(river.totalUnderlyingSupply(), underlyingBefore - 4 ether, "slash applied exactly");
+        assertTrue(river.getLastConsensusLayerReport().slashingContainmentMode, "containment mode persisted");
     }
 
     /// @notice Verifies that SkippedCommitToDepositDueToSlashingContainment is emitted when
@@ -56,14 +36,25 @@ contract SlashingContainmentTest is AccountingInvariants {
         // Step 2: Activate all 4 validators and submit the initial oracle report.
         sim_activateValidators(4);
         sim_oracleReport();
-        // Step 3: Apply a 4 ETH slash penalty to operator one.
+
+        address depositor = makeAddr("containmentCommitDepositor");
+        _allowUser(depositor);
+        _simTotalUserDeposited += DEPOSIT_SIZE;
+        vm.deal(depositor, DEPOSIT_SIZE);
+        vm.prank(depositor);
+        river.deposit{value: DEPOSIT_SIZE}();
+        uint256 depositBefore = river.getBalanceToDeposit();
+        uint256 committedBefore = river.getCommittedBalance();
+
+        // Apply a slash and prove an otherwise committable deposit remains untouched.
         sim_slash(operatorOneIndex, 4 ether);
-        // Step 4: Expect the SkippedCommitToDepositDueToSlashingContainment event when reporting in containment mode.
         vm.expectEmit(false, false, false, false, address(river));
         emit IRiverV1.SkippedCommitToDepositDueToSlashingContainment();
         _setAllowSharePriceDecrease(true);
         sim_oracleReport(false, true);
         _setAllowSharePriceDecrease(false);
+        assertEq(river.getBalanceToDeposit(), depositBefore, "containment must preserve deposit buffer");
+        assertEq(river.getCommittedBalance(), committedBefore, "containment must suppress commitment");
     }
 
     /// @notice Verifies that SkippedExitRequestsDueToSlashingContainment is emitted when
@@ -153,13 +144,26 @@ contract SlashingContainmentTest is AccountingInvariants {
         // Step 2: Activate all 4 validators and submit the initial oracle report.
         sim_activateValidators(4);
         sim_oracleReport();
-        // Step 3: Apply a 2 ETH slash penalty to operator one.
+
+        address depositor = makeAddr("resumeDepositor");
+        _allowUser(depositor);
+        _simTotalUserDeposited += DEPOSIT_SIZE;
+        vm.deal(depositor, DEPOSIT_SIZE);
+        vm.prank(depositor);
+        river.deposit{value: DEPOSIT_SIZE}();
+        uint256 depositBefore = river.getBalanceToDeposit();
+        uint256 committedBefore = river.getCommittedBalance();
+
         sim_slash(operatorOneIndex, 2 ether);
-        // Step 4: Submit a slashing-containment oracle report, allowing share price to decrease.
         _setAllowSharePriceDecrease(true);
         sim_oracleReport(false, true);
         _setAllowSharePriceDecrease(false);
-        // Step 5: Submit a follow-up normal oracle report to verify the protocol resumes correctly.
+        assertEq(river.getBalanceToDeposit(), depositBefore, "containment must defer commitment");
+        assertEq(river.getCommittedBalance(), committedBefore, "nothing committed during containment");
+
+        // A normal report must resume the previously suppressed commitment path.
         sim_oracleReport(false, false);
+        assertLt(river.getBalanceToDeposit(), depositBefore, "normal reporting consumes deposit buffer");
+        assertGt(river.getCommittedBalance(), committedBefore, "normal reporting resumes commitment");
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -25,4 +25,4 @@ runs = 1500
 [invariant]
 runs = 128
 depth = 32
-fail_on_revert = false
+fail_on_revert = true


### PR DESCRIPTION
## Description

Corrects the accounting test suite following a test-by-test effectiveness review.

- generate valid gwei-aligned invariant deposits and fail campaigns on unexpected handler reverts
- track reported rewards, losses, redemptions, and validator counts with exact accounting identities
- snapshot monotonic ghost state before reports so I15-I17 are non-tautological
- replace invalid principal-only exit bounds with autocompounding-aware consistency checks
- remove redundant invariants and the vacuous containment exit test
- exercise real rebalancing, containment, resume, reward, and migration state transitions with exact assertions

## Notice

- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [x] Have you added sufficient documentation in your code?
- [x] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [x] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

None.

## Testing

- [x] Have you tested this code with the official test suite?
- [x] Have you tested this code manually?

## Manual tests (if applicable)

- `forge test --match-path contracts/test/accounting/**/*.sol --summary` — 54 passed, 0 failed; all invariant handlers reported 0 reverts across 128 runs × 32 calls.
- `forge test --match-path contracts/test/components/invariant/*.t.sol --summary` — 6 passed, 0 failed with strict `fail_on_revert = true`.
- `npx prettier --check <changed Solidity files>` — passed.

## Additional comments

The commit is unsigned because the local GPG key requires an interactive passphrase unavailable in this session.