### PR TITLE
chore: remove initializers already executed on every deployed proxy [BS-4968]

### DIFF
--- a/certora/harness/OperatorsRegistryV1Harness.sol
+++ b/certora/harness/OperatorsRegistryV1Harness.sol
@@ -2,8 +2,12 @@
 pragma solidity 0.8.34;
 
 import "../../contracts/src/OperatorsRegistry.1.sol";
+// Verified against the legacy-init subclass so the specs can keep naming the historical
+// initializers (`initOperatorsRegistryV1`, `initOperatorsRegistryV1_1`), which production
+// OperatorsRegistryV1 no longer ships because every deployed proxy has run them.
+import "../../contracts/test/utils/LegacyInit.sol";
 import "../../contracts/src/state/operatorsRegistry/Operators.2.sol";
-contract OperatorsRegistryV1Harness is OperatorsRegistryV1 {
+contract OperatorsRegistryV1Harness is OperatorsRegistryV1WithLegacyInit {
     
     function getOperatorAddress(uint256 index) external view returns (address) {
         OperatorsV2.Operator memory op = OperatorsV2.get(index);

--- a/certora/harness/RedeemManagerV1Harness.sol
+++ b/certora/harness/RedeemManagerV1Harness.sol
@@ -3,8 +3,12 @@ pragma solidity 0.8.34;
 
 import { RedeemManagerV1, WithdrawalStack } from "contracts/src/RedeemManager.1.sol";
 import "contracts/src/state/redeemManager/RedeemQueue.2.sol";
+// Verified against the legacy-init subclass so the specs can keep naming
+// `initializeRedeemManagerV1_2`, which production RedeemManagerV1 no longer ships because
+// every deployed proxy has run it.
+import "contracts/test/utils/LegacyInit.sol";
 
-contract RedeemManagerV1Harness is RedeemManagerV1 {
+contract RedeemManagerV1Harness is RedeemManagerV1WithLegacyInit {
 
     function isMatchByID(uint32 requestID, uint32 eventID) external view returns (bool) {
         if (eventID >= WithdrawalStack.get().length) return false;

--- a/certora/harness/RiverV1Harness.sol
+++ b/certora/harness/RiverV1Harness.sol
@@ -2,8 +2,11 @@
 pragma solidity 0.8.34;
 
 import "contracts/src/River.1.sol";
+// Verified against the legacy-init subclass so the specs can keep naming `initRiverV1_1`,
+// which production RiverV1 no longer ships because every deployed proxy has run it.
+import "contracts/test/utils/RiverV1WithLegacyInit.sol";
 
-contract RiverV1Harness is RiverV1 {
+contract RiverV1Harness is RiverV1WithLegacyInit {
 
     function riverEthBalance() external view returns (uint256) {
         return address(this).balance;

--- a/contracts/src/Allowlist.1.sol
+++ b/contracts/src/Allowlist.1.sol
@@ -19,9 +19,12 @@ import "./state/allowlist/Allowlist.sol";
 /// @notice each bit represents a right in the system. The DENY_MASK defined the mask
 /// @notice used to identify if the denied bit is on, preventing users from interacting
 /// @notice with the system
-/// @dev The v1.0 and v1.1 initializers are intentionally absent: every deployed proxy has already
-///      advanced past those `init` versions, so they are unreachable. Their bodies are preserved for
-///      test bootstrapping in contracts/test/utils/LegacyInit.sol.
+/// @dev REMOVED INITIALIZERS. Every deployed proxy is at `Version == 2`, so the `init(N)` guard on
+///      each of these can never pass again; they were deleted to reclaim bytecode. Recorded here so
+///      the version counter's history stays readable, and so nobody reuses one of these slots:
+///        init(0)  initAllowlistV1(address,address)      -- _admin, _allower
+///        init(1)  initAllowlistV1_1(address)            -- _denier
+///      Bodies preserved verbatim in contracts/test/utils/LegacyInit.sol (AllowlistV1WithLegacyInit).
 contract AllowlistV1 is IAllowlistV1, Initializable, Administrable, IProtocolVersion {
     /// @inheritdoc IAllowlistV1
     function getAllower() external view returns (address) {

--- a/contracts/src/Allowlist.1.sol
+++ b/contracts/src/Allowlist.1.sol
@@ -19,19 +19,10 @@ import "./state/allowlist/Allowlist.sol";
 /// @notice each bit represents a right in the system. The DENY_MASK defined the mask
 /// @notice used to identify if the denied bit is on, preventing users from interacting
 /// @notice with the system
+/// @dev The v1.0 and v1.1 initializers are intentionally absent: every deployed proxy has already
+///      advanced past those `init` versions, so they are unreachable. Their bodies are preserved for
+///      test bootstrapping in contracts/test/utils/LegacyInit.sol.
 contract AllowlistV1 is IAllowlistV1, Initializable, Administrable, IProtocolVersion {
-    /// @inheritdoc IAllowlistV1
-    function initAllowlistV1(address _admin, address _allower) external init(0) {
-        _setAdmin(_admin);
-        AllowerAddress.set(_allower);
-        emit SetAllower(_allower);
-    }
-
-    function initAllowlistV1_1(address _denier) external init(1) {
-        DenierAddress.set(_denier);
-        emit SetDenier(_denier);
-    }
-
     /// @inheritdoc IAllowlistV1
     function getAllower() external view returns (address) {
         return AllowerAddress.get();

--- a/contracts/src/CoverageFund.1.sol
+++ b/contracts/src/CoverageFund.1.sol
@@ -29,13 +29,10 @@ import "./state/slashingCoverage/BalanceForCoverage.sol";
 /// @notice the coverage fund will be pulled after the revenue stream, and there won't be any commission on the eth pulled.
 /// @notice Once a Slashing event occurs, the team will do its best to inject the recovery funds in at maximum 365 days
 /// @notice The entities allowed to donate are selected by the team. It will mainly be treasury entities or insurance protocols able to fill this coverage fund properly.
+/// @dev The v1.0 initializer is intentionally absent: every deployed proxy has already advanced past
+///      `init(0)`, so it is unreachable. Its body is preserved for test bootstrapping in
+///      contracts/test/utils/LegacyInit.sol.
 contract CoverageFundV1 is Initializable, ICoverageFundV1, IProtocolVersion {
-    /// @inheritdoc ICoverageFundV1
-    function initCoverageFundV1(address _riverAddress) external init(0) {
-        RiverAddress.set(_riverAddress);
-        emit SetRiver(_riverAddress);
-    }
-
     /// @inheritdoc ICoverageFundV1
     function pullCoverageFunds(uint256 _maxAmount) external {
         address river = RiverAddress.get();

--- a/contracts/src/CoverageFund.1.sol
+++ b/contracts/src/CoverageFund.1.sol
@@ -29,9 +29,12 @@ import "./state/slashingCoverage/BalanceForCoverage.sol";
 /// @notice the coverage fund will be pulled after the revenue stream, and there won't be any commission on the eth pulled.
 /// @notice Once a Slashing event occurs, the team will do its best to inject the recovery funds in at maximum 365 days
 /// @notice The entities allowed to donate are selected by the team. It will mainly be treasury entities or insurance protocols able to fill this coverage fund properly.
-/// @dev The v1.0 initializer is intentionally absent: every deployed proxy has already advanced past
-///      `init(0)`, so it is unreachable. Its body is preserved for test bootstrapping in
-///      contracts/test/utils/LegacyInit.sol.
+/// @dev REMOVED INITIALIZERS. Every deployed proxy is at `Version == 1`, so the `init(N)` guard on
+///      this can never pass again; it was deleted to reclaim bytecode. Recorded here so the version
+///      counter's history stays readable, and so nobody reuses this slot:
+///        init(0)  initCoverageFundV1(address)           -- _riverAddress
+///      Body preserved verbatim in contracts/test/utils/LegacyInit.sol
+///      (CoverageFundV1WithLegacyInit).
 contract CoverageFundV1 is Initializable, ICoverageFundV1, IProtocolVersion {
     /// @inheritdoc ICoverageFundV1
     function pullCoverageFunds(uint256 _maxAmount) external {

--- a/contracts/src/ELFeeRecipient.1.sol
+++ b/contracts/src/ELFeeRecipient.1.sol
@@ -14,9 +14,12 @@ import "./state/shared/RiverAddress.sol";
 /// @title Execution Layer Fee Recipient (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract receives all the execution layer fees from the proposed blocks + bribes
-/// @dev The v1.0 initializer is intentionally absent: every deployed proxy has already advanced past
-///      `init(0)`, so it is unreachable. Its body is preserved for test bootstrapping in
-///      contracts/test/utils/LegacyInit.sol.
+/// @dev REMOVED INITIALIZERS. Every deployed proxy is at `Version == 1`, so the `init(N)` guard on
+///      this can never pass again; it was deleted to reclaim bytecode. Recorded here so the version
+///      counter's history stays readable, and so nobody reuses this slot:
+///        init(0)  initELFeeRecipientV1(address)         -- _riverAddress
+///      Body preserved verbatim in contracts/test/utils/LegacyInit.sol
+///      (ELFeeRecipientV1WithLegacyInit).
 contract ELFeeRecipientV1 is Initializable, IELFeeRecipientV1, IProtocolVersion {
     /// @inheritdoc IELFeeRecipientV1
     function pullELFees(uint256 _maxAmount) external {

--- a/contracts/src/ELFeeRecipient.1.sol
+++ b/contracts/src/ELFeeRecipient.1.sol
@@ -14,13 +14,10 @@ import "./state/shared/RiverAddress.sol";
 /// @title Execution Layer Fee Recipient (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract receives all the execution layer fees from the proposed blocks + bribes
+/// @dev The v1.0 initializer is intentionally absent: every deployed proxy has already advanced past
+///      `init(0)`, so it is unreachable. Its body is preserved for test bootstrapping in
+///      contracts/test/utils/LegacyInit.sol.
 contract ELFeeRecipientV1 is Initializable, IELFeeRecipientV1, IProtocolVersion {
-    /// @inheritdoc IELFeeRecipientV1
-    function initELFeeRecipientV1(address _riverAddress) external init(0) {
-        RiverAddress.set(_riverAddress);
-        emit SetRiver(_riverAddress);
-    }
-
     /// @inheritdoc IELFeeRecipientV1
     function pullELFees(uint256 _maxAmount) external {
         address river = RiverAddress.get();

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -13,7 +13,6 @@ import "./Administrable.sol";
 
 import "openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
 
-import "./state/operatorsRegistry/Operators.1.sol";
 import "./state/operatorsRegistry/Operators.2.sol";
 import "./state/operatorsRegistry/Operators.3.sol";
 import "./state/operatorsRegistry/ValidatorKeys.sol";
@@ -31,6 +30,10 @@ import "./state/shared/RiverAddress.sol";
 /// @dev Operator index is the position in the operators array. Operators are only
 /// @dev added, never removed, so the operator at index i is always the one at
 /// @dev array position i and indices are stable over time.
+/// @dev The v1.0 and v1.1 initializers are intentionally absent: every deployed proxy has already
+///      advanced past those `init` versions, so they are unreachable. Their bodies — including the
+///      V1 -> V2 operator migration — are preserved for test bootstrapping in
+///      contracts/test/utils/LegacyInit.sol.
 contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrable, ReentrancyGuard, IProtocolVersion {
     uint256 private constant DEPOSIT_SIZE = 32 ether;
 
@@ -47,40 +50,6 @@ contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrab
     // A partial withdrawal cannot drop a validator below the activation floor, so the most it can wire
     // (and reserve) is MaxEB minus the 32 ETH floor.
     uint64 private constant MAX_PARTIAL_EL_EXIT_AMOUNT_GWEI = 2_016_000_000_000; // 2048 - 32 ETH
-
-    /// @inheritdoc IOperatorsRegistryV1
-    function initOperatorsRegistryV1(address _admin, address _river) external init(0) {
-        _setAdmin(_admin);
-        RiverAddress.set(_river);
-        emit SetRiver(_river);
-    }
-
-    /// @inheritdoc IOperatorsRegistryV1
-    function initOperatorsRegistryV1_1() external init(1) {
-        _migrateOperators_V1_1();
-    }
-
-    /// @notice Internal utility to migrate the operators from V1 to V2 format
-    function _migrateOperators_V1_1() internal {
-        uint256 opCount = OperatorsV1.getCount();
-
-        for (uint256 idx = 0; idx < opCount; ++idx) {
-            OperatorsV1.Operator memory oldOperatorValue = OperatorsV1.get(idx);
-
-            OperatorsV2.push(
-                OperatorsV2.Operator({
-                    limit: uint32(oldOperatorValue.limit),
-                    funded: uint32(oldOperatorValue.funded),
-                    requestedExits: 0,
-                    keys: uint32(oldOperatorValue.keys),
-                    latestKeysEditBlockNumber: uint64(oldOperatorValue.latestKeysEditBlockNumber),
-                    active: oldOperatorValue.active,
-                    name: oldOperatorValue.name,
-                    operator: oldOperatorValue.operator
-                })
-            );
-        }
-    }
 
     /// @inheritdoc IOperatorsRegistryV1
     function initOperatorsRegistryV1_2(address _withdrawAddress) external init(2) {

--- a/contracts/src/OperatorsRegistry.1.sol
+++ b/contracts/src/OperatorsRegistry.1.sol
@@ -30,10 +30,15 @@ import "./state/shared/RiverAddress.sol";
 /// @dev Operator index is the position in the operators array. Operators are only
 /// @dev added, never removed, so the operator at index i is always the one at
 /// @dev array position i and indices are stable over time.
-/// @dev The v1.0 and v1.1 initializers are intentionally absent: every deployed proxy has already
-///      advanced past those `init` versions, so they are unreachable. Their bodies — including the
-///      V1 -> V2 operator migration — are preserved for test bootstrapping in
-///      contracts/test/utils/LegacyInit.sol.
+/// @dev REMOVED INITIALIZERS. Every deployed proxy is at `Version == 2`, so the `init(N)` guard on
+///      each of these can never pass again; they were deleted to reclaim bytecode. Recorded here so
+///      the version counter's history stays readable, and so nobody reuses one of these slots:
+///        init(0)  initOperatorsRegistryV1(address,address)  -- _admin, _river
+///        init(1)  initOperatorsRegistryV1_1()               -- ran _migrateOperators_V1_1
+///                                                              (OperatorsV1 -> OperatorsV2)
+///      `init(2)` is still live below as `initOperatorsRegistryV1_2`.
+///      Bodies preserved verbatim in contracts/test/utils/LegacyInit.sol
+///      (OperatorsRegistryV1WithLegacyInit), which is also where `_migrateOperators_V1_1` lives now.
 contract OperatorsRegistryV1 is IOperatorsRegistryV1, Initializable, Administrable, ReentrancyGuard, IProtocolVersion {
     uint256 private constant DEPOSIT_SIZE = 32 ether;
 

--- a/contracts/src/Oracle.1.sol
+++ b/contracts/src/Oracle.1.sol
@@ -18,51 +18,15 @@ import "./state/oracle/ReportsPositions.sol";
 /// @title Oracle (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract handles the input from the allowed oracle members. Highly inspired by Lido's implementation.
+/// @dev The v1.0 and v1.1 initializers are intentionally absent: every deployed proxy has already
+///      advanced past those `init` versions, so they are unreachable. Their bodies are preserved for
+///      test bootstrapping in contracts/test/utils/LegacyInit.sol.
 contract OracleV1 is IOracleV1, Initializable, Administrable, IProtocolVersion {
     modifier onlyAdminOrMember(address _oracleMember) {
         if (msg.sender != _getAdmin() && msg.sender != _oracleMember) {
             revert LibErrors.Unauthorized(msg.sender);
         }
         _;
-    }
-
-    /// @inheritdoc IOracleV1
-    function initOracleV1(
-        address _riverAddress,
-        address _administratorAddress,
-        uint64 _epochsPerFrame,
-        uint64 _slotsPerEpoch,
-        uint64 _secondsPerSlot,
-        uint64 _genesisTime,
-        uint256 _annualAprUpperBound,
-        uint256 _relativeLowerBound
-    ) external init(0) {
-        _setAdmin(_administratorAddress);
-        RiverAddress.set(_riverAddress);
-        emit SetRiver(_riverAddress);
-        CLSpec.set(
-            CLSpec.CLSpecStruct({
-                epochsPerFrame: _epochsPerFrame,
-                slotsPerEpoch: _slotsPerEpoch,
-                secondsPerSlot: _secondsPerSlot,
-                genesisTime: _genesisTime,
-                epochsToAssumedFinality: 0
-            })
-        );
-        emit SetSpec(_epochsPerFrame, _slotsPerEpoch, _secondsPerSlot, _genesisTime);
-        ReportBounds.set(
-            ReportBounds.ReportBoundsStruct({
-                annualAprUpperBound: _annualAprUpperBound, relativeLowerBound: _relativeLowerBound
-            })
-        );
-        emit SetBounds(_annualAprUpperBound, _relativeLowerBound);
-        Quorum.set(0);
-        emit SetQuorum(0);
-    }
-
-    /// @inheritdoc IOracleV1
-    function initOracleV1_1() external init(1) {
-        _clearReports();
     }
 
     /// @inheritdoc IOracleV1

--- a/contracts/src/Oracle.1.sol
+++ b/contracts/src/Oracle.1.sol
@@ -18,9 +18,14 @@ import "./state/oracle/ReportsPositions.sol";
 /// @title Oracle (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract handles the input from the allowed oracle members. Highly inspired by Lido's implementation.
-/// @dev The v1.0 and v1.1 initializers are intentionally absent: every deployed proxy has already
-///      advanced past those `init` versions, so they are unreachable. Their bodies are preserved for
-///      test bootstrapping in contracts/test/utils/LegacyInit.sol.
+/// @dev REMOVED INITIALIZERS. Every deployed proxy is at `Version == 2`, so the `init(N)` guard on
+///      each of these can never pass again; they were deleted to reclaim bytecode. Recorded here so
+///      the version counter's history stays readable, and so nobody reuses one of these slots:
+///        init(0)  initOracleV1(address,address,uint64,uint64,uint64,uint64,uint256,uint256)
+///                 -- _riverAddress, _administratorAddress, _epochsPerFrame, _slotsPerEpoch,
+///                    _secondsPerSlot, _genesisTime, _annualAprUpperBound, _relativeLowerBound
+///        init(1)  initOracleV1_1()                      -- cleared the pending reports
+///      Bodies preserved verbatim in contracts/test/utils/LegacyInit.sol (OracleV1WithLegacyInit).
 contract OracleV1 is IOracleV1, Initializable, Administrable, IProtocolVersion {
     modifier onlyAdminOrMember(address _oracleMember) {
         if (msg.sender != _getAdmin() && msg.sender != _oracleMember) {

--- a/contracts/src/ProtocolMetrics.1.sol
+++ b/contracts/src/ProtocolMetrics.1.sol
@@ -5,11 +5,10 @@ import {ISharesManagerV1} from "./interfaces/components/ISharesManager.1.sol";
 import {Initializable} from "./Initializable.sol";
 import {RiverAddress} from "./state/shared/RiverAddress.sol";
 
+/// @dev The v1.0 initializer is intentionally absent: the deployed proxy has already advanced past
+///      `init(0)`, so it is unreachable. Its body is preserved for test bootstrapping in
+///      contracts/test/utils/LegacyInit.sol.
 contract ProtocolMetricsV1 is Initializable {
-    function initProtocolMetricsV1(address river) external init(0) {
-        RiverAddress.set(river);
-    }
-
     // @dev Returns an 18 decimal fixed point number that is the exchange rate of the token to some other underlying
     //      token. The meaning of this rate depends on the context.
     function getRate() external view returns (uint256) {

--- a/contracts/src/ProtocolMetrics.1.sol
+++ b/contracts/src/ProtocolMetrics.1.sol
@@ -5,9 +5,13 @@ import {ISharesManagerV1} from "./interfaces/components/ISharesManager.1.sol";
 import {Initializable} from "./Initializable.sol";
 import {RiverAddress} from "./state/shared/RiverAddress.sol";
 
-/// @dev The v1.0 initializer is intentionally absent: the deployed proxy has already advanced past
-///      `init(0)`, so it is unreachable. Its body is preserved for test bootstrapping in
-///      contracts/test/utils/LegacyInit.sol.
+/// @dev REMOVED INITIALIZERS. The deployed proxy is at `Version == 1`, so the `init(N)` guard on
+///      this can never pass again; it was deleted to reclaim bytecode. Recorded here so the version
+///      counter's history stays readable, and so nobody reuses this slot:
+///        init(0)  initProtocolMetricsV1(address)        -- river
+///      Body preserved verbatim in contracts/test/utils/LegacyInit.sol
+///      (ProtocolMetricsV1WithLegacyInit). NOTE: `RiverAddress` has no other setter, so this
+///      implementation can no longer bootstrap a fresh proxy (e.g. a rate provider on a new chain).
 contract ProtocolMetricsV1 is Initializable {
     // @dev Returns an 18 decimal fixed point number that is the exchange rate of the token to some other underlying
     //      token. The meaning of this rate depends on the context.

--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -22,10 +22,15 @@ import "./state/redeemManager/RateMarkFloor.sol";
 /// @title Redeem Manager (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract handles the redeem requests of all users
-/// @dev The v1.0 and v1.2 initializers are intentionally absent: every deployed proxy has already
-///      advanced past those `init` versions, so they are unreachable. Their bodies — including the
-///      RedeemQueueV1 -> V2 migration — are preserved for test bootstrapping in
-///      contracts/test/utils/LegacyInit.sol.
+/// @dev REMOVED INITIALIZERS. Every deployed proxy is at `Version == 2`, so the `init(N)` guard on
+///      each of these can never pass again; they were deleted to reclaim bytecode. Recorded here so
+///      the version counter's history stays readable, and so nobody reuses one of these slots:
+///        init(0)  initializeRedeemManagerV1(address)    -- _river
+///        init(1)  initializeRedeemManagerV1_2()         -- ran _redeemQueueMigrationV1_2
+///                                                          (RedeemQueueV1 -> RedeemQueueV2)
+///      `init(2)` is still live below as `initializeRedeemManagerV1_3`.
+///      Bodies preserved verbatim in contracts/test/utils/LegacyInit.sol
+///      (RedeemManagerV1WithLegacyInit), which is also where `_redeemQueueMigrationV1_2` lives now.
 contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IProtocolVersion {
     /// @notice Value returned when resolving a redeem request that is unsatisfied
     int64 internal constant RESOLVE_UNSATISFIED = -1;

--- a/contracts/src/RedeemManager.1.sol
+++ b/contracts/src/RedeemManager.1.sol
@@ -11,7 +11,6 @@ import "./Initializable.sol";
 import "openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
 
 import "./state/shared/RiverAddress.sol";
-import "./state/redeemManager/RedeemQueue.1.sol";
 import "./state/redeemManager/RedeemQueue.2.sol";
 import "./state/redeemManager/WithdrawalStack.sol";
 import "./state/redeemManager/BufferedExceedingEth.sol";
@@ -23,6 +22,10 @@ import "./state/redeemManager/RateMarkFloor.sol";
 /// @title Redeem Manager (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract handles the redeem requests of all users
+/// @dev The v1.0 and v1.2 initializers are intentionally absent: every deployed proxy has already
+///      advanced past those `init` versions, so they are unreachable. Their bodies — including the
+///      RedeemQueueV1 -> V2 migration — are preserved for test bootstrapping in
+///      contracts/test/utils/LegacyInit.sol.
 contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IProtocolVersion {
     /// @notice Value returned when resolving a redeem request that is unsatisfied
     int64 internal constant RESOLVE_UNSATISFIED = -1;
@@ -64,16 +67,6 @@ contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IP
     }
 
     /// @inheritdoc IRedeemManagerV1
-    function initializeRedeemManagerV1(address _river) external init(0) {
-        RiverAddress.set(_river);
-        emit SetRiver(_river);
-    }
-
-    function initializeRedeemManagerV1_2() external init(1) {
-        _redeemQueueMigrationV1_2();
-    }
-
-    /// @inheritdoc IRedeemManagerV1
     function initializeRedeemManagerV1_3() external init(2) {
         // Pin the launch cutover for stopped-earning accrual at the end of the existing queue, so the
         // requests already pending at upgrade time neither accrue (they have no anchor) nor consume the
@@ -87,23 +80,6 @@ contract RedeemManagerV1 is Initializable, ReentrancyGuard, IRedeemManagerV1, IP
         }
         RateMarkFloor.set(floor);
         emit SetRateMarkFloor(floor);
-    }
-
-    function _redeemQueueMigrationV1_2() internal {
-        RedeemQueueV1.RedeemRequest[] memory oldQueue = RedeemQueueV1.get();
-        uint256 oldQueueLen = oldQueue.length;
-        RedeemQueueV2.RedeemRequest[] storage newQueue = RedeemQueueV2.get();
-
-        // Migrate from v1 to v2
-        for (uint256 i = 0; i < oldQueueLen; ++i) {
-            newQueue[i] = RedeemQueueV2.RedeemRequest({
-                amount: oldQueue[i].amount,
-                maxRedeemableEth: oldQueue[i].maxRedeemableEth,
-                recipient: oldQueue[i].recipient,
-                height: oldQueue[i].height,
-                initiator: oldQueue[i].recipient
-            });
-        }
     }
 
     /// @inheritdoc IRedeemManagerV1

--- a/contracts/src/River.1.sol
+++ b/contracts/src/River.1.sol
@@ -44,6 +44,20 @@ import "./state/shared/AttestationVerifierAddress.sol";
 /// @title River (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract merges all the manager contracts and implements all the virtual methods stitching all components together
+/// @dev REMOVED INITIALIZERS. Every deployed proxy is at `Version == 3`, so the `init(N)` guard on
+///      each of these can never pass again; they were deleted to reclaim bytecode. Recorded here so
+///      the version counter's history stays readable, and so nobody reuses one of these slots:
+///        init(0)  initRiverV1(address,address,bytes32,address,address,address,address,address,uint256)
+///                 -- _depositContractAddress, _elFeeRecipientAddress, _withdrawalCredentials,
+///                    _oracleAddress, _systemAdministratorAddress, _allowlistAddress,
+///                    _operatorRegistryAddress, _collectorAddress, _globalFee
+///        init(1)  initRiverV1_1(address,uint64,uint64,uint64,uint64,uint64,uint256,uint256,uint128,uint128)
+///                 -- _redeemManager, CL spec, report bounds and daily committable limits
+///        init(2)  initRiverV1_2()
+///                 -- rounded the committed balance down to a multiple of 32 ETH
+///      `init(3)` is still live below as `initRiverV1_3`.
+///      Bodies preserved verbatim in contracts/test/utils/RiverV1WithLegacyInit.sol, which also holds
+///      the `initOracleManagerV1` / `initOracleManagerV1_1` internals they used to call.
 contract RiverV1 is
     ConsensusLayerDepositManagerV1,
     UserDepositManagerV1,

--- a/contracts/src/TLC.1.sol
+++ b/contracts/src/TLC.1.sol
@@ -10,6 +10,10 @@ import "./interfaces/ITLC.1.sol";
 /// @notice Upon deployment, all minted tokens are send to account provided at construction, in charge of creating the vesting schedules
 /// @notice The contract is based on ERC20Votes by OpenZeppelin. Users need to delegate their voting power to someone or themselves to be able to vote.
 /// @notice The contract contains vesting logics allowing vested users to still be able to delegate their voting power while their tokens are held in an escrow
+/// @dev The v1.0 initializer and the vesting-schedule migration are intentionally absent: the deployed
+///      proxy already sits at OpenZeppelin `_initialized == 2`, so neither can be re-run. Their bodies
+///      are preserved for test bootstrapping in contracts/test/utils/LegacyInit.sol, which is why the
+///      token constants below are still declared here.
 contract TLCV1 is ITLCV1, ERC20VestableVotesUpgradeableV1 {
     // Token information
     string internal constant NAME = "Liquid Collective";
@@ -21,18 +25,5 @@ contract TLCV1 is ITLCV1, ERC20VestableVotesUpgradeableV1 {
     /// @notice Disables implementation initialization
     constructor() {
         _disableInitializers();
-    }
-
-    /// @inheritdoc ITLCV1
-    function initTLCV1(address _account) external initializer {
-        LibSanitize._notZeroAddress(_account);
-        __ERC20Permit_init(NAME);
-        __ERC20_init(NAME, SYMBOL);
-        _mint(_account, INITIAL_SUPPLY);
-    }
-
-    /// @inheritdoc ITLCV1
-    function migrateVestingSchedules() external reinitializer(2) {
-        ERC20VestableVotesUpgradeableV1.migrateVestingSchedulesFromV1ToV2();
     }
 }

--- a/contracts/src/TLC.1.sol
+++ b/contracts/src/TLC.1.sol
@@ -10,9 +10,14 @@ import "./interfaces/ITLC.1.sol";
 /// @notice Upon deployment, all minted tokens are send to account provided at construction, in charge of creating the vesting schedules
 /// @notice The contract is based on ERC20Votes by OpenZeppelin. Users need to delegate their voting power to someone or themselves to be able to vote.
 /// @notice The contract contains vesting logics allowing vested users to still be able to delegate their voting power while their tokens are held in an escrow
-/// @dev The v1.0 initializer and the vesting-schedule migration are intentionally absent: the deployed
-///      proxy already sits at OpenZeppelin `_initialized == 2`, so neither can be re-run. Their bodies
-///      are preserved for test bootstrapping in contracts/test/utils/LegacyInit.sol, which is why the
+/// @dev REMOVED INITIALIZERS. TLC uses OpenZeppelin's `Initializable`, not the protocol's `init(N)`
+///      counter, and the deployed proxy already sits at `_initialized == 2`, so neither of these can
+///      run again; they were deleted to reclaim bytecode. Recorded here so the initialization history
+///      stays readable, and so nobody reuses one of these OZ versions:
+///        initializer      initTLCV1(address)            -- _account, minted INITIAL_SUPPLY to it
+///        reinitializer(2) migrateVestingSchedules()     -- ran migrateVestingSchedulesFromV1ToV2
+///                                                          (VestingSchedulesV1 -> V2)
+///      Bodies preserved verbatim in contracts/test/utils/TLCV1WithLegacyInit.sol, which is why the
 ///      token constants below are still declared here.
 contract TLCV1 is ITLCV1, ERC20VestableVotesUpgradeableV1 {
     // Token information

--- a/contracts/src/Withdraw.1.sol
+++ b/contracts/src/Withdraw.1.sol
@@ -24,9 +24,12 @@ import "./state/withdraw/PectraConsolidationContractAddress.sol";
 /// @notice It is in charge of holding the exited and skimmed funds and allows river to pull these funds.
 /// @notice Furthermore, it enables consolidation of LC validators.
 /// @notice LC validators (0x02) can be EL-exited using partial or full EL withdrawals via the withdraw function.
-/// @dev The v1.0 initializer is intentionally absent: every deployed proxy has already advanced past
-///      `init(0)`, so it is unreachable. Its body is preserved for test bootstrapping in
-///      contracts/test/utils/LegacyInit.sol.
+/// @dev REMOVED INITIALIZERS. Every deployed proxy is at `Version == 1`, so the `init(N)` guard on
+///      this can never pass again; it was deleted to reclaim bytecode. Recorded here so the version
+///      counter's history stays readable, and so nobody reuses this slot:
+///        init(0)  initializeWithdrawV1(address)         -- _river, called _setRiver
+///      `init(1)` is still live below as `initWithdrawV1_1`.
+///      Body preserved verbatim in contracts/test/utils/LegacyInit.sol (WithdrawV1WithLegacyInit).
 contract WithdrawV1 is IWithdrawV1, Initializable, ReentrancyGuard, IProtocolVersion {
     modifier onlyRiver() {
         if (msg.sender != RiverAddress.get()) {

--- a/contracts/src/Withdraw.1.sol
+++ b/contracts/src/Withdraw.1.sol
@@ -24,17 +24,15 @@ import "./state/withdraw/PectraConsolidationContractAddress.sol";
 /// @notice It is in charge of holding the exited and skimmed funds and allows river to pull these funds.
 /// @notice Furthermore, it enables consolidation of LC validators.
 /// @notice LC validators (0x02) can be EL-exited using partial or full EL withdrawals via the withdraw function.
+/// @dev The v1.0 initializer is intentionally absent: every deployed proxy has already advanced past
+///      `init(0)`, so it is unreachable. Its body is preserved for test bootstrapping in
+///      contracts/test/utils/LegacyInit.sol.
 contract WithdrawV1 is IWithdrawV1, Initializable, ReentrancyGuard, IProtocolVersion {
     modifier onlyRiver() {
         if (msg.sender != RiverAddress.get()) {
             revert LibErrors.Unauthorized(msg.sender);
         }
         _;
-    }
-
-    /// @inheritdoc IWithdrawV1
-    function initializeWithdrawV1(address _river) external init(0) {
-        _setRiver(_river);
     }
 
     /// @inheritdoc IWithdrawV1
@@ -221,6 +219,8 @@ contract WithdrawV1 is IWithdrawV1, Initializable, ReentrancyGuard, IProtocolVer
     }
 
     /// @notice Internal utility to set the river address
+    /// @dev Retained for the legacy-init test harness; the production v1.0 initializer that called it
+    ///      has been removed, so this is unreachable onchain and stripped from the deployed bytecode.
     /// @param _river The new river address
     function _setRiver(address _river) internal {
         RiverAddress.set(_river);

--- a/contracts/src/components/ERC20VestableVotesUpgradeable.1.sol
+++ b/contracts/src/components/ERC20VestableVotesUpgradeable.1.sol
@@ -81,6 +81,10 @@ abstract contract ERC20VestableVotesUpgradeableV1 is
 
     /// @notice This method migrates the state of the vesting schedules from V1 to V2
     /// @dev This method should be used if deployment with the old version using V1 state models is upgraded
+    /// @dev Retained for the legacy-init test harness only: the deployed TLC proxy already ran this
+    ///      migration, so `TLCV1.migrateVestingSchedules` has been removed and nothing in
+    ///      contracts/src calls this. It is therefore stripped from the deployed bytecode. See
+    ///      contracts/test/utils/TLCV1WithLegacyInit.sol.
     function migrateVestingSchedulesFromV1ToV2() internal {
         if (VestingSchedulesV2.getCount() == 0) {
             uint256 existingV1VestingSchedules = VestingSchedulesV1.getCount();

--- a/contracts/src/components/OracleManager.1.sol
+++ b/contracts/src/components/OracleManager.1.sol
@@ -30,48 +30,6 @@ abstract contract OracleManagerV1 is IOracleManagerV1 {
         _;
     }
 
-    /// @notice Set the initial oracle address
-    /// @param _oracle Address of the oracle
-    function initOracleManagerV1(address _oracle) internal {
-        OracleAddress.set(_oracle);
-        emit SetOracle(_oracle);
-    }
-
-    /// @notice Initializes version 1.1 of the oracle manager
-    /// @param _epochsPerFrame The amounts of epochs in a frame
-    /// @param _slotsPerEpoch The slots inside an epoch
-    /// @param _secondsPerSlot The seconds inside a slot
-    /// @param _genesisTime The genesis timestamp
-    /// @param _epochsToAssumedFinality The number of epochs before an epoch is considered final on-chain
-    /// @param _annualAprUpperBound The reporting upper bound
-    /// @param _relativeLowerBound The reporting lower bound
-    function initOracleManagerV1_1(
-        uint64 _epochsPerFrame,
-        uint64 _slotsPerEpoch,
-        uint64 _secondsPerSlot,
-        uint64 _genesisTime,
-        uint64 _epochsToAssumedFinality,
-        uint256 _annualAprUpperBound,
-        uint256 _relativeLowerBound
-    ) internal {
-        CLSpec.set(
-            CLSpec.CLSpecStruct({
-                epochsPerFrame: _epochsPerFrame,
-                slotsPerEpoch: _slotsPerEpoch,
-                secondsPerSlot: _secondsPerSlot,
-                genesisTime: _genesisTime,
-                epochsToAssumedFinality: _epochsToAssumedFinality
-            })
-        );
-        emit SetSpec(_epochsPerFrame, _slotsPerEpoch, _secondsPerSlot, _genesisTime, _epochsToAssumedFinality);
-        ReportBounds.set(
-            ReportBounds.ReportBoundsStruct({
-                annualAprUpperBound: _annualAprUpperBound, relativeLowerBound: _relativeLowerBound
-            })
-        );
-        emit SetBounds(_annualAprUpperBound, _relativeLowerBound);
-    }
-
     /// @inheritdoc IOracleManagerV1
     function getOracle() external view returns (address) {
         return OracleAddress.get();

--- a/contracts/src/components/OracleManager.1.sol
+++ b/contracts/src/components/OracleManager.1.sol
@@ -16,6 +16,18 @@ import "../state/river/OracleAddress.sol";
 /// @notice data whenever a new report has been deemed valid. The report consists in two
 /// @notice values: the sum of all balances of all deposited validators and the count of
 /// @notice validators that have been activated on the consensus layer.
+/// @dev REMOVED INITIALIZERS. These two carried no `init(N)` number of their own — they were
+///      `internal` helpers, reachable only from `RiverV1.initRiverV1` (`init(0)`) and
+///      `RiverV1.initRiverV1_1` (`init(1)`) respectively. Both callers are gone, so these became
+///      unreachable and were deleted:
+///        internal  initOracleManagerV1(address)
+///                  -- _oracle; set OracleAddress
+///        internal  initOracleManagerV1_1(uint64,uint64,uint64,uint64,uint64,uint256,uint256)
+///                  -- _epochsPerFrame, _slotsPerEpoch, _secondsPerSlot, _genesisTime,
+///                     _epochsToAssumedFinality, _annualAprUpperBound, _relativeLowerBound;
+///                     set CLSpec and ReportBounds
+///      Bodies preserved verbatim in contracts/test/utils/RiverV1WithLegacyInit.sol and, for the
+///      component's own tests, in contracts/test/components/OracleManager.1.t.sol.
 abstract contract OracleManagerV1 is IOracleManagerV1 {
     /// @notice Handler called to retrieve the system administrator address
     /// @dev Must be overridden

--- a/contracts/src/interfaces/IAllowlist.1.sol
+++ b/contracts/src/interfaces/IAllowlist.1.sol
@@ -34,15 +34,6 @@ interface IAllowlistV1 {
     /// @notice Allower can't remove deny permission
     error AttemptToRemoveDenyPermission();
 
-    /// @notice Initializes the allowlist
-    /// @param _admin Address of the Allowlist administrator
-    /// @param _allower Address of the allower
-    function initAllowlistV1(address _admin, address _allower) external;
-
-    /// @notice Initializes the allowlist denier
-    /// @param _denier Address of the denier
-    function initAllowlistV1_1(address _denier) external;
-
     /// @notice Retrieves the allower address
     /// @return The address of the allower
     function getAllower() external view returns (address);

--- a/contracts/src/interfaces/IAllowlist.1.sol
+++ b/contracts/src/interfaces/IAllowlist.1.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.34;
 /// @title Allowlist Interface (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This interface exposes methods to handle the list of allowed recipients.
+/// @dev `initAllowlistV1` (init(0)) and `initAllowlistV1_1` (init(1)) were removed; see the
+///      REMOVED INITIALIZERS note on AllowlistV1 in contracts/src/Allowlist.1.sol.
 interface IAllowlistV1 {
     /// @notice The permissions of several accounts have changed
     /// @param accounts List of accounts

--- a/contracts/src/interfaces/ICoverageFund.1.sol
+++ b/contracts/src/interfaces/ICoverageFund.1.sol
@@ -20,10 +20,6 @@ interface ICoverageFundV1 {
     /// @notice A donation with 0 ETH has been performed
     error EmptyDonation();
 
-    /// @notice Initialize the coverage fund with the required arguments
-    /// @param _riverAddress Address of River
-    function initCoverageFundV1(address _riverAddress) external;
-
     /// @notice Pulls ETH into the River contract
     /// @dev Only callable by the River contract
     /// @param _maxAmount The maximum amount to pull into the system

--- a/contracts/src/interfaces/ICoverageFund.1.sol
+++ b/contracts/src/interfaces/ICoverageFund.1.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.34;
 /// @title Coverage Fund Interface (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This interface exposes methods to receive donations for the slashing coverage fund and pull the funds into river
+/// @dev `initCoverageFundV1` (init(0)) was removed; see the REMOVED INITIALIZERS note on
+///      CoverageFundV1 in contracts/src/CoverageFund.1.sol.
 interface ICoverageFundV1 {
     /// @notice The storage river address has changed
     /// @param river The new river address

--- a/contracts/src/interfaces/IELFeeRecipient.1.sol
+++ b/contracts/src/interfaces/IELFeeRecipient.1.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.34;
 /// @title Execution Layer Fee Recipient Interface (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This interface exposes methods to receive all the execution layer fees from the proposed blocks + bribes
+/// @dev `initELFeeRecipientV1` (init(0)) was removed; see the REMOVED INITIALIZERS note on
+///      ELFeeRecipientV1 in contracts/src/ELFeeRecipient.1.sol.
 interface IELFeeRecipientV1 {
     /// @notice The storage river address has changed
     /// @param river The new river address

--- a/contracts/src/interfaces/IELFeeRecipient.1.sol
+++ b/contracts/src/interfaces/IELFeeRecipient.1.sol
@@ -12,10 +12,6 @@ interface IELFeeRecipientV1 {
     /// @notice The fallback has been triggered
     error InvalidCall();
 
-    /// @notice Initialize the fee recipient with the required arguments
-    /// @param _riverAddress Address of River
-    function initELFeeRecipientV1(address _riverAddress) external;
-
     /// @notice Pulls ETH to the River contract
     /// @dev Only callable by the River contract
     /// @param _maxAmount The maximum amount to pull into the system

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -329,14 +329,6 @@ interface IOperatorsRegistryV1 {
     /// @param stopIndex The exclusive stop key index
     error InvalidPrePectraRange(uint256 operatorIndex, uint256 startIndex, uint256 stopIndex);
 
-    /// @notice Initializes the operators registry
-    /// @param _admin Admin in charge of managing operators
-    /// @param _river Address of River system
-    function initOperatorsRegistryV1(address _admin, address _river) external;
-
-    /// @notice Initializes the operators registry for V1_1, migrating operators from V1 to V2 storage
-    function initOperatorsRegistryV1_1() external;
-
     /// @notice Migrates operators from V2 to V3 storage, dropping key-management fields
     /// @dev    Migrated operators start with `activeCLETH == 0`, which is only populated by the first
     ///         post-upgrade oracle report. Since `requestETHExits` caps each operator's allocation by

--- a/contracts/src/interfaces/IOperatorRegistry.1.sol
+++ b/contracts/src/interfaces/IOperatorRegistry.1.sol
@@ -7,6 +7,9 @@ import "./IWithdraw.1.sol";
 /// @title Operators Registry Interface (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This interface exposes methods to handle the list of operators
+/// @dev `initOperatorsRegistryV1` (init(0)) and `initOperatorsRegistryV1_1` (init(1)) were
+///      removed; see the REMOVED INITIALIZERS note on OperatorsRegistryV1 in
+///      contracts/src/OperatorsRegistry.1.sol.
 interface IOperatorsRegistryV1 {
     /// @notice Structure representing a validator deposit
     /// @param operatorIndex The index of the operator

--- a/contracts/src/interfaces/IOracle.1.sol
+++ b/contracts/src/interfaces/IOracle.1.sol
@@ -84,29 +84,6 @@ interface IOracleV1 {
     /// @param newAddress The address already in use
     error AddressAlreadyInUse(address newAddress);
 
-    /// @notice Initializes the oracle
-    /// @param _river Address of the River contract, able to receive oracle input data after quorum is met
-    /// @param _administratorAddress Address able to call administrative methods
-    /// @param _epochsPerFrame CL spec parameter. Number of epochs in a frame.
-    /// @param _slotsPerEpoch CL spec parameter. Number of slots in one epoch.
-    /// @param _secondsPerSlot CL spec parameter. Number of seconds between slots.
-    /// @param _genesisTime CL spec parameter. Timestamp of the genesis slot.
-    /// @param _annualAprUpperBound CL bound parameter. Maximum apr allowed for balance increase. Delta between updates is extrapolated on a year time frame.
-    /// @param _relativeLowerBound CL bound parameter. Maximum relative balance decrease.
-    function initOracleV1(
-        address _river,
-        address _administratorAddress,
-        uint64 _epochsPerFrame,
-        uint64 _slotsPerEpoch,
-        uint64 _secondsPerSlot,
-        uint64 _genesisTime,
-        uint256 _annualAprUpperBound,
-        uint256 _relativeLowerBound
-    ) external;
-
-    /// @notice Initializes the oracle
-    function initOracleV1_1() external;
-
     /// @notice Retrieve River address
     /// @return The address of River
     function getRiver() external view returns (address);

--- a/contracts/src/interfaces/IOracle.1.sol
+++ b/contracts/src/interfaces/IOracle.1.sol
@@ -8,6 +8,8 @@ import "../state/oracle/ReportsVariants.sol";
 /// @author Alluvial Finance Inc.
 /// @notice This interface exposes methods to handle the input from the allowed oracle members.
 /// @notice Highly inspired by Lido's implementation.
+/// @dev `initOracleV1` (init(0)) and `initOracleV1_1` (init(1)) were removed; see the
+///      REMOVED INITIALIZERS note on OracleV1 in contracts/src/Oracle.1.sol.
 interface IOracleV1 {
     /// @notice The storage quorum value has been changed
     /// @param newQuorum The new quorum value

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -135,11 +135,6 @@ interface IRedeemManagerV1 {
     /// @notice Thrown when an action is blocked because slashing containment mode is active
     error SlashingContainmentModeEnabled();
 
-    /// @param _river The address of the River contract
-    function initializeRedeemManagerV1(address _river) external;
-
-    function initializeRedeemManagerV1_2() external;
-
     /// @notice Pins the launch cutover for stopped-earning rate marks at the end of the current queue
     /// @dev Must run in the same governance action that upgrades the implementation. Without it the
     ///      floor stays 0 and the first reports after the upgrade spend their stopped-earning credit on

--- a/contracts/src/interfaces/IRedeemManager.1.sol
+++ b/contracts/src/interfaces/IRedeemManager.1.sol
@@ -9,6 +9,9 @@ import "../state/redeemManager/RedeemRequestAnchor.sol";
 /// @title Redeem Manager Interface (v1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract handles the redeem requests of all users
+/// @dev `initializeRedeemManagerV1` (init(0)) and `initializeRedeemManagerV1_2` (init(1)) were
+///      removed; see the REMOVED INITIALIZERS note on RedeemManagerV1 in
+///      contracts/src/RedeemManager.1.sol.
 interface IRedeemManagerV1 {
     /// @notice Emitted when a redeem request is created
     /// @param recipient The recipient of the redeem request

--- a/contracts/src/interfaces/ITLC.1.sol
+++ b/contracts/src/interfaces/ITLC.1.sol
@@ -9,11 +9,7 @@ import "./components/IERC20VestableVotesUpgradeable.1.sol";
 /// @title TLC Interface (v1)
 /// @author Alluvial Finance Inc.
 /// @notice TLC token interface
-interface ITLCV1 is IERC20Upgradeable, IVotesUpgradeable, IERC20VestableVotesUpgradeableV1 {
-    /// @notice Initializes the TLC Token
-    /// @param _account The initial account to grant all the minted tokens
-    function initTLCV1(address _account) external;
-
-    /// @notice Migrates the vesting schedule state structures
-    function migrateVestingSchedules() external;
-}
+/// @dev The v1.0 initializer and the vesting-schedule migration are intentionally absent: the deployed
+///      proxy already sits at OpenZeppelin `_initialized == 2`, so neither can be re-run. Their bodies
+///      are preserved for test bootstrapping in contracts/test/utils/LegacyInit.sol.
+interface ITLCV1 is IERC20Upgradeable, IVotesUpgradeable, IERC20VestableVotesUpgradeableV1 {}

--- a/contracts/src/interfaces/ITLC.1.sol
+++ b/contracts/src/interfaces/ITLC.1.sol
@@ -9,7 +9,8 @@ import "./components/IERC20VestableVotesUpgradeable.1.sol";
 /// @title TLC Interface (v1)
 /// @author Alluvial Finance Inc.
 /// @notice TLC token interface
-/// @dev The v1.0 initializer and the vesting-schedule migration are intentionally absent: the deployed
-///      proxy already sits at OpenZeppelin `_initialized == 2`, so neither can be re-run. Their bodies
-///      are preserved for test bootstrapping in contracts/test/utils/LegacyInit.sol.
+/// @dev This interface is deliberately empty. It used to declare `initTLCV1(address)` (OZ
+///      `initializer`) and `migrateVestingSchedules()` (OZ `reinitializer(2)`); both were removed
+///      because the deployed proxy already sits at `_initialized == 2`. See the note on TLCV1 in
+///      contracts/src/TLC.1.sol for the full record.
 interface ITLCV1 is IERC20Upgradeable, IVotesUpgradeable, IERC20VestableVotesUpgradeableV1 {}

--- a/contracts/src/interfaces/IWithdraw.1.sol
+++ b/contracts/src/interfaces/IWithdraw.1.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.34;
 /// @title Withdraw Interface (V1)
 /// @author Alluvial Finance Inc.
 /// @notice This contract is in charge of holding the exit and skimming funds and allow river to pull these funds
+/// @dev `initializeWithdrawV1` (init(0)) was removed; see the REMOVED INITIALIZERS note on
+///      WithdrawV1 in contracts/src/Withdraw.1.sol.
 interface IWithdrawV1 {
     /// @notice Request to consolidate multiple source pubkeys into a single target pubkey
     /// @param srcPubkeys Source validator pubkeys (48 bytes each)

--- a/contracts/src/interfaces/IWithdraw.1.sol
+++ b/contracts/src/interfaces/IWithdraw.1.sol
@@ -74,10 +74,7 @@ interface IWithdrawV1 {
     /// @param pubkey The offending 48-byte BLS pubkey
     error SelfConsolidationNotAllowed(bytes pubkey);
 
-    /// @param _river The address of the River contract
-    function initializeWithdrawV1(address _river) external;
-
-    /// @notice Initialize Pectra EL contract addresses (callable once after initializeWithdrawV1)
+    /// @notice Initialize Pectra EL contract addresses (callable once after the v1.0 initializer)
     /// @param _pectraWithdrawalContractAddress The Pectra EL withdrawal contract address
     /// @param _pectraConsolidationContractAddress The Pectra EL consolidation contract address
     /// @param _operatorsRegistry The OperatorsRegistry address

--- a/contracts/src/state/operatorsRegistry/Operators.1.sol
+++ b/contracts/src/state/operatorsRegistry/Operators.1.sol
@@ -6,6 +6,9 @@ import "../../libraries/LibSanitize.sol";
 /// @title Operators Storage
 /// @notice Utility to manage the Operators in storage
 /// @notice This state variable is deprecated and was kept due to migration logic needs
+/// @dev No longer read by contracts/src: the V1 -> V2 operator migration that used it now lives in
+///      contracts/test/utils/LegacyInit.sol, since mainnet ran it long ago. Kept so that harness (and
+///      the mainnet fork tests replaying the migration) can still address these slots.
 library OperatorsV1 {
     /// @notice Storage slot of the Operators
     bytes32 internal constant OPERATORS_SLOT = bytes32(uint256(keccak256("river.state.operators")) - 1);

--- a/contracts/src/state/redeemManager/RedeemQueue.1.sol
+++ b/contracts/src/state/redeemManager/RedeemQueue.1.sol
@@ -3,6 +3,9 @@ pragma solidity 0.8.34;
 
 /// @title Redeem Manager Redeem Queue storage
 /// @notice Utility to manage the Redeem Queue in the Redeem Manager
+/// @dev No longer read by contracts/src: the V1 -> V2 queue migration that used it now lives in
+///      contracts/test/utils/LegacyInit.sol, since mainnet ran it long ago. Kept so that harness (and
+///      the fork tests replaying the migration) can still address these slots.
 library RedeemQueueV1 {
     /// @notice Storage slot of the Redeem Queue
     bytes32 internal constant REDEEM_QUEUE_ID_SLOT = bytes32(uint256(keccak256("river.state.redeemQueue")) - 1);

--- a/contracts/test/Allowlist.1.t.sol
+++ b/contracts/test/Allowlist.1.t.sol
@@ -10,8 +10,9 @@ import "./utils/UserFactory.sol";
 import "./utils/LibImplementationUnbricker.sol";
 
 import "../src/Allowlist.1.sol";
+import "./utils/LegacyInit.sol";
 
-contract AllowlistV1Sudo is AllowlistV1 {
+contract AllowlistV1Sudo is AllowlistV1WithLegacyInit {
     function sudoSetAdmin(address admin) external {
         LibAdministrable._setAdmin(admin);
     }
@@ -26,7 +27,7 @@ abstract contract AllowlistV1TestBase is Test {
     address internal allower = address(0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8);
     address internal denier = makeAddr("denier");
 
-    AllowlistV1 internal allowlist;
+    AllowlistV1WithLegacyInit internal allowlist;
 
     event SetAllower(address indexed allower);
     event SetDenier(address indexed denier);

--- a/contracts/test/ConsolidationCoverageFund.1.t.sol
+++ b/contracts/test/ConsolidationCoverageFund.1.t.sol
@@ -11,6 +11,8 @@ import "../src/ConsolidationCoverageFund.1.sol";
 import "../src/interfaces/IConsolidationCoverageFund.1.sol";
 import "../src/Allowlist.1.sol";
 
+import "./utils/LegacyInit.sol";
+
 contract RiverMock {
     event BalanceUpdated(uint256 amount);
 
@@ -40,7 +42,7 @@ contract RiverMock {
 abstract contract ConsolidationCoverageFundV1TestBase is Test {
     ConsolidationCoverageFundV1 internal consolidationCoverageFund;
 
-    AllowlistV1 internal allowlist;
+    AllowlistV1WithLegacyInit internal allowlist;
     RiverMock internal river;
     UserFactory internal uf = new UserFactory();
     address internal admin;
@@ -53,7 +55,7 @@ abstract contract ConsolidationCoverageFundV1TestBase is Test {
 contract ConsolidationCoverageFundV1InitializationTests is ConsolidationCoverageFundV1TestBase {
     function setUp() public {
         admin = makeAddr("admin");
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(admin, admin);
         river = new RiverMock(address(allowlist));
@@ -71,7 +73,7 @@ contract ConsolidationCoverageFundV1InitializationTests is ConsolidationCoverage
 contract ConsolidationCoverageFundTestV1 is ConsolidationCoverageFundV1TestBase {
     function setUp() public {
         admin = makeAddr("admin");
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(admin, admin);
         allowlist.initAllowlistV1_1(admin);

--- a/contracts/test/CoverageFund.1.t.sol
+++ b/contracts/test/CoverageFund.1.t.sol
@@ -10,6 +10,8 @@ import "./utils/LibImplementationUnbricker.sol";
 import "../src/CoverageFund.1.sol";
 import "../src/Allowlist.1.sol";
 
+import "./utils/LegacyInit.sol";
+
 contract RiverMock {
     event BalanceUpdated(uint256 amount);
 
@@ -33,9 +35,9 @@ contract RiverMock {
 }
 
 abstract contract CoverageFundV1TestBase is Test {
-    CoverageFundV1 internal coverageFund;
+    CoverageFundV1WithLegacyInit internal coverageFund;
 
-    AllowlistV1 internal allowlist;
+    AllowlistV1WithLegacyInit internal allowlist;
     RiverMock internal river;
     UserFactory internal uf = new UserFactory();
     address internal admin;
@@ -48,11 +50,11 @@ abstract contract CoverageFundV1TestBase is Test {
 contract CoverageFundV1InitializationTests is CoverageFundV1TestBase {
     function setUp() public {
         admin = makeAddr("admin");
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(admin, admin);
         river = new RiverMock(address(allowlist));
-        coverageFund = new CoverageFundV1();
+        coverageFund = new CoverageFundV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(coverageFund));
     }
 
@@ -66,12 +68,12 @@ contract CoverageFundV1InitializationTests is CoverageFundV1TestBase {
 contract CoverageFundTestV1 is CoverageFundV1TestBase {
     function setUp() public {
         admin = makeAddr("admin");
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(admin, admin);
         allowlist.initAllowlistV1_1(admin);
         river = new RiverMock(address(allowlist));
-        coverageFund = new CoverageFundV1();
+        coverageFund = new CoverageFundV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(coverageFund));
         vm.expectEmit(true, true, true, true);
         emit SetRiver(address(river));

--- a/contracts/test/ELFeeRecipient.1.t.sol
+++ b/contracts/test/ELFeeRecipient.1.t.sol
@@ -9,6 +9,8 @@ import "./utils/LibImplementationUnbricker.sol";
 
 import "../src/ELFeeRecipient.1.sol";
 
+import "./utils/LegacyInit.sol";
+
 contract RiverDonationMock {
     event BalanceUpdated(uint256 amount);
 
@@ -22,7 +24,7 @@ contract RiverDonationMock {
 }
 
 abstract contract ELFeeRecipientV1TestBase is Test {
-    ELFeeRecipientV1 internal feeRecipient;
+    ELFeeRecipientV1WithLegacyInit internal feeRecipient;
 
     RiverDonationMock internal river;
     UserFactory internal uf = new UserFactory();
@@ -34,7 +36,7 @@ abstract contract ELFeeRecipientV1TestBase is Test {
 contract ELFeeRecipientV1InitializationTests is ELFeeRecipientV1TestBase {
     function setUp() public {
         river = new RiverDonationMock();
-        feeRecipient = new ELFeeRecipientV1();
+        feeRecipient = new ELFeeRecipientV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(feeRecipient));
     }
 
@@ -48,7 +50,7 @@ contract ELFeeRecipientV1InitializationTests is ELFeeRecipientV1TestBase {
 contract ELFeeRecipientV1Test is ELFeeRecipientV1TestBase {
     function setUp() public {
         river = new RiverDonationMock();
-        feeRecipient = new ELFeeRecipientV1();
+        feeRecipient = new ELFeeRecipientV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(feeRecipient));
         vm.expectEmit(true, true, true, true);
         emit SetRiver(address(river));

--- a/contracts/test/ExternalConsolidationRecipientMapping.t.sol
+++ b/contracts/test/ExternalConsolidationRecipientMapping.t.sol
@@ -12,6 +12,8 @@ import "../src/ExternalConsolidationRecipientMapping.1.sol";
 import "../src/interfaces/IExternalConsolidationRecipientMapping.1.sol";
 import "../src/libraries/LibAllowlistMasks.sol";
 
+import "./utils/LegacyInit.sol";
+
 contract ExternalConsolidationRecipientMappingRiverMock {
     address internal allowlist;
 
@@ -26,7 +28,7 @@ contract ExternalConsolidationRecipientMappingRiverMock {
 
 abstract contract ExternalConsolidationRecipientMappingV1TestBase is Test {
     ExternalConsolidationRecipientMappingV1 internal mappingContract;
-    AllowlistV1 internal allowlist;
+    AllowlistV1WithLegacyInit internal allowlist;
     ExternalConsolidationRecipientMappingRiverMock internal river;
     UserFactory internal uf = new UserFactory();
     address internal admin;
@@ -58,7 +60,7 @@ abstract contract ExternalConsolidationRecipientMappingV1TestBase is Test {
 contract ExternalConsolidationRecipientMappingV1InitializationTests is ExternalConsolidationRecipientMappingV1TestBase {
     function setUp() public {
         admin = makeAddr("admin");
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(admin, admin);
         river = new ExternalConsolidationRecipientMappingRiverMock(address(allowlist));
@@ -83,7 +85,7 @@ contract ExternalConsolidationRecipientMappingV1InitializationTests is ExternalC
 contract ExternalConsolidationRecipientMappingV1Tests is ExternalConsolidationRecipientMappingV1TestBase {
     function setUp() public {
         admin = makeAddr("admin");
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(admin, admin);
         allowlist.initAllowlistV1_1(admin);

--- a/contracts/test/Firewall.t.sol
+++ b/contracts/test/Firewall.t.sol
@@ -20,17 +20,19 @@ import "../src/Oracle.1.sol";
 import "../src/OperatorsRegistry.1.sol";
 import "../src/ELFeeRecipient.1.sol";
 
+import "./utils/LegacyInit.sol";
+
 /// @dev Concrete `RiverV1WithLegacyInit` so tests can `new` it. Production
 ///      `RiverV1` no longer ships `initRiverV1` / `_1` / `_2`.
 contract FirewallTestRiverV1 is RiverV1WithLegacyInit {}
 
 contract FirewallTests is BytesGenerator, OperatorAllocationTestBase {
-    AllowlistV1 internal allowlist;
+    AllowlistV1WithLegacyInit internal allowlist;
 
-    ELFeeRecipientV1 internal elFeeRecipient;
+    ELFeeRecipientV1WithLegacyInit internal elFeeRecipient;
 
     IDepositContract internal deposit;
-    WithdrawV1 internal withdraw;
+    WithdrawV1WithLegacyInit internal withdraw;
 
     address internal riverGovernor = address(0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8);
     address internal executor = address(0xa22c003A45554Ce90E7F97a3f613F16905440468);
@@ -40,21 +42,21 @@ contract FirewallTests is BytesGenerator, OperatorAllocationTestBase {
     address internal collector = address(0xC88F7666330b4b511358b7742dC2a3234710e7B1);
 
     FirewallTestRiverV1 internal river;
-    OracleV1 internal oracle;
+    OracleV1WithLegacyInit internal oracle;
     Firewall internal oracleFirewall;
-    OracleV1 internal firewalledOracle;
+    OracleV1WithLegacyInit internal firewalledOracle;
     IRiverV1 internal oracleInput;
 
-    AllowlistV1 internal firewalledAllowlist;
+    AllowlistV1WithLegacyInit internal firewalledAllowlist;
     Firewall internal allowlistFirewall;
 
     FirewallTestRiverV1 internal firewalledRiver;
     Firewall internal riverFirewall;
 
-    OperatorsRegistryV1 internal firewalledOperatorsRegistry;
+    OperatorsRegistryV1WithLegacyInit internal firewalledOperatorsRegistry;
     Firewall internal operatorsRegistryFirewall;
 
-    OperatorsRegistryV1 internal operatorsRegistry;
+    OperatorsRegistryV1WithLegacyInit internal operatorsRegistry;
     uint64 internal constant EPOCHS_PER_FRAME = 225;
     uint64 internal constant SLOTS_PER_EPOCH = 32;
     uint64 internal constant SECONDS_PER_SLOT = 12;
@@ -71,17 +73,17 @@ contract FirewallTests is BytesGenerator, OperatorAllocationTestBase {
 
     function setUp() public {
         deposit = new DepositContractMock();
-        elFeeRecipient = new ELFeeRecipientV1();
+        elFeeRecipient = new ELFeeRecipientV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(elFeeRecipient));
-        withdraw = new WithdrawV1();
+        withdraw = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(withdraw));
         river = new FirewallTestRiverV1();
         LibImplementationUnbricker.unbrick(vm, address(river));
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
-        operatorsRegistry = new OperatorsRegistryV1();
+        operatorsRegistry = new OperatorsRegistryV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(operatorsRegistry));
-        oracle = new OracleV1();
+        oracle = new OracleV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(oracle));
 
         elFeeRecipient.initELFeeRecipientV1(address(river));
@@ -92,7 +94,7 @@ contract FirewallTests is BytesGenerator, OperatorAllocationTestBase {
         emit SetDestination(address(allowlist));
         allowlistFirewall =
             new Firewall(riverGovernor, executor, address(allowlist), executorCallableAllowlistSelectors);
-        firewalledAllowlist = AllowlistV1(payable(address(allowlistFirewall)));
+        firewalledAllowlist = AllowlistV1WithLegacyInit(payable(address(allowlistFirewall)));
         allowlist.initAllowlistV1(payable(address(allowlistFirewall)), payable(address(allowlistFirewall)));
         allowlist.initAllowlistV1_1(payable(address(allowlistFirewall)));
 
@@ -101,7 +103,7 @@ contract FirewallTests is BytesGenerator, OperatorAllocationTestBase {
         operatorsRegistryFirewall = new Firewall(
             riverGovernor, executor, address(operatorsRegistry), executorCallableOperatorsRegistrySelectors
         );
-        firewalledOperatorsRegistry = OperatorsRegistryV1(payable(address(operatorsRegistryFirewall)));
+        firewalledOperatorsRegistry = OperatorsRegistryV1WithLegacyInit(payable(address(operatorsRegistryFirewall)));
         operatorsRegistry.initOperatorsRegistryV1(address(operatorsRegistryFirewall), address(river));
 
         bytes32 withdrawalCredentials = withdraw.getCredentials();
@@ -130,7 +132,7 @@ contract FirewallTests is BytesGenerator, OperatorAllocationTestBase {
         executorCallableOracleSelectors[1] = oracle.removeMember.selector;
         executorCallableOracleSelectors[2] = oracle.setQuorum.selector;
         oracleFirewall = new Firewall(riverGovernor, executor, address(oracle), executorCallableOracleSelectors);
-        firewalledOracle = OracleV1(address(oracleFirewall));
+        firewalledOracle = OracleV1WithLegacyInit(address(oracleFirewall));
         oracleInput = IRiverV1(payable(address(new RiverMock())));
         oracle.initOracleV1(
             address(oracleInput),

--- a/contracts/test/OperatorsRegistry.1.t.sol
+++ b/contracts/test/OperatorsRegistry.1.t.sol
@@ -19,7 +19,9 @@ import "../src/state/operatorsRegistry/CurrentValidatorExitsDemand.sol";
 import "../src/state/operatorsRegistry/TotalValidatorExitsRequested.sol";
 import "../src/state/operatorsRegistry/ValidatorKeys.sol";
 
-contract OperatorsRegistryInitializableV1 is OperatorsRegistryV1 {
+import "./utils/LegacyInit.sol";
+
+contract OperatorsRegistryInitializableV1 is OperatorsRegistryV1WithLegacyInit {
     function sudoSetFunded(uint256 _index, uint256 _funded) external {
         OperatorsV3.Operator storage operator = OperatorsV3.get(_index);
         operator.funded = _funded;
@@ -43,7 +45,7 @@ contract OperatorsRegistryInitializableV1 is OperatorsRegistryV1 {
 }
 
 /// @dev Same as OperatorsRegistryInitializableV1 but does NOT override onlyRiver; use for tests that assert Unauthorized
-contract OperatorsRegistryStrictRiverV1 is OperatorsRegistryV1 {
+contract OperatorsRegistryStrictRiverV1 is OperatorsRegistryV1WithLegacyInit {
     function sudoSetFunded(uint256 _index, uint256 _funded) external {
         OperatorsV3.Operator storage operator = OperatorsV3.get(_index);
         operator.funded = _funded;
@@ -55,7 +57,7 @@ contract OperatorsRegistryStrictRiverV1 is OperatorsRegistryV1 {
 }
 
 /// @dev Extension that exposes internal V1/V2 storage writers
-contract OperatorsRegistryWithMigrationHelpers is OperatorsRegistryV1 {
+contract OperatorsRegistryWithMigrationHelpers is OperatorsRegistryV1WithLegacyInit {
     function sudoPushV2Operator(OperatorsV2.Operator memory op) external {
         OperatorsV2.push(op);
     }
@@ -246,7 +248,7 @@ contract RiverMock {
 abstract contract OperatorsRegistryV1TestBase is Test {
     UserFactory internal uf = new UserFactory();
 
-    OperatorsRegistryV1 internal operatorsRegistry;
+    OperatorsRegistryV1WithLegacyInit internal operatorsRegistry;
     address internal admin;
     address internal river;
     address internal keeper;
@@ -809,7 +811,7 @@ contract OperatorsRegistryV1Tests is OperatorsRegistryV1TestBase, OperatorAlloca
 /// @notice Tests that verify the protocol returns the correct keys for the correct operators
 /// @notice when given explicit allocation instructions
 contract OperatorsRegistryV1AllocationCorrectnessTests is OperatorAllocationTestBase {
-    OperatorsRegistryV1 internal operatorsRegistry;
+    OperatorsRegistryV1WithLegacyInit internal operatorsRegistry;
     address internal admin;
     address internal river;
 
@@ -864,7 +866,7 @@ contract OperatorsRegistryV1AllocationCorrectnessTests is OperatorAllocationTest
 ///         requestedExits across sequential calls, partial fulfillment, stopped validator
 ///         interactions, and combined deposit+exit flows.
 contract OperatorsRegistryV1ExitCorrectnessTests is OperatorAllocationTestBase {
-    OperatorsRegistryV1 internal operatorsRegistry;
+    OperatorsRegistryV1WithLegacyInit internal operatorsRegistry;
     address internal admin;
     address internal river;
     address internal keeper;
@@ -1582,7 +1584,7 @@ contract OperatorsRegistryV1ExitCorrectnessTests is OperatorAllocationTestBase {
 /// @notice Tests that exercise _flattenByteArrays and allocation validation logic
 ///         via the public view function getNextValidatorsToDepositFromActiveOperators.
 contract OperatorsRegistryV1FlattenAndAllocationTests is OperatorAllocationTestBase {
-    OperatorsRegistryV1 internal operatorsRegistry;
+    OperatorsRegistryV1WithLegacyInit internal operatorsRegistry;
     address internal admin;
     address internal river;
 
@@ -2343,7 +2345,7 @@ contract RejectingRefundRecipient {
 contract OperatorsRegistryV1ELExitTests is Test {
     OperatorsRegistryWithMigrationHelpers internal reg;
     MockWithdrawForELExits internal mockWithdraw;
-    WithdrawV1 internal withdrawContract;
+    WithdrawV1WithLegacyInit internal withdrawContract;
     address internal pectraWithdrawal;
     address internal admin;
     address internal keeper;
@@ -2387,7 +2389,7 @@ contract OperatorsRegistryV1ELExitTests is Test {
         mockELWithdrawal.setFee(fee);
         pectraWithdrawal = address(mockELWithdrawal);
 
-        withdrawContract = new WithdrawV1();
+        withdrawContract = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(withdrawContract));
         withdrawContract.initializeWithdrawV1(river);
         withdrawContract.initWithdrawV1_1(

--- a/contracts/test/Oracle.1.t.sol
+++ b/contracts/test/Oracle.1.t.sol
@@ -11,8 +11,10 @@ import "./mocks/RiverMock.sol";
 import "../src/Oracle.1.sol";
 import "../src/interfaces/IRiver.1.sol";
 
+import "./utils/LegacyInit.sol";
+
 abstract contract OracleV1TestBase is Test {
-    OracleV1 internal oracle;
+    OracleV1WithLegacyInit internal oracle;
 
     IRiverV1 internal oracleInput;
     UserFactory internal uf = new UserFactory();
@@ -40,7 +42,7 @@ abstract contract OracleV1TestBase is Test {
 
     function setUp() public virtual {
         oracleInput = IRiverV1(payable(address(new RiverMock())));
-        oracle = new OracleV1();
+        oracle = new OracleV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(oracle));
     }
 }

--- a/contracts/test/ProtocolMetrics.t.sol
+++ b/contracts/test/ProtocolMetrics.t.sol
@@ -6,15 +6,15 @@ import "forge-std/Test.sol";
 import {RiverMock} from "./RedeemManager.1.t.sol";
 import "./utils/LibImplementationUnbricker.sol";
 
-import {ProtocolMetricsV1} from "./../src/ProtocolMetrics.1.sol";
+import {ProtocolMetricsV1WithLegacyInit} from "./utils/LegacyInit.sol";
 
 contract ProtocolMetricsTest is Test {
     RiverMock river;
-    ProtocolMetricsV1 protocolMetrics;
+    ProtocolMetricsV1WithLegacyInit protocolMetrics;
 
     function setUp() external {
         river = new RiverMock(address(0x00));
-        protocolMetrics = new ProtocolMetricsV1();
+        protocolMetrics = new ProtocolMetricsV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(protocolMetrics));
 
         protocolMetrics.initProtocolMetricsV1(address(river));

--- a/contracts/test/RedeemManager.1.t.sol
+++ b/contracts/test/RedeemManager.1.t.sol
@@ -20,6 +20,8 @@ import "../src/Allowlist.1.sol";
 import "./mocks/RejectEtherMock.sol";
 import "./mocks/ReentrancyClaimAttackMock.sol";
 
+import "./utils/LegacyInit.sol";
+
 contract RiverMock {
     mapping(address => uint256) internal balances;
     mapping(address => mapping(address => uint256)) internal approvals;
@@ -125,7 +127,7 @@ contract RiverMock {
 }
 
 contract RedeeManagerV1TestBase is Test {
-    AllowlistV1 internal allowlist;
+    AllowlistV1WithLegacyInit internal allowlist;
     RiverMock internal river;
     UserFactory internal uf = new UserFactory();
     address internal allowlistAdmin;
@@ -158,15 +160,15 @@ contract RedeeManagerV1TestBase is Test {
 }
 
 contract RedeemManagerV1Tests is RedeeManagerV1TestBase {
-    RedeemManagerV1 internal redeemManager;
+    RedeemManagerV1WithLegacyInit internal redeemManager;
 
     function setUp() external {
         allowlistAdmin = makeAddr("allowlistAdmin");
         allowlistAllower = makeAddr("allowlistAllower");
         allowlistDenier = makeAddr("allowlistDenier");
-        redeemManager = new RedeemManagerV1();
+        redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(allowlistAdmin, allowlistAllower);
         allowlist.initAllowlistV1_1(allowlistDenier);
@@ -2189,8 +2191,11 @@ contract RedeemManagerV1Tests is RedeeManagerV1TestBase {
     /// @dev Deploys a fresh, independent RiverMock + RedeemManagerV1 pair sharing this test's
     ///      allowlist, so a scenario can be replayed from a clean slate without disturbing the
     ///      contract-level `redeemManager`/`river` used by every other test.
-    function _deployFreshManager() internal returns (RiverMock riverInstance, RedeemManagerV1 managerInstance) {
-        managerInstance = new RedeemManagerV1();
+    function _deployFreshManager()
+        internal
+        returns (RiverMock riverInstance, RedeemManagerV1WithLegacyInit managerInstance)
+    {
+        managerInstance = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(managerInstance));
         riverInstance = new RiverMock(address(allowlist));
         managerInstance.initializeRedeemManagerV1(address(riverInstance));
@@ -3614,7 +3619,7 @@ contract InitializeRedeemManagerV1_2Test is RedeeManagerV1TestBase {
         allowlistAdmin = makeAddr("allowlistAdmin");
         allowlistAllower = makeAddr("allowlistAllower");
         allowlistDenier = makeAddr("allowlistDenier");
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(allowlistAdmin, allowlistAllower);
         allowlist.initAllowlistV1_1(allowlistDenier);
@@ -3642,19 +3647,19 @@ contract InitializeRedeemManagerV1_2Test is RedeeManagerV1TestBase {
     }
 
     function testInitializeTwice() public {
-        RedeemManagerV1 redeemQueueImplV2 = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit redeemQueueImplV2 = new RedeemManagerV1WithLegacyInit();
         vm.store(redeemManager, IMPLEMENTATION_SLOT, bytes32(uint256(uint160(address(redeemQueueImplV2)))));
-        RedeemManagerV1(redeemManager).initializeRedeemManagerV1_2();
+        RedeemManagerV1WithLegacyInit(redeemManager).initializeRedeemManagerV1_2();
 
         vm.expectRevert(abi.encodeWithSignature("InvalidInitialization(uint256,uint256)", 1, 2));
-        RedeemManagerV1(redeemManager).initializeRedeemManagerV1_2();
+        RedeemManagerV1WithLegacyInit(redeemManager).initializeRedeemManagerV1_2();
     }
 
     function testRedeemQueueMigrationV1_2() public {
         // Call the migration function
-        RedeemManagerV1 redeemQueueImplV2 = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit redeemQueueImplV2 = new RedeemManagerV1WithLegacyInit();
         vm.store(redeemManager, IMPLEMENTATION_SLOT, bytes32(uint256(uint160(address(redeemQueueImplV2)))));
-        RedeemManagerV1(redeemManager).initializeRedeemManagerV1_2();
+        RedeemManagerV1WithLegacyInit(redeemManager).initializeRedeemManagerV1_2();
 
         // Check all existing redeemRequests are intact after the migration (from oldQueue)
         for (uint256 i = 0; i < 30; i++) {
@@ -3678,9 +3683,9 @@ contract InitializeRedeemManagerV1_2Test is RedeeManagerV1TestBase {
 
     function testRedeemQueueV1_2PostMigrationWithNewRequests() public {
         // Call the migration function
-        RedeemManagerV1 redeemQueueImplV2 = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit redeemQueueImplV2 = new RedeemManagerV1WithLegacyInit();
         vm.store(redeemManager, IMPLEMENTATION_SLOT, bytes32(uint256(uint160(address(redeemQueueImplV2)))));
-        RedeemManagerV1(redeemManager).initializeRedeemManagerV1_2();
+        RedeemManagerV1WithLegacyInit(redeemManager).initializeRedeemManagerV1_2();
 
         // Add new 30 random redeem requests after upgrade / migration. Note: 30 is just a random number
         for (uint256 i = 30; i < 60; i++) {

--- a/contracts/test/RedeemManager.2.t.sol
+++ b/contracts/test/RedeemManager.2.t.sol
@@ -8,12 +8,14 @@ import "../src/Allowlist.1.sol";
 
 import "./utils/LibImplementationUnbricker.sol";
 
+import "./utils/LegacyInit.sol";
+
 interface IRedeemManagerV1Mock {
     /// @notice Thrown when a transfer error occured with LsETH
     error TransferError();
 }
 
-contract RedeemManagerV1Mock is RedeemManagerV1 {
+contract RedeemManagerV1Mock is RedeemManagerV1WithLegacyInit {
     // The error we are testing for
     function redeem(uint256 _lsETHAmount) external onlyRiver {
         if (!_castedRiver().transferFrom(msg.sender, address(this), _lsETHAmount)) {
@@ -115,7 +117,7 @@ contract RiverMock is MockERC20 {
 
 contract RedeemManagerTest is Test {
     RedeemManagerV1Mock internal redeemManager;
-    AllowlistV1 internal allowlist;
+    AllowlistV1WithLegacyInit internal allowlist;
     RiverMock internal river;
     address internal allowlistAdmin;
     address internal allowlistAllower;
@@ -128,7 +130,7 @@ contract RedeemManagerTest is Test {
         allowlistDenier = makeAddr("allowlistDenier");
         redeemManager = new RedeemManagerV1Mock();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         allowlist.initAllowlistV1(allowlistAdmin, allowlistAllower);
         allowlist.initAllowlistV1_1(allowlistDenier);

--- a/contracts/test/River.1.t.sol
+++ b/contracts/test/River.1.t.sol
@@ -32,6 +32,8 @@ import "../src/ConsolidationCoverageFund.1.sol";
 import "../src/ExternalConsolidationRecipientMapping.1.sol";
 import "../src/RedeemManager.1.sol";
 
+import "./utils/LegacyInit.sol";
+
 contract MockDepositDataBuffer is IDepositDataBuffer {
     mapping(bytes32 => DepositObject) internal _batches;
     mapping(bytes32 => bool) internal _exists;
@@ -63,7 +65,7 @@ contract MockDepositDataBuffer is IDepositDataBuffer {
     }
 }
 
-contract OperatorsRegistryWithOverridesV1 is OperatorsRegistryV1 {
+contract OperatorsRegistryWithOverridesV1 is OperatorsRegistryV1WithLegacyInit {
     function sudoReportExitedETH(uint256[] calldata exitedETH) external {
         _setExitedETH(exitedETH);
     }
@@ -112,13 +114,13 @@ abstract contract RiverV1TestBase is OperatorAllocationTestBase, BytesGenerator 
 
     RiverV1ForceCommittable internal river;
     IDepositContract internal deposit;
-    WithdrawV1 internal withdraw;
-    OracleV1 internal oracle;
-    ELFeeRecipientV1 internal elFeeRecipient;
-    CoverageFundV1 internal coverageFund;
+    WithdrawV1WithLegacyInit internal withdraw;
+    OracleV1WithLegacyInit internal oracle;
+    ELFeeRecipientV1WithLegacyInit internal elFeeRecipient;
+    CoverageFundV1WithLegacyInit internal coverageFund;
     ConsolidationCoverageFundV1 internal consolidationCoverageFund;
     ExternalConsolidationRecipientMappingV1 internal externalConsolidationRecipientMapping;
-    AllowlistV1 internal allowlist;
+    AllowlistV1WithLegacyInit internal allowlist;
     OperatorsRegistryWithOverridesV1 internal operatorsRegistry;
 
     MockDepositDataBuffer internal depositBuffer;
@@ -231,21 +233,21 @@ abstract contract RiverV1TestBase is OperatorAllocationTestBase, BytesGenerator 
 
         vm.warp(857034746);
 
-        elFeeRecipient = new ELFeeRecipientV1();
+        elFeeRecipient = new ELFeeRecipientV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(elFeeRecipient));
-        coverageFund = new CoverageFundV1();
+        coverageFund = new CoverageFundV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(coverageFund));
         consolidationCoverageFund = new ConsolidationCoverageFundV1();
         LibImplementationUnbricker.unbrick(vm, address(consolidationCoverageFund));
         externalConsolidationRecipientMapping = new ExternalConsolidationRecipientMappingV1();
         LibImplementationUnbricker.unbrick(vm, address(externalConsolidationRecipientMapping));
-        oracle = new OracleV1();
+        oracle = new OracleV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(oracle));
-        allowlist = new AllowlistV1();
+        allowlist = new AllowlistV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(allowlist));
         deposit = new DepositContractMock();
         LibImplementationUnbricker.unbrick(vm, address(deposit));
-        withdraw = new WithdrawV1();
+        withdraw = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(withdraw));
         river = new RiverV1ForceCommittable();
         LibImplementationUnbricker.unbrick(vm, address(river));
@@ -619,8 +621,8 @@ contract RiverV1Tests is RiverV1TestBase {
 
     function testInit2(uint128 depositTotal, uint96 committedBalance) public {
         vm.assume(depositTotal > committedBalance && committedBalance > 0);
-        RedeemManagerV1 redeemManager;
-        redeemManager = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit redeemManager;
+        redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
         redeemManager.initializeRedeemManagerV1(address(river));
 
@@ -1378,7 +1380,7 @@ contract RiverV1Tests is RiverV1TestBase {
     }
 
     function testRequestRedeemAllowedWhenSlashingModeOff() public {
-        RedeemManagerV1 redeemManager = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
         redeemManager.initializeRedeemManagerV1(address(river));
         river.initRiverV1_1(
@@ -1406,7 +1408,7 @@ contract RiverV1Tests is RiverV1TestBase {
     }
 
     function testClaimRedeemRequestsAllowedWhenSlashingModeOff() public {
-        RedeemManagerV1 redeemManager = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
         redeemManager.initializeRedeemManagerV1(address(river));
         river.initRiverV1_1(
@@ -1430,7 +1432,7 @@ contract RiverV1Tests is RiverV1TestBase {
     }
 
     function testClaimRedeemRequestsAllowedInSlashingContainmentMode() public {
-        RedeemManagerV1 redeemManager = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
         redeemManager.initializeRedeemManagerV1(address(river));
         river.initRiverV1_1(
@@ -1533,12 +1535,12 @@ contract RiverV1Tests is RiverV1TestBase {
 }
 
 contract RiverV1TestsReport_HEAVY_FUZZING is RiverV1TestBase {
-    RedeemManagerV1 redeemManager;
+    RedeemManagerV1WithLegacyInit redeemManager;
 
     function setUp() public override {
         super.setUp();
         bytes32 withdrawalCredentials = withdraw.getCredentials();
-        redeemManager = new RedeemManagerV1();
+        redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
         redeemManager.initializeRedeemManagerV1(address(river));
         vm.expectEmit(true, true, true, true);
@@ -2985,7 +2987,7 @@ contract RiverV1TestsReport_HEAVY_FUZZING is RiverV1TestBase {
 // ─────────────────────────────────────────────────────────────────────────────
 
 contract RiverV1CoverageTests is RiverV1TestBase {
-    RedeemManagerV1 internal redeemManager;
+    RedeemManagerV1WithLegacyInit internal redeemManager;
 
     bytes32 constant DEPOSITED_VALIDATOR_COUNT_SLOT =
         bytes32(uint256(keccak256("river.state.depositedValidatorCount")) - 1);
@@ -4733,7 +4735,7 @@ contract RiverV1CoverageTests is RiverV1TestBase {
 
     function _initRiverAndV1_2() internal {
         super.setUp();
-        redeemManager = new RedeemManagerV1();
+        redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
         bytes32 wc = withdraw.getCredentials();
         river.initRiverV1(
@@ -4771,7 +4773,7 @@ contract RiverV1CoverageTests is RiverV1TestBase {
 
     function _initRiverMinimalForReporting() internal {
         super.setUp();
-        redeemManager = new RedeemManagerV1();
+        redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
         bytes32 wc = withdraw.getCredentials();
         river.initRiverV1(
@@ -5098,12 +5100,12 @@ contract RiverV1PectraTests is RiverV1TestBase {
 }
 
 contract RiverV1ConsolidationMintTests is RiverV1TestBase {
-    RedeemManagerV1 redeemManager;
+    RedeemManagerV1WithLegacyInit redeemManager;
 
     function setUp() public override {
         super.setUp();
         bytes32 withdrawalCredentials = withdraw.getCredentials();
-        redeemManager = new RedeemManagerV1();
+        redeemManager = new RedeemManagerV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(redeemManager));
         redeemManager.initializeRedeemManagerV1(address(river));
         vm.expectEmit(true, true, true, true);

--- a/contracts/test/TLC.1.t.sol
+++ b/contracts/test/TLC.1.t.sol
@@ -3,12 +3,13 @@
 pragma solidity 0.8.34;
 
 import "../src/TLC.1.sol";
+import "./utils/TLCV1WithLegacyInit.sol";
 import "../src/TUPProxy.sol";
 import "forge-std/Test.sol";
 
 abstract contract TLCTestBase is Test {
-    TLCV1 internal tlcImplem;
-    TLCV1 internal tlc;
+    TLCV1WithLegacyInit internal tlcImplem;
+    TLCV1WithLegacyInit internal tlc;
 
     address internal escrowImplem;
     address internal initAccount;
@@ -24,11 +25,11 @@ contract TLCInitializationTest is TLCTestBase {
         joe = makeAddr("joe");
         admin = makeAddr("admin");
 
-        tlcImplem = new TLCV1();
+        tlcImplem = new TLCV1WithLegacyInit();
     }
 
     function testInitialization() external {
-        tlc = TLCV1(
+        tlc = TLCV1WithLegacyInit(
             address(
                 new TUPProxy(
                     address(tlcImplem), admin, abi.encodeWithSelector(tlcImplem.initTLCV1.selector, initAccount)
@@ -47,8 +48,8 @@ contract TLCTests is TLCTestBase {
         joe = makeAddr("joe");
         admin = makeAddr("admin");
 
-        tlcImplem = new TLCV1();
-        tlc = TLCV1(
+        tlcImplem = new TLCV1WithLegacyInit();
+        tlc = TLCV1WithLegacyInit(
             address(
                 new TUPProxy(
                     address(tlcImplem), admin, abi.encodeWithSelector(tlcImplem.initTLCV1.selector, initAccount)

--- a/contracts/test/Withdraw.1.t.sol
+++ b/contracts/test/Withdraw.1.t.sol
@@ -12,6 +12,8 @@ import "../src/OperatorsRegistry.1.sol";
 import "../src/libraries/LibErrors.sol";
 import "../src/AttestationVerifier.1.sol";
 
+import "./utils/LegacyInit.sol";
+
 contract RiverMock {
     event DebugReceivedCLFunds(uint256 amount);
 
@@ -141,10 +143,10 @@ contract MockELShortReturn {
 }
 
 abstract contract WithdrawV1TestBase is Test {
-    WithdrawV1 internal withdraw;
+    WithdrawV1WithLegacyInit internal withdraw;
     RiverMock internal river;
     UserFactory internal uf = new UserFactory();
-    OperatorsRegistryV1 internal operatorsRegistry;
+    OperatorsRegistryV1WithLegacyInit internal operatorsRegistry;
     AttestationVerifierV1 internal attestationVerifier;
 
     event DebugReceivedCLFunds(uint256 amount);
@@ -156,9 +158,9 @@ abstract contract WithdrawV1TestBase is Test {
 
     function setUp() public virtual {
         river = new RiverMock();
-        operatorsRegistry = new OperatorsRegistryV1();
+        operatorsRegistry = new OperatorsRegistryV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(operatorsRegistry));
-        withdraw = new WithdrawV1();
+        withdraw = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(withdraw));
         attestationVerifier = new AttestationVerifierV1();
         LibImplementationUnbricker.unbrick(vm, address(attestationVerifier));
@@ -343,7 +345,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
     }
 
     function testInitWithdrawV1_1SetsAddresses() external {
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         assertEq(w.getRiver(), address(river));
@@ -741,7 +743,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
 
     function testWithdrawRequestFailedReverts() external {
         MockELWithdrawalFails mockFail = new MockELWithdrawalFails();
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         w.initWithdrawV1_1(
@@ -763,7 +765,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
     /// @notice Tests that consolidate reverts when fee read (staticcall) fails.
     function testConsolidateFailsIfNoValueSent() public {
         MockELConsolidationFeeReadFails mockConsolidationFeeReadFails = new MockELConsolidationFeeReadFails();
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         w.initWithdrawV1_1(
@@ -908,7 +910,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
         uint256 maxFeePerConsolidation = 0.1 ether;
         mockConsolidationFails.setFee(maxFeePerConsolidation);
 
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         w.initWithdrawV1_1(
@@ -1021,7 +1023,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
     /// @notice Tests that withdraw reverts when the fee read fails.
     function testWithdrawFailsIfFeeReadFails() public {
         MockELWithdrawalFeeReadFails mockWithdrawalFeeReadFails = new MockELWithdrawalFeeReadFails();
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         w.initWithdrawV1_1(
@@ -1064,7 +1066,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
     /// @notice Tests that withdraw reverts when the request fails.
     function testWithdrawFailsIfRequestFails() public {
         MockELWithdrawalFails mockWithdrawalFails = new MockELWithdrawalFails();
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         w.initWithdrawV1_1(
@@ -1305,7 +1307,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
     /// @notice withdraw reverts when the withdrawal predeploy returns fewer than 32 bytes for the fee.
     function testWithdrawRevertsOnShortFeeReturndata() public {
         MockELShortReturn shortMock = new MockELShortReturn(2); // 2 bytes of returndata
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         w.initWithdrawV1_1(
@@ -1329,7 +1331,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
     /// @notice consolidate reverts when the consolidation predeploy returns fewer than 32 bytes for the fee.
     function testConsolidateRevertsOnShortFeeReturndata() public {
         MockELShortReturn shortMock = new MockELShortReturn(31); // 31 bytes: one short of a full word
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         w.initWithdrawV1_1(
@@ -1352,7 +1354,7 @@ contract WithdrawV1PectraTests is WithdrawV1TestBase {
     /// @notice An empty fee return (0 bytes) also reverts: there is no 32-byte word to decode.
     function testWithdrawRevertsOnEmptyFeeReturndata() public {
         MockELShortReturn shortMock = new MockELShortReturn(0); // empty returndata
-        WithdrawV1 w = new WithdrawV1();
+        WithdrawV1WithLegacyInit w = new WithdrawV1WithLegacyInit();
         LibImplementationUnbricker.unbrick(vm, address(w));
         w.initializeWithdrawV1(address(river));
         w.initWithdrawV1_1(

--- a/contracts/test/accounting/AccountingHarnessBase.sol
+++ b/contracts/test/accounting/AccountingHarnessBase.sol
@@ -29,6 +29,8 @@ import "../../src/state/river/CommittedBalance.sol";
 import "../../src/state/river/BalanceToDeposit.sol";
 import "../../src/state/operatorsRegistry/Operators.3.sol";
 
+import "../utils/LegacyInit.sol";
+
 // -----------------------------------------------------------------------
 // Mock DepositDataBuffer — stores batches by ID for accounting harness deposits
 // -----------------------------------------------------------------------
@@ -65,7 +67,7 @@ contract AccountingMockDepositDataBuffer is IDepositDataBuffer {
 }
 
 /// @dev Test-only OperatorsRegistry subclass exposing raw exited ETH initialization.
-contract AccountingTestOperatorsRegistry is OperatorsRegistryV1 {
+contract AccountingTestOperatorsRegistry is OperatorsRegistryV1WithLegacyInit {
     function sudoSetRawExitedETH(uint256[] memory value) external {
         OperatorsV3.setRawExitedETH(value);
     }
@@ -95,13 +97,13 @@ abstract contract AccountingHarnessBase is Test, BytesGenerator {
 
     // ─── contracts ────────────────────────────────────────────────────────────
     AccountingRiverV1 internal river;
-    OracleV1 internal oracle;
+    OracleV1WithLegacyInit internal oracle;
     AccountingTestOperatorsRegistry internal operatorsRegistry;
-    AllowlistV1 internal allowlist;
-    ELFeeRecipientV1 internal elFeeRecipient;
-    CoverageFundV1 internal coverageFund;
-    RedeemManagerV1 internal redeemManager;
-    WithdrawV1 internal withdraw;
+    AllowlistV1WithLegacyInit internal allowlist;
+    ELFeeRecipientV1WithLegacyInit internal elFeeRecipient;
+    CoverageFundV1WithLegacyInit internal coverageFund;
+    RedeemManagerV1WithLegacyInit internal redeemManager;
+    WithdrawV1WithLegacyInit internal withdraw;
     IDepositContract internal depositContract;
     AccountingMockDepositDataBuffer internal depositBuffer;
     AttestationVerifierV1 internal attestationVerifier;
@@ -164,12 +166,12 @@ abstract contract AccountingHarnessBase is Test, BytesGenerator {
 
         depositContract = new DepositContractMock();
         depositBuffer = new AccountingMockDepositDataBuffer();
-        withdraw = new WithdrawV1();
-        oracle = new OracleV1();
-        allowlist = new AllowlistV1();
-        redeemManager = new RedeemManagerV1();
-        elFeeRecipient = new ELFeeRecipientV1();
-        coverageFund = new CoverageFundV1();
+        withdraw = new WithdrawV1WithLegacyInit();
+        oracle = new OracleV1WithLegacyInit();
+        allowlist = new AllowlistV1WithLegacyInit();
+        redeemManager = new RedeemManagerV1WithLegacyInit();
+        elFeeRecipient = new ELFeeRecipientV1WithLegacyInit();
+        coverageFund = new CoverageFundV1WithLegacyInit();
         externalConsolidationRecipientMapping = new ExternalConsolidationRecipientMappingV1();
         river = new AccountingRiverV1();
         operatorsRegistry = new AccountingTestOperatorsRegistry();

--- a/contracts/test/accounting/scenarios/Migration.t.sol
+++ b/contracts/test/accounting/scenarios/Migration.t.sol
@@ -8,8 +8,10 @@ import "../../../src/state/operatorsRegistry/Operators.2.sol";
 import "../../../src/state/operatorsRegistry/Operators.3.sol";
 import "../../utils/LibImplementationUnbricker.sol";
 
+import "../../utils/LegacyInit.sol";
+
 /// @dev Subclass of OperatorsRegistryV1 that exposes internal V2 storage writes for migration testing.
-contract MigrationOperatorsRegistry is OperatorsRegistryV1 {
+contract MigrationOperatorsRegistry is OperatorsRegistryV1WithLegacyInit {
     /// @dev Push a V2 operator directly into OperatorsV2 storage.
     function sudoPushV2Operator(
         string calldata _name,

--- a/contracts/test/components/OracleManager.1.t.sol
+++ b/contracts/test/components/OracleManager.1.t.sol
@@ -78,8 +78,8 @@ contract OracleManagerV1ExposeInitializer is OracleManagerV1 {
         uint256 relativeLowerBound
     ) {
         AdministratorAddress.set(admin);
-        initOracleManagerV1(oracle);
-        initOracleManagerV1_1(
+        _initOracleManagerV1(oracle);
+        _initOracleManagerV1_1(
             epochsPerFrame,
             slotsPerEpoch,
             secondsPerSlot,
@@ -88,6 +88,44 @@ contract OracleManagerV1ExposeInitializer is OracleManagerV1 {
             annualAprUpperBound,
             relativeLowerBound
         );
+    }
+
+    /// @dev Copied from contracts/src/components/OracleManager.1.sol, where `initOracleManagerV1` was
+    ///      only reachable through the removed `initRiverV1`. Duplicated rather than shared through a
+    ///      mixin because RiverV1's `_getRiverAdmin` override is not `virtual`, so the River-side
+    ///      harness cannot linearize a second OracleManagerV1 base. The other copy lives in
+    ///      contracts/test/utils/RiverV1WithLegacyInit.sol.
+    function _initOracleManagerV1(address _oracle) internal {
+        OracleAddress.set(_oracle);
+        emit SetOracle(_oracle);
+    }
+
+    /// @dev Copied from contracts/src/components/OracleManager.1.sol — see `_initOracleManagerV1`.
+    function _initOracleManagerV1_1(
+        uint64 _epochsPerFrame,
+        uint64 _slotsPerEpoch,
+        uint64 _secondsPerSlot,
+        uint64 _genesisTime,
+        uint64 _epochsToAssumedFinality,
+        uint256 _annualAprUpperBound,
+        uint256 _relativeLowerBound
+    ) internal {
+        CLSpec.set(
+            CLSpec.CLSpecStruct({
+                epochsPerFrame: _epochsPerFrame,
+                slotsPerEpoch: _slotsPerEpoch,
+                secondsPerSlot: _secondsPerSlot,
+                genesisTime: _genesisTime,
+                epochsToAssumedFinality: _epochsToAssumedFinality
+            })
+        );
+        emit SetSpec(_epochsPerFrame, _slotsPerEpoch, _secondsPerSlot, _genesisTime, _epochsToAssumedFinality);
+        ReportBounds.set(
+            ReportBounds.ReportBoundsStruct({
+                annualAprUpperBound: _annualAprUpperBound, relativeLowerBound: _relativeLowerBound
+            })
+        );
+        emit SetBounds(_annualAprUpperBound, _relativeLowerBound);
     }
 }
 

--- a/contracts/test/fork/holesky/1.redeemQueueMigrationV1_2_1.t.sol
+++ b/contracts/test/fork/holesky/1.redeemQueueMigrationV1_2_1.t.sol
@@ -13,6 +13,8 @@ import {
     ITransparentUpgradeableProxy
 } from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
+import "../../utils/LegacyInit.sol";
+
 interface MockIRedeemManagerV1 {
     function getRedeemRequestDetails(uint32 _redeemRequestId) external view returns (RedeemQueueV1.RedeemRequest memory);
 
@@ -58,11 +60,12 @@ contract RedeemQueueMigrationV1_2 is Test {
         // Set up the fork at a new block for making the v1_2_1 upgrade, and testing
         vm.createSelectFork(_rpcUrl, 2440762);
         // Upgrade the RedeemManager
-        RedeemManagerV1 newImplementation = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit newImplementation = new RedeemManagerV1WithLegacyInit();
         vm.prank(REDEEM_MANAGER_STAGING_PROXY_ADMIN_ADDRESS);
         ITransparentUpgradeableProxy(address(redeemManagerProxy))
             .upgradeToAndCall(
-                address(newImplementation), abi.encodeWithSelector(RedeemManagerV1.initializeRedeemManagerV1_2.selector)
+                address(newImplementation),
+                abi.encodeWithSelector(RedeemManagerV1WithLegacyInit.initializeRedeemManagerV1_2.selector)
             );
 
         // After upgrade: check that state before the upgrade, and state after upgrade are same.

--- a/contracts/test/fork/mainnet/1.vestingSchedulesMigrationV1toV2.t.sol
+++ b/contracts/test/fork/mainnet/1.vestingSchedulesMigrationV1toV2.t.sol
@@ -11,6 +11,8 @@ import {
     ITransparentUpgradeableProxy
 } from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
+import "../../utils/TLCV1WithLegacyInit.sol";
+
 contract VestingSchedulesMigrationV1ToV2 is Test {
     bool internal _skip = false;
 
@@ -35,12 +37,12 @@ contract VestingSchedulesMigrationV1ToV2 is Test {
     function test_migration() external shouldSkip {
         TUPProxy tlcProxy = TUPProxy(payable(TLC_MAINNET_ADDRESS));
 
-        TLCV1 newImplementation = new TLCV1();
+        TLCV1WithLegacyInit newImplementation = new TLCV1WithLegacyInit();
 
         vm.prank(TLC_MAINNET_PROXY_ADMIN_ADDRESS);
         ITransparentUpgradeableProxy(address(tlcProxy))
             .upgradeToAndCall(
-                address(newImplementation), abi.encodeWithSelector(TLCV1.migrateVestingSchedules.selector)
+                address(newImplementation), abi.encodeWithSelector(TLCV1WithLegacyInit.migrateVestingSchedules.selector)
             );
 
         TLCV1 tlc = TLCV1(TLC_MAINNET_ADDRESS);

--- a/contracts/test/fork/mainnet/2.operatorsMigrationV1toV2.t.sol
+++ b/contracts/test/fork/mainnet/2.operatorsMigrationV1toV2.t.sol
@@ -11,12 +11,14 @@ import {
     ITransparentUpgradeableProxy
 } from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
+import "../../utils/LegacyInit.sol";
+
 /// @notice Test-only subclass exposing V2-format read accessors. After initOperatorsRegistryV1_1
 /// @notice (V1 -> V2) the operators live in OperatorsV2 storage, but the production OperatorsRegistryV1
 /// @notice is V3-native: its getOperator decodes storage as V3 and the V2 stopped-validator getters were
 /// @notice removed. These views let this fork test observe the intermediate V2 state produced by the
 /// @notice V1 -> V2 migration in isolation, before the V2 -> V3 step runs.
-contract OperatorsRegistryV1WithV2Views is OperatorsRegistryV1 {
+contract OperatorsRegistryV1WithV2Views is OperatorsRegistryV1WithLegacyInit {
     function getOperatorV2(uint256 _index) external view returns (OperatorsV2.Operator memory) {
         return OperatorsV2.get(_index);
     }
@@ -69,7 +71,8 @@ contract OperatorsMigrationV1ToV2 is Test {
         vm.prank(OPERATORS_REGISTRY_MAINNET_PROXY_ADMIN_ADDRESS);
         ITransparentUpgradeableProxy(address(orProxy))
             .upgradeToAndCall(
-                address(newImplementation), abi.encodeCall(OperatorsRegistryV1.initOperatorsRegistryV1_1, ())
+                address(newImplementation),
+                abi.encodeCall(OperatorsRegistryV1WithLegacyInit.initOperatorsRegistryV1_1, ())
             );
 
         OperatorsRegistryV1WithV2Views or = OperatorsRegistryV1WithV2Views(OPERATORS_REGISTRY_MAINNET_ADDRESS);

--- a/contracts/test/fork/mainnet/2.operatorsMigrationV1toV3.t.sol
+++ b/contracts/test/fork/mainnet/2.operatorsMigrationV1toV3.t.sol
@@ -10,6 +10,8 @@ import {
     ITransparentUpgradeableProxy
 } from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
+import "../../utils/LegacyInit.sol";
+
 /// @notice Drives the full V1 → V2 → V3 operator migration against a pre-V1_1 mainnet fork using the
 /// @notice production initializers: initOperatorsRegistryV1_1 (V1 → V2) then initOperatorsRegistryV1_2
 /// @notice (V2 → V3). Both initializers ship on the mainnet OperatorsRegistryV1 implementation.
@@ -38,13 +40,14 @@ contract OperatorsMigrationV1ToV3 is Test {
     function test_migration() external shouldSkip {
         TUPProxy orProxy = TUPProxy(payable(OPERATORS_REGISTRY_MAINNET_ADDRESS));
 
-        OperatorsRegistryV1 migrationImplementation = new OperatorsRegistryV1();
+        OperatorsRegistryV1WithLegacyInit migrationImplementation = new OperatorsRegistryV1WithLegacyInit();
 
         // Run V1 → V2 migration (initOperatorsRegistryV1_1 migrates the operator structs from V1 to V2)
         vm.prank(OPERATORS_REGISTRY_MAINNET_PROXY_ADMIN_ADDRESS);
         ITransparentUpgradeableProxy(address(orProxy))
             .upgradeToAndCall(
-                address(migrationImplementation), abi.encodeCall(OperatorsRegistryV1.initOperatorsRegistryV1_1, ())
+                address(migrationImplementation),
+                abi.encodeCall(OperatorsRegistryV1WithLegacyInit.initOperatorsRegistryV1_1, ())
             );
 
         OperatorsRegistryV1 or = OperatorsRegistryV1(OPERATORS_REGISTRY_MAINNET_ADDRESS);

--- a/contracts/test/fork/mainnet/4.redeemQueueMigrationV1_2_1.t.sol
+++ b/contracts/test/fork/mainnet/4.redeemQueueMigrationV1_2_1.t.sol
@@ -13,6 +13,8 @@ import {
     ITransparentUpgradeableProxy
 } from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
+import "../../utils/LegacyInit.sol";
+
 interface MockIRedeemManagerV1 {
     function getRedeemRequestDetails(uint32 _redeemRequestId) external view returns (RedeemQueueV1.RedeemRequest memory);
 
@@ -58,11 +60,12 @@ contract RedeemQueueMigrationV1_2 is Test {
         // Set up the fork at a new block for making the v1_2_1 upgrade, and testing
         vm.createSelectFork(_rpcUrl, 20678000);
         // Upgrade the RedeemManager
-        RedeemManagerV1 newImplementation = new RedeemManagerV1();
+        RedeemManagerV1WithLegacyInit newImplementation = new RedeemManagerV1WithLegacyInit();
         vm.prank(REDEEM_MANAGER_MAINNET_PROXY_ADMIN_ADDRESS);
         ITransparentUpgradeableProxy(address(redeemManagerProxy))
             .upgradeToAndCall(
-                address(newImplementation), abi.encodeWithSelector(RedeemManagerV1.initializeRedeemManagerV1_2.selector)
+                address(newImplementation),
+                abi.encodeWithSelector(RedeemManagerV1WithLegacyInit.initializeRedeemManagerV1_2.selector)
             );
 
         // After upgrade: check that state before the upgrade, and state after upgrade are same.

--- a/contracts/test/redemption/RedemptionReportBase.sol
+++ b/contracts/test/redemption/RedemptionReportBase.sol
@@ -32,6 +32,8 @@ import "../../src/state/redeemManager/RedeemQueue.2.sol";
 import "../../src/state/redeemManager/RedeemRequestAnchor.sol";
 import "../../src/state/redeemManager/WithdrawalStack.sol";
 
+import "../utils/LegacyInit.sol";
+
 /// @dev Concrete `RiverV1WithLegacyInit` so the fixture can `new` it. Production `RiverV1` no longer
 ///      ships `initRiverV1` / `_1` / `_2`, and the fixture bootstraps from genesis. The body is
 ///      deliberately EMPTY: this suite drives the RedeemManager entirely through real oracle reports,
@@ -167,14 +169,14 @@ abstract contract RedemptionReportBase is Test {
 
     // ─── contracts ────────────────────────────────────────────────────────────
     RedemptionRiverV1 internal river;
-    RedeemManagerV1 internal redeemManager;
-    AllowlistV1 internal allowlist;
-    OracleV1 internal oracle;
-    OperatorsRegistryV1 internal operatorsRegistry;
-    ELFeeRecipientV1 internal elFeeRecipient;
-    CoverageFundV1 internal coverageFund;
+    RedeemManagerV1WithLegacyInit internal redeemManager;
+    AllowlistV1WithLegacyInit internal allowlist;
+    OracleV1WithLegacyInit internal oracle;
+    OperatorsRegistryV1WithLegacyInit internal operatorsRegistry;
+    ELFeeRecipientV1WithLegacyInit internal elFeeRecipient;
+    CoverageFundV1WithLegacyInit internal coverageFund;
     ConsolidationCoverageFundV1 internal consolidationCoverageFund;
-    WithdrawV1 internal withdraw;
+    WithdrawV1WithLegacyInit internal withdraw;
     AttestationVerifierV1 internal attestationVerifier;
     ExternalConsolidationRecipientMappingV1 internal externalConsolidationRecipientMapping;
     RedemptionDepositDataBuffer internal depositBuffer;
@@ -255,14 +257,14 @@ abstract contract RedemptionReportBase is Test {
         depositContract = new DepositContractMock();
         depositBuffer = new RedemptionDepositDataBuffer();
         river = new RedemptionRiverV1();
-        redeemManager = new RedeemManagerV1();
-        allowlist = new AllowlistV1();
-        oracle = new OracleV1();
-        operatorsRegistry = new OperatorsRegistryV1();
-        elFeeRecipient = new ELFeeRecipientV1();
-        coverageFund = new CoverageFundV1();
+        redeemManager = new RedeemManagerV1WithLegacyInit();
+        allowlist = new AllowlistV1WithLegacyInit();
+        oracle = new OracleV1WithLegacyInit();
+        operatorsRegistry = new OperatorsRegistryV1WithLegacyInit();
+        elFeeRecipient = new ELFeeRecipientV1WithLegacyInit();
+        coverageFund = new CoverageFundV1WithLegacyInit();
         consolidationCoverageFund = new ConsolidationCoverageFundV1();
-        withdraw = new WithdrawV1();
+        withdraw = new WithdrawV1WithLegacyInit();
         attestationVerifier = new AttestationVerifierV1();
         externalConsolidationRecipientMapping = new ExternalConsolidationRecipientMappingV1();
 

--- a/contracts/test/utils/LegacyInit.sol
+++ b/contracts/test/utils/LegacyInit.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../src/Allowlist.1.sol";
+import "../../src/CoverageFund.1.sol";
+import "../../src/ELFeeRecipient.1.sol";
+import "../../src/OperatorsRegistry.1.sol";
+import "../../src/Oracle.1.sol";
+import "../../src/ProtocolMetrics.1.sol";
+import "../../src/RedeemManager.1.sol";
+import "../../src/Withdraw.1.sol";
+
+// The V1-format state libraries are no longer referenced by contracts/src — the only readers
+// left are the migration bodies restored below.
+import "../../src/state/operatorsRegistry/Operators.1.sol";
+import "../../src/state/redeemManager/RedeemQueue.1.sol";
+
+/// @title LegacyInit (test-only)
+/// @author Alluvial Finance Inc.
+/// @notice Test subclasses that add back the initializers removed from the production contracts.
+/// @dev Every deployed proxy has already advanced past these `init(N)` versions (or, for TLC, past the
+///      OpenZeppelin `_initialized` value), so the production implementations no longer ship them —
+///      they can never be re-run onchain and only cost bytecode. The bodies below are byte-for-byte
+///      copies of what previously lived in contracts/src, kept so tests can still bootstrap fresh
+///      instances from genesis state and so the fork tests can replay the historical migrations.
+///      Keep them in lockstep with the mainnet initialization sequence; do not "improve" them.
+///
+///      This mirrors the pattern already established for River in RiverV1WithLegacyInit.sol.
+
+/// @notice AllowlistV1 with the v1.0 and v1.1 initializers restored.
+contract AllowlistV1WithLegacyInit is AllowlistV1 {
+    function initAllowlistV1(address _admin, address _allower) external init(0) {
+        _setAdmin(_admin);
+        AllowerAddress.set(_allower);
+        emit SetAllower(_allower);
+    }
+
+    function initAllowlistV1_1(address _denier) external init(1) {
+        DenierAddress.set(_denier);
+        emit SetDenier(_denier);
+    }
+}
+
+/// @notice CoverageFundV1 with the v1.0 initializer restored.
+contract CoverageFundV1WithLegacyInit is CoverageFundV1 {
+    function initCoverageFundV1(address _riverAddress) external init(0) {
+        RiverAddress.set(_riverAddress);
+        emit SetRiver(_riverAddress);
+    }
+}
+
+/// @notice ELFeeRecipientV1 with the v1.0 initializer restored.
+contract ELFeeRecipientV1WithLegacyInit is ELFeeRecipientV1 {
+    function initELFeeRecipientV1(address _riverAddress) external init(0) {
+        RiverAddress.set(_riverAddress);
+        emit SetRiver(_riverAddress);
+    }
+}
+
+/// @notice ProtocolMetricsV1 with the v1.0 initializer restored.
+contract ProtocolMetricsV1WithLegacyInit is ProtocolMetricsV1 {
+    function initProtocolMetricsV1(address river) external init(0) {
+        RiverAddress.set(river);
+    }
+}
+
+/// @notice OracleV1 with the v1.0 and v1.1 initializers restored.
+contract OracleV1WithLegacyInit is OracleV1 {
+    function initOracleV1(
+        address _riverAddress,
+        address _administratorAddress,
+        uint64 _epochsPerFrame,
+        uint64 _slotsPerEpoch,
+        uint64 _secondsPerSlot,
+        uint64 _genesisTime,
+        uint256 _annualAprUpperBound,
+        uint256 _relativeLowerBound
+    ) external init(0) {
+        _setAdmin(_administratorAddress);
+        RiverAddress.set(_riverAddress);
+        emit SetRiver(_riverAddress);
+        CLSpec.set(
+            CLSpec.CLSpecStruct({
+                epochsPerFrame: _epochsPerFrame,
+                slotsPerEpoch: _slotsPerEpoch,
+                secondsPerSlot: _secondsPerSlot,
+                genesisTime: _genesisTime,
+                epochsToAssumedFinality: 0
+            })
+        );
+        emit SetSpec(_epochsPerFrame, _slotsPerEpoch, _secondsPerSlot, _genesisTime);
+        ReportBounds.set(
+            ReportBounds.ReportBoundsStruct({
+                annualAprUpperBound: _annualAprUpperBound, relativeLowerBound: _relativeLowerBound
+            })
+        );
+        emit SetBounds(_annualAprUpperBound, _relativeLowerBound);
+        Quorum.set(0);
+        emit SetQuorum(0);
+    }
+
+    function initOracleV1_1() external init(1) {
+        _clearReports();
+    }
+}
+
+/// @notice OperatorsRegistryV1 with the v1.0 and v1.1 initializers restored.
+/// @dev The V1 -> V2 operator migration lives here too: it is only reachable through
+///      `initOperatorsRegistryV1_1`, which mainnet ran long ago.
+contract OperatorsRegistryV1WithLegacyInit is OperatorsRegistryV1 {
+    function initOperatorsRegistryV1(address _admin, address _river) external init(0) {
+        _setAdmin(_admin);
+        RiverAddress.set(_river);
+        emit SetRiver(_river);
+    }
+
+    function initOperatorsRegistryV1_1() external init(1) {
+        _migrateOperators_V1_1();
+    }
+
+    /// @notice Internal utility to migrate the operators from V1 to V2 format
+    function _migrateOperators_V1_1() internal {
+        uint256 opCount = OperatorsV1.getCount();
+
+        for (uint256 idx = 0; idx < opCount; ++idx) {
+            OperatorsV1.Operator memory oldOperatorValue = OperatorsV1.get(idx);
+
+            OperatorsV2.push(
+                OperatorsV2.Operator({
+                    limit: uint32(oldOperatorValue.limit),
+                    funded: uint32(oldOperatorValue.funded),
+                    requestedExits: 0,
+                    keys: uint32(oldOperatorValue.keys),
+                    latestKeysEditBlockNumber: uint64(oldOperatorValue.latestKeysEditBlockNumber),
+                    active: oldOperatorValue.active,
+                    name: oldOperatorValue.name,
+                    operator: oldOperatorValue.operator
+                })
+            );
+        }
+    }
+}
+
+/// @notice RedeemManagerV1 with the v1.0 and v1.2 initializers restored.
+/// @dev The RedeemQueueV1 -> V2 migration lives here too: it is only reachable through
+///      `initializeRedeemManagerV1_2`, which mainnet ran long ago.
+contract RedeemManagerV1WithLegacyInit is RedeemManagerV1 {
+    function initializeRedeemManagerV1(address _river) external init(0) {
+        RiverAddress.set(_river);
+        emit SetRiver(_river);
+    }
+
+    function initializeRedeemManagerV1_2() external init(1) {
+        _redeemQueueMigrationV1_2();
+    }
+
+    function _redeemQueueMigrationV1_2() internal {
+        RedeemQueueV1.RedeemRequest[] memory oldQueue = RedeemQueueV1.get();
+        uint256 oldQueueLen = oldQueue.length;
+        RedeemQueueV2.RedeemRequest[] storage newQueue = RedeemQueueV2.get();
+
+        // Migrate from v1 to v2
+        for (uint256 i = 0; i < oldQueueLen; ++i) {
+            newQueue[i] = RedeemQueueV2.RedeemRequest({
+                amount: oldQueue[i].amount,
+                maxRedeemableEth: oldQueue[i].maxRedeemableEth,
+                recipient: oldQueue[i].recipient,
+                height: oldQueue[i].height,
+                initiator: oldQueue[i].recipient
+            });
+        }
+    }
+}
+
+/// @notice WithdrawV1 with the v1.0 initializer restored.
+contract WithdrawV1WithLegacyInit is WithdrawV1 {
+    function initializeWithdrawV1(address _river) external init(0) {
+        _setRiver(_river);
+    }
+}

--- a/contracts/test/utils/RiverV1WithLegacyInit.sol
+++ b/contracts/test/utils/RiverV1WithLegacyInit.sol
@@ -46,7 +46,7 @@ abstract contract RiverV1WithLegacyInit is RiverV1 {
             _depositContractAddress, _withdrawalCredentials
         );
 
-        OracleManagerV1.initOracleManagerV1(_oracleAddress);
+        initOracleManagerV1(_oracleAddress);
     }
 
     function initRiverV1_1(
@@ -82,6 +82,53 @@ abstract contract RiverV1WithLegacyInit is RiverV1 {
         );
 
         _approve(address(this), _redeemManager, type(uint256).max);
+    }
+
+    /// @notice Set the initial oracle address
+    /// @dev Copied from contracts/src/components/OracleManager.1.sol, where it was only reachable
+    ///      through `initRiverV1`. Duplicated rather than shared through a mixin because RiverV1's
+    ///      `_getRiverAdmin` override is not itself `virtual`, so a second OracleManagerV1 base cannot
+    ///      be linearized here. The other copy lives in contracts/test/components/OracleManager.1.t.sol.
+    /// @param _oracle Address of the oracle
+    function initOracleManagerV1(address _oracle) internal {
+        OracleAddress.set(_oracle);
+        emit SetOracle(_oracle);
+    }
+
+    /// @notice Initializes version 1.1 of the oracle manager
+    /// @dev Copied from contracts/src/components/OracleManager.1.sol — see `initOracleManagerV1` above.
+    /// @param _epochsPerFrame The amounts of epochs in a frame
+    /// @param _slotsPerEpoch The slots inside an epoch
+    /// @param _secondsPerSlot The seconds inside a slot
+    /// @param _genesisTime The genesis timestamp
+    /// @param _epochsToAssumedFinality The number of epochs before an epoch is considered final on-chain
+    /// @param _annualAprUpperBound The reporting upper bound
+    /// @param _relativeLowerBound The reporting lower bound
+    function initOracleManagerV1_1(
+        uint64 _epochsPerFrame,
+        uint64 _slotsPerEpoch,
+        uint64 _secondsPerSlot,
+        uint64 _genesisTime,
+        uint64 _epochsToAssumedFinality,
+        uint256 _annualAprUpperBound,
+        uint256 _relativeLowerBound
+    ) internal {
+        CLSpec.set(
+            CLSpec.CLSpecStruct({
+                epochsPerFrame: _epochsPerFrame,
+                slotsPerEpoch: _slotsPerEpoch,
+                secondsPerSlot: _secondsPerSlot,
+                genesisTime: _genesisTime,
+                epochsToAssumedFinality: _epochsToAssumedFinality
+            })
+        );
+        emit SetSpec(_epochsPerFrame, _slotsPerEpoch, _secondsPerSlot, _genesisTime, _epochsToAssumedFinality);
+        ReportBounds.set(
+            ReportBounds.ReportBoundsStruct({
+                annualAprUpperBound: _annualAprUpperBound, relativeLowerBound: _relativeLowerBound
+            })
+        );
+        emit SetBounds(_annualAprUpperBound, _relativeLowerBound);
     }
 
     function initRiverV1_2() external init(2) {

--- a/contracts/test/utils/TLCV1WithLegacyInit.sol
+++ b/contracts/test/utils/TLCV1WithLegacyInit.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.34;
+
+import "../../src/TLC.1.sol";
+
+/// @title TLCV1WithLegacyInit (test-only)
+/// @author Alluvial Finance Inc.
+/// @notice Test subclass that adds back the v1.0 initializer and the vesting-schedule migration.
+/// @dev The deployed TLC proxy already sits at OpenZeppelin `_initialized == 2`, so neither function
+///      can be re-run onchain; production TLCV1 therefore no longer ships them. The bodies below are
+///      byte-for-byte copies of what previously lived in contracts/src/TLC.1.sol, kept so tests can
+///      still mint a fresh TLC and so the mainnet fork test can replay the V1 -> V2 vesting migration.
+/// @dev Lives in its own file because TLC.1.sol pulls in OpenZeppelin's `Initializable`, which clashes
+///      with the protocol's own `Initializable` imported by the harnesses in LegacyInit.sol.
+contract TLCV1WithLegacyInit is TLCV1 {
+    function initTLCV1(address _account) external initializer {
+        LibSanitize._notZeroAddress(_account);
+        __ERC20Permit_init(NAME);
+        __ERC20_init(NAME, SYMBOL);
+        _mint(_account, INITIAL_SUPPLY);
+    }
+
+    function migrateVestingSchedules() external reinitializer(2) {
+        ERC20VestableVotesUpgradeableV1.migrateVestingSchedulesFromV1ToV2();
+    }
+}


### PR DESCRIPTION
Every deployed proxy has advanced past these init(N) versions (or, for TLC, past OpenZeppelin's _initialized value), so the initializers below can never run again and only cost bytecode:

  AllowlistV1           initAllowlistV1, initAllowlistV1_1
  OperatorsRegistryV1   initOperatorsRegistryV1, initOperatorsRegistryV1_1
                        (+ _migrateOperators_V1_1)
  OracleV1              initOracleV1, initOracleV1_1
  RedeemManagerV1       initializeRedeemManagerV1, initializeRedeemManagerV1_2
                        (+ _redeemQueueMigrationV1_2)
  WithdrawV1            initializeWithdrawV1
  CoverageFundV1        initCoverageFundV1
  ELFeeRecipientV1      initELFeeRecipientV1
  ProtocolMetricsV1     initProtocolMetricsV1
  TLCV1                 initTLCV1, migrateVestingSchedules
  OracleManagerV1       initOracleManagerV1, initOracleManagerV1_1 (internal,
                        only reachable from the already-removed initRiverV1*)

The pending initializers stay: initRiverV1_3, initOperatorsRegistryV1_2, initializeRedeemManagerV1_3, initWithdrawV1_1, and the initializers of the not-yet-deployed AttestationVerifier / ConsolidationCoverageFund / ExternalConsolidationRecipientMapping / WLSETH / BurnMintERC20.

Bodies move verbatim to contracts/test/utils/LegacyInit.sol and TLCV1WithLegacyInit.sol, following the RiverV1WithLegacyInit.sol precedent, so tests can still bootstrap from genesis and the fork tests can still replay the historical migrations. contracts/src no longer reads OperatorsV1 or RedeemQueueV1; those libraries stay for the harness and fork tests.

Runtime bytecode saved: TLCV1 -3406, OperatorsRegistryV1 -1091, OracleV1 -1018, RedeemManagerV1 -770, AllowlistV1 -487, ELFeeRecipientV1 -291, CoverageFundV1 -278, ProtocolMetricsV1 -262, WithdrawV1 -247 bytes. RiverV1 is unchanged (its legacy initializers were already gone and the OracleManager ones were internal).

Note: removing the init(0) entry points means an implementation can no longer bootstrap a fresh proxy, so the greenfield testnet deploy scripts under deploy/hoodi and deploy/devHoodi can no longer run against these contracts.


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

<!-------------------------------------------------------
To be uncommented when Contribution Guide will be created
- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide? 
-------------------------------------------------------->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/liquid-collective/liquid-collective-protocol/pulls) for the same update/change?
- [ ] Have you assigned this PR to yourself?
- [ ] Have you added at least 1 reviewer?
- [ ] Have you updated the official documentation?
- [ ] Have you added sufficient documentation in your code?
- [ ] Have you added relevant tests to the official test suite?

## Pull Request Type

- [ ] 💫 New Feature (Breaking Change)
- [ ] 💫 New Feature (Non-breaking Change)
- [ ] 🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ] 🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)

## Breaking changes (if applicable)

<!-- Please complete this section if any breaking changes have been made -->

## Testing

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you tested this code with the official test suite?
- [ ] Have you tested this code manually?

## Manual tests (if applicable)

<!-- Please complete this section if you ran manual tests for this functionality -->

## Additional comments

<!-- Please post additional comments in this section if you have them -->