### PR TITLE
test(pectra): assert consolidation mint share conversion at non-unity price

### DIFF
--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -100,6 +100,11 @@ contract RiverV1ForceCommittable is RiverV1WithLegacyInit {
         IOracleManagerV1.StoredConsensusLayerReport storage report = LastConsensusLayerReport.get();
         report.slashingContainmentMode = _enabled;
     }
+
+    function sudoSetValidatorsBalance(uint256 _validatorsBalance) external {
+        IOracleManagerV1.StoredConsensusLayerReport storage report = LastConsensusLayerReport.get();
+        report.validatorsBalance = _validatorsBalance;
+    }
 }
 
 abstract contract RiverV1TestBase is OperatorAllocationTestBase, BytesGenerator {
@@ -3952,6 +3957,49 @@ contract RiverV1ConsolidationMintTests is RiverV1TestBase {
         vm.prank(consolidator);
         vm.expectRevert(abi.encodeWithSignature("Denied(address)", joe));
         river.mintLsETHForConsolidation(consolidation);
+    }
+
+    function testMintLsETHForConsolidationAtNonUnityPrice() public {
+        address depositor = makeAddr("depositor");
+        address[] memory allowees = new address[](1);
+        allowees[0] = depositor;
+        uint256[] memory permissions = new uint256[](1);
+        permissions[0] = LibAllowlistMasks.DEPOSIT_MASK;
+        vm.prank(allower);
+        allowlist.setAllowPermissions(allowees, permissions);
+
+        vm.deal(depositor, 10 ether);
+        vm.prank(depositor);
+        river.deposit{value: 10 ether}();
+        river.sudoSetValidatorsBalance(10 ether);
+
+        uint256 supplyBefore = river.totalSupply();
+        uint256 underlyingBefore = river.totalUnderlyingSupply();
+        assertEq(supplyBefore, 10 ether, "supply should equal deposited shares");
+        assertEq(underlyingBefore, 20 ether, "underlying should include validator balance");
+
+        uint256 amount = 3 ether;
+        uint256 expectedShares = (amount * supplyBefore) / underlyingBefore;
+        uint256 pricePerShareBefore = river.underlyingBalanceFromShares(1 ether);
+        assertLt(expectedShares, amount, "share price should exceed one");
+
+        _allowConsolidation(bob);
+        IAttestationVerifierV1.ConsolidationObject memory consolidation = _buildConsolidation(bob, amount, 11);
+
+        vm.expectEmit(true, true, true, true);
+        emit IRiverV1.LsETHMintedForConsolidation(bob, amount, expectedShares);
+        vm.prank(consolidator);
+        river.mintLsETHForConsolidation(consolidation);
+
+        assertEq(river.balanceOf(bob), expectedShares, "minted shares should follow share price");
+        assertEq(river.totalSupply(), supplyBefore + expectedShares, "total supply should grow by converted shares");
+        assertEq(river.totalUnderlyingSupply(), underlyingBefore + amount, "underlying should grow by totalAmount");
+        assertApproxEqAbs(
+            river.underlyingBalanceFromShares(1 ether),
+            pricePerShareBefore,
+            1,
+            "share price should be neutral within 1 wei"
+        );
     }
 
     function testMintLsETHForConsolidationCumulativeBalanceAndShares() public {


### PR DESCRIPTION
## Summary

Closes coverage-review finding #1 (PROVEN by live mutation): every `mintLsETHForConsolidation` test ran in the bootstrap regime where the share price is exactly 1:1, so `_mintShares` was numerically identical to `_mintRawShares` and the mutant swapping them survived 10/10 — at any real post-rewards price that mutant over-mints unbacked LsETH that dilutes every holder.

- Added `testMintLsETHForConsolidationAtNonUnityPrice`: a real 10 ETH deposit (10e18 shares) plus 10 ETH of reported validator balance sets the share price to 2, then a 3 ETH consolidation mint must mint exactly `totalAmount * S / U = 1.5e18` shares — asserted via the `LsETHMintedForConsolidation` event, recipient `balanceOf`, total supply/underlying deltas, and share-price neutrality within 1 wei.
- Added `sudoSetValidatorsBalance` to the `RiverV1ForceCommittable` harness (same pattern as `sudoSetSlashingContainmentMode`) to move the price off 1:1.

The `_mintShares → _mintRawShares` mutant now mints 3e18 shares instead of 1.5e18 and fails four assertions.

## Testing

`forge test --match-contract RiverV1ConsolidationMintTests` — 11 passed, 0 failed.
