### PR TITLE
fix(redemption-rewards): price the stopped-earning mark at the pre-re…

### DIFF
--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -243,8 +243,10 @@ contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IP
     }
 
     /// @inheritdoc IRedeemManagerV1
-    function reportStoppedEarning(uint256 _stoppedEarningEth) external onlyRiver {
-        if (_stoppedEarningEth == 0) {
+    function reportStoppedEarning(uint256 _stoppedEarningEth, uint256 _stoppedEarningLsETH) external onlyRiver {
+        // a zero LsETH leg also covers the degenerate pools where River's conversion returns 0 (no asset
+        // balance or no shares), which is what makes the division at the end unconditionally safe
+        if (_stoppedEarningEth == 0 || _stoppedEarningLsETH == 0) {
             return;
         }
 
@@ -270,8 +272,7 @@ contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IP
             markStart = settledHeight;
         }
 
-        IRiverV1 river = _castedRiver();
-        uint256 reportedLsETH = river.sharesFromUnderlyingBalance(_stoppedEarningEth);
+        uint256 reportedLsETH = _stoppedEarningLsETH;
         uint256 lsETHToMark = reportedLsETH;
         uint256 markable = totalRequestedHeight > markStart ? totalRequestedHeight - markStart : 0;
         if (lsETHToMark > markable) {
@@ -282,9 +283,12 @@ contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IP
             return;
         }
 
-        // Priced at the pool rate of THIS report. River calls this after the rebase and the fee mint,
-        // so the rate is already final for the interval.
-        uint256 markedEth = river.underlyingBalanceFromShares(lsETHToMark);
+        // Priced at the rate River held BEFORE this report was applied, which is exactly the ratio of the
+        // two arguments — the interval during which the principal stopped earning is excluded on purpose.
+        // Marking the whole reported amount therefore needs no conversion at all; only the clamped case
+        // divides, scaling the eth leg down in the same proportion so the locked rate is preserved.
+        uint256 markedEth =
+            lsETHToMark == reportedLsETH ? _stoppedEarningEth : (_stoppedEarningEth * lsETHToMark) / reportedLsETH;
 
         RateMarkStack.RateMark[] storage rateMarks = RateMarkStack.get();
         uint32 rateMarkId = uint32(rateMarks.length);

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -228,8 +228,14 @@ interface IRedeemManagerV1 {
     ///      report is marked before its shares are burned and removed from the redeem demand.
     /// @dev Must be called unconditionally whenever the delta is non-zero. River persists the cumulative
     ///      `validatorsStoppedEarningBalance` before this point, so a skipped call loses the delta for good.
+    /// @dev The two arguments are the same amount denominated in ETH and in LsETH, both valued by River
+    ///      from its pre-report snapshot — the pool valuation as it stood before the report was applied.
+    ///      Their ratio is the rate the resulting mark locks, and it is passed in rather than read from
+    ///      River here because by the time this runs River has already rebased and minted the interval's
+    ///      fee, so a live read would return the very rewards the mark is meant to exclude.
     /// @param _stoppedEarningEth The ETH value of the principal that crossed exit_epoch in this interval
-    function reportStoppedEarning(uint256 _stoppedEarningEth) external;
+    /// @param _stoppedEarningLsETH The same amount in LsETH, valued at River's pre-report rate
+    function reportStoppedEarning(uint256 _stoppedEarningEth, uint256 _stoppedEarningLsETH) external;
 
     /// @notice Retrieve the global count of rate marks
     function getRateMarkCount() external view returns (uint256);

--- a/contracts/src/libraries/LibOracleReporting.sol
+++ b/contracts/src/libraries/LibOracleReporting.sol
@@ -64,6 +64,7 @@ library LibOracleReporting {
         uint256 totalExternalConsolidationETHIncrease;
         uint256 totalExitViaConsolidationETHIncrease;
         uint256 stoppedEarningAmountIncrease;
+        uint256 stoppedEarningLsETH;
         uint256 timeElapsedSinceLastReport;
         uint256 availableAmountToUpperBound;
         IOracleManagerV1.ConsensusLayerDataReportingTrace trace;
@@ -204,6 +205,19 @@ library LibOracleReporting {
 
         // we retrieve the current total underlying balance before any reporting data is applied to the system
         vars.preReportUnderlyingBalance = ISharesManagerV1(address(this)).totalUnderlyingSupply();
+
+        // the stopped-earning delta is valued here, at the PREVIOUS interval's rate, and carried down to
+        // the reportStoppedEarning call as data. This is the last point where the conversion views are
+        // meaningful: _pullCLFunds below credits the exited and skimmed eth to the buffers while
+        // LastConsensusLayerReport still counts the same eth in validatorsBalance, so the asset balance is
+        // double counted until the stored report is updated, and past that point it already carries this
+        // interval's rewards and the fee mint. Valuing it here is the whole point of the mark: principal
+        // that crossed exit_epoch must stop accruing pool rewards from that moment, so the demand it backs
+        // may not be credited with the very interval during which it stopped earning.
+        if (vars.stoppedEarningAmountIncrease > 0) {
+            vars.stoppedEarningLsETH =
+                ISharesManagerV1(address(this)).sharesFromUnderlyingBalance(vars.stoppedEarningAmountIncrease);
+        }
 
         // if we have new exited / skimmed eth available, we pull funds from the consensus layer recipient
         if (vars.exitedAmountIncrease + vars.skimmedAmountIncrease > 0) {
@@ -362,16 +376,22 @@ library LibOracleReporting {
         );
 
         // we mark the pending redeem demand whose backing principal stopped earning in this interval, at
-        // this report's rate. This must run BEFORE _reportWithdrawToRedeemManager: settlement burns the
-        // corresponding shares and removes that LsETH from the redeem demand, so demand settled in this
-        // same report would otherwise never be marked and would be paid at its request-time rate.
+        // the rate that was in force before this report was applied. The two arguments are the same
+        // amount denominated in eth and in LsETH, both valued at the pre-report snapshot taken above, and
+        // their ratio is the rate the mark locks. It is passed as data rather than read here on purpose:
+        // by this point the stored report and the fee mint have landed, so anything the redeem manager
+        // could read from River would be this interval's rate.
+        // This must run BEFORE _reportWithdrawToRedeemManager: settlement burns the corresponding shares
+        // and removes that LsETH from the redeem demand, so demand settled in this same report would
+        // otherwise never be marked and would be paid at its request-time rate.
         // Called unconditionally on a non-zero delta — the cumulative validatorsStoppedEarningBalance was
         // already persisted above, so skipping the call would discard the delta permanently. In
         // particular it is NOT gated on slashing containment: containment freezes new exits while leaving
         // settlement priced at the depressed rate, which lengthens a queued redeemer's wait, so
         // suspending accrual there would penalise them twice.
         if (vars.stoppedEarningAmountIncrease > 0) {
-            IRedeemManagerV1(RedeemManagerAddress.get()).reportStoppedEarning(vars.stoppedEarningAmountIncrease);
+            IRedeemManagerV1(RedeemManagerAddress.get())
+                .reportStoppedEarning(vars.stoppedEarningAmountIncrease, vars.stoppedEarningLsETH);
         }
 
         // we use the updated balanceToRedeem value to report a withdraw event on the redeem manager

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -93,8 +93,18 @@ contract RiverMock {
         return (balance * 1e18) / rate;
     }
 
+    /// @notice Reports a stopped-earning amount valued at the mock's current rate, the way River values
+    ///         it from its pre-report snapshot
     function sudoReportStoppedEarning(address redeemManager, uint256 stoppedEarningEth) external {
-        RedeemManagerV1(redeemManager).reportStoppedEarning(stoppedEarningEth);
+        RedeemManagerV1(redeemManager).reportStoppedEarning(stoppedEarningEth, (stoppedEarningEth * 1e18) / rate);
+    }
+
+    /// @notice Reports a stopped-earning amount with an explicitly chosen LsETH leg, so tests can pin the
+    ///         locked rate to something other than the mock's live rate
+    function sudoReportStoppedEarningAt(address redeemManager, uint256 stoppedEarningEth, uint256 stoppedEarningLsETH)
+        external
+    {
+        RedeemManagerV1(redeemManager).reportStoppedEarning(stoppedEarningEth, stoppedEarningLsETH);
     }
 
     function pullExceedingEth(address redeemManager, uint256 amount) external {
@@ -1841,6 +1851,55 @@ contract RedeemManagerV1Tests is RedeeManagerV1TestBase {
         // a second report has nothing left to mark and must not push an empty mark
         river.sudoReportStoppedEarning(address(redeemManager), 100e18);
         assertEq(redeemManager.getRateMarkCount(), 1);
+    }
+
+    /// The locked rate is the (eth, LsETH) pair River passes in, and nothing else. River values the
+    /// delta from its pre-report snapshot; by the time this call lands River has already applied the
+    /// report and minted the interval's fee, so reading the rate live here would credit the redeemer
+    /// with the very interval during which their principal stopped earning.
+    function testMarkUsesReportedPairNotLiveRate() external {
+        address user = _generateAllowlistedUser(0);
+        river.sudoSetRate(1e18);
+        uint32 id = _openRequest(user, 30e18);
+
+        // River reports 30 LsETH of principal valued at its pre-report rate of 1.02, while its live
+        // rate has already rebased to 1.1
+        river.sudoSetRate(1.1e18);
+        river.sudoReportStoppedEarningAt(address(redeemManager), applyRate(30e18, 1.02e18), 30e18);
+
+        RateMarkStack.RateMark memory mark = redeemManager.getRateMarkDetails(0);
+        assertEq(mark.amount, 30e18);
+        assertEq(mark.markedEth, applyRate(30e18, 1.02e18));
+
+        // and the cap follows the mark, not the rate the pool ended the interval on
+        uint256 received = _settleAndClaim(id, 30e18, 1.1e18);
+        assertEq(received, applyRate(30e18, 1.02e18));
+        assertEq(redeemManager.getBufferedExceedingEth(), applyRate(30e18, 1.1e18) - applyRate(30e18, 1.02e18));
+    }
+
+    /// When the reported principal overshoots the markable demand, the eth leg must be scaled down in
+    /// the same proportion as the LsETH leg: the clamp shortens the marked span, it must not re-rate
+    /// it. testReportStoppedEarningClampsToMarkableDemand runs at a 1:1 rate, where a mis-scaled eth
+    /// leg is indistinguishable from a correct one.
+    function testClampedMarkPreservesReportedRate() external {
+        address user = _generateAllowlistedUser(0);
+        river.sudoSetRate(1e18);
+        uint32 id = _openRequest(user, 30e18);
+
+        // 100 LsETH of principal stopped earning at a rate of 1.05, but only 30 LsETH is markable
+        uint256 reportedEth = applyRate(100e18, 1.05e18);
+        vm.expectEmit(true, true, true, true);
+        emit StoppedEarningExceededMarkableDemand(100e18, 30e18);
+        river.sudoReportStoppedEarningAt(address(redeemManager), reportedEth, 100e18);
+
+        RateMarkStack.RateMark memory mark = redeemManager.getRateMarkDetails(0);
+        assertEq(mark.amount, 30e18);
+        assertEq(mark.markedEth, applyRate(30e18, 1.05e18));
+        // the locked rate survives the clamp exactly
+        assertEq(mark.markedEth * 100e18, reportedEth * 30e18);
+
+        river.sudoSetRate(1.05e18);
+        assertEq(_settleAndClaim(id, 30e18, 1.05e18), applyRate(30e18, 1.05e18));
     }
 
     /// Marks never cover demand that a withdrawal event has already priced. Otherwise a redeemer

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -3560,6 +3560,109 @@ contract RiverV1CoverageTests is RiverV1TestBase {
         assertEq(river.getLastConsensusLayerReport().validatorsStoppedEarningBalance, 32 ether);
     }
 
+    /// @dev Deposits `depositAmount`, queues `redeemAmount` of LsETH for redemption and returns the
+    ///      largest CL balance increase this report may carry without tripping the upper reporting bound.
+    ///      The pool rate is 1:1 on entry, so LsETH and ETH amounts coincide before the report.
+    function _seedRedeemDemandAndBound(uint256 depositAmount, uint256 redeemAmount, uint256 epoch)
+        private
+        returns (uint256 maxIncrease)
+    {
+        address alice = makeAddr("alice");
+        _allowDeposit(alice);
+        vm.deal(alice, depositAmount);
+        vm.prank(alice);
+        river.deposit{value: depositAmount}();
+
+        vm.prank(alice);
+        river.approve(address(redeemManager), redeemAmount);
+        vm.prank(alice);
+        redeemManager.requestRedeem(redeemAmount);
+
+        _warpToFinalizedEpoch(epoch);
+
+        // mirrors LibOracleReporting._maxIncrease for a first report (last stored epoch is 0)
+        uint256 elapsed = epoch * slotsPerEpoch * secondsPerSlot;
+        maxIncrease = (river.totalUnderlyingSupply() * river.getReportBounds().annualAprUpperBound * elapsed)
+            / (LibBasisPoints.BASIS_POINTS_MAX * 365 days);
+        assertGt(maxIncrease, 0);
+    }
+
+    /// Asserts the rate mark is priced at the rate River held BEFORE the report was applied, not the one
+    /// it ends the interval on. The report path values the stopped-earning delta at
+    /// LibOracleReporting.setConsensusLayerData's pre-report snapshot — taken before _pullCLFunds, the
+    /// stored-report update and the fee mint — and carries it to reportStoppedEarning as data. Principal
+    /// that crossed exit_epoch must stop accruing pool rewards from that moment, so the demand it backs
+    /// may not be credited with the interval during which it stopped earning.
+    function testReportStoppedEarningMarksAtPreReportRate() public {
+        _initRiverMinimalForReporting();
+
+        uint256 epoch = epochsPerFrame;
+        uint256 maxIncrease = _seedRedeemDemandAndBound(64 ether, 32 ether, epoch);
+
+        uint256 preUnderlying = river.totalUnderlyingSupply();
+        uint256 preSupply = river.totalSupply();
+
+        // a real rewards interval: the CL balance grows within bound, so the rate genuinely moves
+        uint256 reward = maxIncrease / 2;
+        assertGt(reward, 0);
+        uint256 stoppedEarningEth = 10 ether;
+
+        IOracleManagerV1.ConsensusLayerReport memory clr;
+        clr.epoch = epoch;
+        clr.validatorsBalance = reward;
+        clr.validatorsStoppedEarningBalance = stoppedEarningEth;
+        clr.totalDepositedActivatedETH = 0;
+        clr.exitedETHPerOperator = new uint256[](1);
+        clr.activeCLETHPerOperator = new uint256[](1);
+
+        vm.prank(address(oracle));
+        river.setConsensusLayerData(clr);
+
+        // the rate did move over the report, so pre and post are genuinely distinguishable
+        assertGt(river.totalUnderlyingSupply() * preSupply, preUnderlying * river.totalSupply());
+
+        assertEq(redeemManager.getRateMarkCount(), 1);
+        RateMarkStack.RateMark memory mark = redeemManager.getRateMarkDetails(0);
+
+        // the whole delta fits in the pending demand, so it is marked verbatim at the pre-report rate
+        assertEq(mark.amount, (stoppedEarningEth * preSupply) / preUnderlying);
+        assertEq(mark.markedEth, stoppedEarningEth);
+
+        // and that is strictly less than what the interval's closing rate would have locked in
+        assertLt(mark.markedEth, river.underlyingBalanceFromShares(mark.amount));
+    }
+
+    /// Slashing containment freezes new exit requests but leaves the rest of the report — including the
+    /// rebase and the fee mint — running, so the mark must still be anchored to the pre-report rate.
+    /// Suspending accrual here would penalise a queued redeemer twice.
+    function testReportStoppedEarningMarksAtPreReportRateUnderSlashingContainment() public {
+        _initRiverMinimalForReporting();
+
+        uint256 epoch = epochsPerFrame;
+        uint256 maxIncrease = _seedRedeemDemandAndBound(64 ether, 32 ether, epoch);
+
+        uint256 preUnderlying = river.totalUnderlyingSupply();
+        uint256 preSupply = river.totalSupply();
+        uint256 stoppedEarningEth = 10 ether;
+
+        IOracleManagerV1.ConsensusLayerReport memory clr;
+        clr.epoch = epoch;
+        clr.validatorsBalance = maxIncrease / 2;
+        clr.validatorsStoppedEarningBalance = stoppedEarningEth;
+        clr.slashingContainmentMode = true;
+        clr.totalDepositedActivatedETH = 0;
+        clr.exitedETHPerOperator = new uint256[](1);
+        clr.activeCLETHPerOperator = new uint256[](1);
+
+        vm.prank(address(oracle));
+        river.setConsensusLayerData(clr);
+
+        RateMarkStack.RateMark memory mark = redeemManager.getRateMarkDetails(0);
+        assertEq(mark.amount, (stoppedEarningEth * preSupply) / preUnderlying);
+        assertEq(mark.markedEth, stoppedEarningEth);
+        assertLt(mark.markedEth, river.underlyingBalanceFromShares(mark.amount));
+    }
+
     function testReportConsolidationsUnchangedKeepsBuffer() public {
         _initRiverMinimalForReporting();
         // No consolidation coverage fund configured, so the end-of-report pull path cannot touch the buffer.


### PR DESCRIPTION
…port rate

reportStoppedEarning derived the locked rate from live callbacks into River (sharesFromUnderlyingBalance / underlyingBalanceFromShares), and LibOracleReporting calls it after LastConsensusLayerReport.set and after the _onEarnings fee mint. The mark therefore captured the closing rate of the interval, crediting the redeemer with one interval of rewards more than intended — the very interval during which their backing principal stopped earning.

River now values the delta at its pre-report snapshot, taken one line before _pullCLFunds, where the conversion views still return the previous interval's answer. Past that point the asset balance is transiently double counted: _pullCLFunds credits exited and skimmed eth to the buffers while the stored report still counts the same eth in validatorsBalance.

The valuation travels to the redeem manager as data rather than being read there, so the anchor cannot silently drift if setConsensusLayerData is reordered. reportStoppedEarning takes the amount in both eth and LsETH; their ratio is the rate the mark locks. (eth, LsETH) rather than a scaled rate keeps the shape a RateMark already stores, matching how RedeemRequestAnchor holds (ethAtRequest, lsETHAtRequest), and avoids the extra rounding a 1e18-scaled scalar would compound. Marking the whole reported amount now needs no conversion at all; only the clamped case divides, scaling the eth leg in the same proportion so the locked rate survives the clamp.

The call site keeps its position: running before _reportWithdrawToRedeemManager, so that demand settled in the same report is marked before its shares are burned, is unchanged and still load bearing.

Tests: the existing redeem manager call sites are untouched — the mock helper derives the LsETH leg from its own rate, reproducing the previous math exactly. Four new tests pin the behaviour and all four fail against the old live-rate implementation: two at the redeem manager (the pair overrides the live rate; the clamp preserves the reported rate) and two end to end on River, with and without slashing containment.

## Description

<!-- Please provide a detailed description of your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->