### PR TITLE
test(pectra): join consolidation mint, report drawdown and coverage pull

### DIFF
--- a/contracts/test/accounting/scenarios/ConsolidationCoverage.t.sol
+++ b/contracts/test/accounting/scenarios/ConsolidationCoverage.t.sol
@@ -138,7 +138,7 @@ contract ConsolidationCoverageScenarioTest is AccountingInvariants {
         assertEq(river.totalSupply(), sharesBefore, "no fee shares minted on consolidated principal");
     }
 
-    function testMintReportDrawdownAndCoveragePullConservesUnderlyingAndShares() public {
+    function testMintedConsolidationPartiallyLandsAndCoverageCoversTheShortfall() public {
         _baseline();
 
         uint256 coverage = 5 ether;

--- a/contracts/test/accounting/scenarios/ConsolidationCoverage.t.sol
+++ b/contracts/test/accounting/scenarios/ConsolidationCoverage.t.sol
@@ -5,6 +5,7 @@ import "../AccountingInvariants.sol";
 import "../../utils/LibImplementationUnbricker.sol";
 import "../../../src/ConsolidationCoverageFund.1.sol";
 import "../../../src/interfaces/components/IOracleManager.1.sol";
+import "../../../src/interfaces/IAttestationVerifier.1.sol";
 
 /// @title ConsolidationCoverageScenarioTest
 /// @notice Scenario tests for the consolidation-reporting accounting path, exercised against the real
@@ -135,5 +136,67 @@ contract ConsolidationCoverageScenarioTest is AccountingInvariants {
         // (neither a drop nor an increase) and no fee shares are minted on the principal.
         assertEq(river.totalUnderlyingSupply(), underlyingBefore, "total underlying unchanged (netted out)");
         assertEq(river.totalSupply(), sharesBefore, "no fee shares minted on consolidated principal");
+    }
+
+    function testConsolidationLifecycleConservation() public {
+        _baseline();
+
+        uint256 coverage = 5 ether;
+        _donateConsolidationCoverage(coverage);
+
+        address consolidated = makeAddr("consolidatedUser");
+        address[] memory addrs = new address[](1);
+        addrs[0] = consolidated;
+        uint256[] memory masks = new uint256[](1);
+        masks[0] = LibAllowlistMasks.CONSOLIDATE_MASK;
+        vm.prank(allower);
+        allowlist.setAllowPermissions(addrs, masks);
+
+        uint256 amount = 4 ether;
+        IAttestationVerifierV1.ConsolidationObject memory consolidation = IAttestationVerifierV1.ConsolidationObject({
+            withdrawalAddress: consolidated,
+            sourcePubkeys: new bytes[](1),
+            targetPubkeys: new bytes[](1),
+            totalAmount: amount,
+            signatures: new bytes[](1)
+        });
+        vm.mockCall(
+            address(attestationVerifier),
+            abi.encodeWithSelector(IAttestationVerifierV1.validateConsolidation.selector),
+            abi.encode(true)
+        );
+
+        uint256 underlyingBeforeMint = river.totalUnderlyingSupply();
+        uint256 supplyBeforeMint = river.totalSupply();
+        uint256 expectedShares = (amount * supplyBeforeMint) / underlyingBeforeMint;
+
+        vm.prank(consolidator);
+        river.mintLsETHForConsolidation(consolidation);
+
+        assertEq(river.getBalanceToConsolidate(), amount, "mint increases buffer by totalAmount");
+        assertEq(
+            river.totalUnderlyingSupply(), underlyingBeforeMint + amount, "mint increases underlying by totalAmount"
+        );
+        assertEq(river.balanceOf(consolidated), expectedShares, "mint converts totalAmount at share price");
+
+        uint256 delta = 1 ether;
+        IOracleManagerV1.ConsensusLayerReport memory report = _buildBadReport(false, false);
+        report.validatorsBalance += delta;
+        report.totalExternalConsolidationsAmountReported += delta;
+        vm.prank(oracleMember);
+        oracle.reportConsensusLayerData(report);
+
+        assertEq(river.getBalanceToConsolidate(), 0, "report drawdown plus fund pull drains buffer");
+        assertEq(
+            address(consolidationCoverageFund).balance,
+            coverage - (amount - delta),
+            "fund covers exactly the residual buffer"
+        );
+        assertEq(
+            river.totalUnderlyingSupply(),
+            underlyingBeforeMint + amount,
+            "underlying conserved across drawdown and pull"
+        );
+        assertEq(river.totalSupply(), supplyBeforeMint + expectedShares, "no shares minted by drawdown or pull");
     }
 }

--- a/contracts/test/accounting/scenarios/ConsolidationCoverage.t.sol
+++ b/contracts/test/accounting/scenarios/ConsolidationCoverage.t.sol
@@ -138,7 +138,7 @@ contract ConsolidationCoverageScenarioTest is AccountingInvariants {
         assertEq(river.totalSupply(), sharesBefore, "no fee shares minted on consolidated principal");
     }
 
-    function testConsolidationLifecycleConservation() public {
+    function testMintReportDrawdownAndCoveragePullConservesUnderlyingAndShares() public {
         _baseline();
 
         uint256 coverage = 5 ether;


### PR DESCRIPTION
## Summary

Closes coverage-review finding #8 (“Pectra Diff — Test-Coverage Findings”, Medium #8): the consolidation mint→report→coverage-pull lifecycle was never joined — every buffer-decrease test seeded the buffer with `vm.store` instead of a real mint, so if the report's drawdown semantics diverged from the mint's addition, minted shares would silently become unbacked with no test signal.

Added `testMintedConsolidationPartiallyLandsAndCoverageCoversTheShortfall` to `ConsolidationCoverageScenarioTest`, chaining the real flow with no storage seeding:

1. Real `mintLsETHForConsolidation` (4 ETH) — asserts the buffer increase, underlying increase, and share conversion all come from the actual mint path.
2. Oracle report where 1 ETH of consolidated principal lands in `validatorsBalance` and is reported as consolidation — draws the buffer down by the netted delta.
3. Residual 3 ETH pulled from a real, donated-to `ConsolidationCoverageFundV1` — asserts the buffer drains to zero, the fund pays exactly the residual, total underlying is conserved end-to-end, and zero shares are minted by the drawdown/pull.

`validateConsolidation` is `vm.mockCall`ed (same pattern as the harness's existing `verifyBLSDeposit` mock) — signature binding is covered by the River unit tests and the upcoming single-field tamper tests; this test targets the accounting join.

Deliberately out of scope (larger harness change, flagged in the review as a follow-up): wiring a funded coverage fund into the *invariant* harness, where the fund is currently a code-less EOA, plus an `invariant_consolidationCoverageNeverOverPulls` property.

## Testing

`forge test --match-contract ConsolidationCoverageScenarioTest` — 3 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the consolidation lifecycle, including coverage fund donations, successful validation, share minting, and oracle reporting.
  * Verifies conservation of underlying assets and accurate share supply throughout consolidation and coverage fund activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

