### PR TITLE
test(pectra): tamper-test each consolidation signature field individually

### DIFF
--- a/contracts/test/components/ConsolidationAttestation.t.sol
+++ b/contracts/test/components/ConsolidationAttestation.t.sol
@@ -565,6 +565,53 @@ contract ConsolidationAttestationTest is Test {
         _validateConsolidationAsRiver(c);
     }
 
+    function testRevert_tamperedWithdrawalAddress() public {
+        IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(address(0x11), 41);
+        c.withdrawalAddress = address(0x22);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 0, 2)
+        );
+        _validateConsolidationAsRiver(c);
+    }
+
+    function testRevert_tamperedSourcePubkeys() public {
+        IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(address(0x11), 42);
+        c.sourcePubkeys[0] = _pubkey(9999);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 0, 2)
+        );
+        _validateConsolidationAsRiver(c);
+    }
+
+    function testRevert_tamperedTargetPubkeys() public {
+        IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(address(0x11), 43);
+        c.targetPubkeys[0] = _pubkey(9998);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 0, 2)
+        );
+        _validateConsolidationAsRiver(c);
+    }
+
+    function testRevert_tamperedTotalAmount() public {
+        IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(address(0x11), 44);
+        c.totalAmount = c.totalAmount + 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 0, 2)
+        );
+        _validateConsolidationAsRiver(c);
+    }
+
+    function testRevert_swappedSourceAndTargetPubkeys() public {
+        IAttestationVerifierV1.ConsolidationObject memory c = _validConsolidation(address(0x11), 45);
+        bytes[] memory originalSources = c.sourcePubkeys;
+        c.sourcePubkeys = c.targetPubkeys;
+        c.targetPubkeys = originalSources;
+        vm.expectRevert(
+            abi.encodeWithSelector(IAttestationVerifierV1.InsufficientConsolidationAttestations.selector, 0, 2)
+        );
+        _validateConsolidationAsRiver(c);
+    }
+
     // -----------------------------------------------------------------------
     // Signature verification tests
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes coverage-review finding #11: the consolidation digest (`AttestationVerifier.1.sol:660-668`) binds `withdrawalAddress`, `sourcePubkeys`, `targetPubkeys`, and `totalAmount`, but no test mutated exactly one field after signing and asserted rejection — existing tests recompute the digest from the same fields via the mirror helper, making them blind to a shared bug. A mutant dropping any field from the digest would leave it unbound: an attacker or faulty off-chain pipeline could inflate `totalAmount` (fed straight into `mintLsETHForConsolidation`) or redirect `withdrawalAddress` after the committee signed.

Added five tamper tests to `ConsolidationAttestationTest`. Each builds a fully-signed consolidation via the existing `_validConsolidation` helper, then mutates exactly one thing without re-signing and expects `InsufficientConsolidationAttestations(0, 2)`:

- `testRevert_tamperedWithdrawalAddress`
- `testRevert_tamperedSourcePubkeys` (one pubkey substituted, valid length)
- `testRevert_tamperedTargetPubkeys` (same)
- `testRevert_tamperedTotalAmount` (+1 wei)
- `testRevert_swappedSourceAndTargetPubkeys` (source↔target array swap)

## Testing

`forge test --match-contract ConsolidationAttestationTest` — 51 passed, 0 failed.
