### PR TITLE
test(pectra): assert SetOperatorExitedETH event index/value pairing

### DIFF
--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -241,7 +241,7 @@ abstract contract OperatorsRegistryV1TestBase is Test {
 
     event SetRiver(address indexed river);
     event UpdatedExitedETH(uint256[] exitedETH);
-    event SetOperatorExitedETH(uint256 operatorIndex, uint256 exitedETH);
+    event SetOperatorExitedETH(uint256 indexed index, uint256 exitedETH);
 }
 
 contract OperatorsRegistryV1InitializationTests is OperatorsRegistryV1TestBase {
@@ -725,6 +725,11 @@ contract OperatorsRegistryV1Tests is OperatorsRegistryV1TestBase, OperatorAlloca
         for (uint256 idx2 = 0; idx2 < len; ++idx2) {
             OperatorsRegistryInitializableV1(address(operatorsRegistry))
                 .sudoSetActiveCLETH(idx2, uint256(totalCount) * 32 ether);
+        }
+
+        for (uint256 idx = 1; idx < len + 1; ++idx) {
+            vm.expectEmit(true, true, true, true, address(operatorsRegistry));
+            emit SetOperatorExitedETH(idx - 1, exitedETH[idx]);
         }
 
         vm.prank(river);


### PR DESCRIPTION
## Summary

Closes coverage-review finding M-EV1: `SetOperatorExitedETH` was never `expectEmit`-checked, leaving the non-obvious wire mapping — event index `idx - 1`, value `_exitedETH[idx]` (array slot 0 is the total) — unguarded. A regression emitting `idx` instead of `idx - 1` would shift every operator's exited balance by one in off-chain indexers while all storage-based assertions stayed green.

- `testReportExitedETH` now asserts a `SetOperatorExitedETH(idx - 1, exitedETH[idx])` emission per operator before the `reportExitedETH` call, pinning the index/value pairing across fuzzed operator counts.
- Fixed the test-base event declaration to `uint256 indexed index`, matching `IOperatorRegistry.1.sol` — it was missing `indexed`, which would have made any `expectEmit` against it match the wrong topics.

## Testing

`forge test --match-test testReportExitedETH` — 7 passed, 0 failed (fuzz at 1500 runs).
