### PR TITLE
chore: remove unused code in `ConsensusLayerDepositManager.1.sol` (BS-4957)

### DIFF
--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -390,12 +390,7 @@ contract RiverV1 is
 
     /// @notice Overridden handler to pass the system admin inside components
     /// @return The address of the admin
-    function _getRiverAdmin()
-        internal
-        view
-        override(OracleManagerV1, ConsensusLayerDepositManagerV1)
-        returns (address)
-    {
+    function _getRiverAdmin() internal view override(OracleManagerV1) returns (address) {
         return Administrable._getAdmin();
     }
 

--- a/contracts/src/components/ConsensusLayerDepositManager.1.sol
+++ b/contracts/src/components/ConsensusLayerDepositManager.1.sol
@@ -46,14 +46,6 @@ abstract contract ConsensusLayerDepositManagerV1 is IConsensusLayerDepositManage
         _;
     }
 
-    modifier onlyRiverAdmin() {
-        if (msg.sender != _getRiverAdmin()) revert LibErrors.Unauthorized(msg.sender);
-        _;
-    }
-
-    /// @notice Handler called to retrieve the internal River admin address
-    function _getRiverAdmin() internal view virtual returns (address);
-
     /// @notice Handler called to increment the funded ETH for the operators
     /// @param _deltas The per-operator funding deltas (sorted by operatorIndex)
     function _incrementFundedETH(IOperatorsRegistryV1.OperatorFundingDelta[] memory _deltas) internal virtual;

--- a/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
+++ b/contracts/test/components/ConsensusLayerDepositManagerAttestation.t.sol
@@ -122,10 +122,6 @@ contract AttestationDepositHarness is ConsensusLayerDepositManagerV1 {
         return operatorsRegistry;
     }
 
-    function _getRiverAdmin() internal view override returns (address) {
-        return _admin;
-    }
-
     function _setCommittedBalance(uint256 v) internal override {
         CommittedBalance.set(v);
     }


### PR DESCRIPTION
## Description

Removes `onlyRiverAdmin` modifier from `ConsensusLayerDepositManager.1.sol`, since it's not used anywhere.
Consequently `ConsensusLayerDepositManager.1.sol::_getRiverAdmin()` can be removed, too, since it was used only in the modifier.

## Pull Request Type

- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Testing

No tests are functionally affected. 
`ConsensusLayerDepositManagerAttestation.t.sol::_getRiverAdmin()` is removed since it does not need to implement `ConsensusLayerDepositManager.1.sol::_getRiverAdmin()` anymore, but it does not affect any test case. 

## Additional comments

Code was ignored by compiler already before, so the change does not affect bytesize of any contract or affect any test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined administration checks for consensus-layer deposit operations.
  * Preserved existing River administrator access and attestation verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->